### PR TITLE
Run on push, test on py3.9, simplify upload yaml

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,14 +1,16 @@
 name: Testing
-on: pull_request
+on: [pull_request, push]
 jobs:
   build-and-test:
     name: Testing using ${{ matrix.os }} with ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
+    # run pipeline on either a push event or a PR event on a fork
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     strategy:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: [3.7, 3.8]
+        python-version: ["3.7", "3.9"]
     steps:
       - uses: actions/checkout@v2
       - run: git fetch --prune --unshallow --tags
@@ -20,14 +22,13 @@ jobs:
         run: |
           pip install pytest
           pip install pytest-cov
-      - name: Install nwbwidgets
+      - name: Install package
         run: pip install -e .
       - name: Run pytest with coverage
         run: pytest --cov=./ --cov-report xml:./nwbinspector/nwbinspector/coverage.xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
           file: ./nwbinspector/nwbinspector/coverage.xml
           flags: unittests
-          name: codecov-umbrella


### PR DESCRIPTION
Follow-up to #25 to resolve #24. https://codecov.io/github/NeurodataWithoutBorders/nwbinspector/ is still empty.

There is no codecov uploaded for the master branch - just the recent PR branches. This change makes CI run when a commit is made to master. It also tests on python 3.9 and simplifies the codecov upload yaml. 