### PR TITLE
Units table: negative spike times

### DIFF
--- a/nwbinspector/__init__.py
+++ b/nwbinspector/__init__.py
@@ -1,3 +1,4 @@
 from .register_checks import available_checks, Importance
 from .checks.nwb_containers import *
 from .checks.time_series import *
+from .checks.ecephys import *

--- a/nwbinspector/checks/ecephys.py
+++ b/nwbinspector/checks/ecephys.py
@@ -1,0 +1,24 @@
+"""Check functions specific to extracellular electrophysiology neurodata types."""
+import numpy as np
+from numbers import Real
+
+from pynwb.misc import Units
+
+from ..register_checks import register_check, Importance, InspectorMessage
+
+
+@register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=Units)
+def check_negative_spike_times(units_table: Units):
+    """Check if the Units table contains negative spike times."""
+    if "spike_times" not in units_table:
+        return None
+    min_spike_time = np.array(units_table["spike_times"][:], dtype="object").min()
+    if not isinstance(min_spike_time, Real):  # If table has only a single unit, will return scalar
+        min_spike_time = min_spike_time[0]  # If table has more than one unit, will return a list with a single element
+    if min_spike_time < 0:
+        return InspectorMessage(
+            message=(
+                "This Units table contains negative spike times. Time should generally be aligned to the earliest "
+                "time reference in the NWBFile."
+            )
+        )

--- a/tests/unit_tests/test_ecephys.py
+++ b/tests/unit_tests/test_ecephys.py
@@ -1,0 +1,34 @@
+from pynwb.misc import Units
+
+from nwbinspector import check_negative_spike_times
+from nwbinspector.register_checks import InspectorMessage, Importance, Severity
+
+
+def test_check_negative_spike_times_all_positive():
+    units_table = Units()
+    units_table.add_unit(spike_times=[0.0, 0.1])
+    units_table.add_unit(spike_times=[1.0])
+    assert check_negative_spike_times(units_table=units_table) is None
+
+
+def test_check_negative_spike_times_empty():
+    units_table = Units()
+    assert check_negative_spike_times(units_table=units_table) is None
+
+
+def test_check_negative_spike_times_some_negative():
+    units_table = Units()
+    units_table.add_unit(spike_times=[0.0, 0.1])
+    units_table.add_unit(spike_times=[-1.0])
+    assert check_negative_spike_times(units_table=units_table) == InspectorMessage(
+        severity=Severity.NO_SEVERITY,
+        message=(
+            "This Units table contains negative spike times. Time should generally be aligned to the earliest time "
+            "reference in the NWBFile."
+        ),
+        importance=Importance.BEST_PRACTICE_VIOLATION,
+        check_function_name="check_negative_spike_times",
+        object_type="Units",
+        object_name="Units",
+        location="/",
+    )


### PR DESCRIPTION
fix #1 

Adding the first ecephys check: complains if it finds a negative spike time in a Units table.

Replaces https://github.com/NeurodataWithoutBorders/nwbinspector/pull/2