### PR TITLE
Do not raise warning for `TimeSeries` subclasses with 0/1 data

### DIFF
--- a/nwbinspector/nwbinspector.py
+++ b/nwbinspector/nwbinspector.py
@@ -98,7 +98,9 @@ def check_timeseries(nwbfile):
             error_code = 'A101'
             print("- %s: '%s' %s data has all values = %s" % (error_code, ts.name, type(ts).__name__, uniq[0]))
         elif np.array_equal(uniq, [0., 1.]):
-            if ts.data.dtype != bool:
+            if ts.data.dtype != bool and type(ts) is pynwb.TimeSeries:
+                # if a base TimeSeries object has 0/1 data but is not using booleans
+                # note that this tests only base TimeSeries objects. TimeSeries subclasses may require numeric/int/etc.
                 error_code = 'A101'
                 print("- %s: '%s' %s data only contains values 0 and 1. Consider changing to type boolean instead of %s"
                       % (error_code, ts.name, type(ts).__name__, ts.data.dtype))


### PR DESCRIPTION
Previously, if the 'data' dataset of an instance of `TimeSeries` or its subclasses had two unique values and the data type was not boolean, the inspector would raise an error and say to consider changing the data type to boolean. However, the 'data' dataset of most `TimeSeries` subclasses require a numeric or int/float data type, and do not allow boolean.

This PR changes the check so that it applies only to instances of the base `TimeSeries` class. 