### PR TITLE
DynamicTable: empty

### DIFF
--- a/nwbinspector/__init__.py
+++ b/nwbinspector/__init__.py
@@ -1,3 +1,4 @@
 from .register_checks import available_checks, Importance
 from .checks.nwb_containers import *
 from .checks.time_series import *
+from .checks.tables import *

--- a/nwbinspector/checks/tables.py
+++ b/nwbinspector/checks/tables.py
@@ -1,21 +1,14 @@
-# """Authors: Cody Baker, Ben Dichter, and Ryan Ly."""
-# import pynwb
-# import hdmf
+"""Check functions that can apply to any descendant of DynamicTable."""
+from hdmf.common import DynamicTable
 
-# from ..tools import all_of_type
-# from ..utils import register_check
+from ..register_checks import register_check, InspectorMessage, Importance
 
 
-# @register_check(importance="Best Practice Violation", neurodata_type=pynwb.core.DynamicTable)
-# def check_empty_tables(nwbfile):
-#     """Check if DynamicTable is empty."""
-#     for tab in all_of_type(nwbfile, pynwb.core.DynamicTable):
-#         if len(tab.id) == 0:
-#             print("NOTE: '%s' %s has no rows" % (tab.name, type(tab).__name__))
-#             continue
-#         if len(tab.id) == 1:
-#             print("NOTE: '%s' %s has one row" % (tab.name, type(tab).__name__))
-#             continue
+@register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=DynamicTable)
+def check_empty_table(table: DynamicTable):
+    """Check if a DynamicTable is empty."""
+    if len(table.id) == 0:
+        return InspectorMessage(message="This table has no data added to it.")
 
 
 # @register_check(importance="Best Practice Violation", neurodata_type=pynwb.core.DynamicTable)

--- a/tests/unit_tests/test_tables.py
+++ b/tests/unit_tests/test_tables.py
@@ -1,9 +1,27 @@
 import pytest
+from hdmf.common import DynamicTable
+
+from nwbinspector import check_empty_table
+from nwbinspector.register_checks import InspectorMessage, Importance, Severity
 
 
-@pytest.mark.skip(reason="TODO")
-def test_check_empty_tables():
-    pass
+def test_check_empty_table_with_data():
+    table = DynamicTable(name="test_table", description="")
+    table.add_column(name="test_column", description="")
+    table.add_row(test_column=1)
+    assert check_empty_table(table=table) is None
+
+
+def test_check_empty_table_without_data():
+    assert check_empty_table(table=DynamicTable(name="test_table", description="")) == InspectorMessage(
+        severity=Severity.NO_SEVERITY,
+        message="This table has no data added to it.",
+        importance=Importance.BEST_PRACTICE_VIOLATION,
+        check_function_name="check_empty_table",
+        object_type="DynamicTable",
+        object_name="test_table",
+        location="/",
+    )
 
 
 @pytest.mark.skip(reason="TODO")


### PR DESCRIPTION
Adding the first table check back in: complains if it finds a DynamicTable that is empty (has no data rows added to it).

This is also the first check to be added with both a positive and negative test added for it, which Ben mentioned we probably ought to have for everything to demonstrate the case where it should not be raised, and the case where it should.