### PR TITLE
fix save path for log file

### DIFF
--- a/nwbinspector/nwbinspector.py
+++ b/nwbinspector/nwbinspector.py
@@ -107,10 +107,9 @@ def inspect_all(
             print("ERROR: ", ex)
             traceback.print_exc()
     if len(organized_results):
-        write_results(
-            log_file_path=nwbfiles[0].parent / log_file_name, organized_results=organized_results, overwrite=overwrite
-        )
-        print_to_console(log_file_path=log_file_name)
+        log_file_path = nwbfiles[0].parent / log_file_name
+        write_results(log_file_path=log_file_path, organized_results=organized_results, overwrite=overwrite)
+        print_to_console(log_file_path=log_file_path)
         print(f"{os.linesep*2}Log file saved at {str(log_file_name)}!")
     if num_invalid_files:
         print(f"{num_exceptions}/{num_nwbfiles} files are invalid.")

--- a/nwbinspector/nwbinspector.py
+++ b/nwbinspector/nwbinspector.py
@@ -20,7 +20,6 @@ from .utils import FilePathType, PathType, OptionalListOfStrings
 @click.option("-m", "--modules", help="Modules to import prior to reading the file(s).")
 @click.option("-o", "--overwrite", help="Overwrite an existing log file at the location.", is_flag=True)
 @click.option(
-    "-n",
     "--log-file-path",
     default="nwbinspector_log_file.txt",
     help="Save path for the log file. Defaults to the current directory.",

--- a/nwbinspector/nwbinspector.py
+++ b/nwbinspector/nwbinspector.py
@@ -107,7 +107,9 @@ def inspect_all(
             print("ERROR: ", ex)
             traceback.print_exc()
     if len(organized_results):
-        write_results(log_file_path=log_file_name, organized_results=organized_results, overwrite=overwrite)
+        write_results(
+            log_file_path=nwbfiles[0].parent / log_file_name, organized_results=organized_results, overwrite=overwrite
+        )
         print_to_console(log_file_path=log_file_name)
         print(f"{os.linesep*2}Log file saved at {str(log_file_name)}!")
     if num_invalid_files:

--- a/nwbinspector/nwbinspector.py
+++ b/nwbinspector/nwbinspector.py
@@ -21,9 +21,9 @@ from .utils import FilePathType, PathType, OptionalListOfStrings
 @click.option("-o", "--overwrite", help="Overwrite an existing log file at the location.", is_flag=True)
 @click.option(
     "-n",
-    "--log-file-name",
+    "--log-file-path",
     default="nwbinspector_log_file.txt",
-    help="Name of the log file to be saved.",
+    help="Save path for the log file. Defaults to the current directory.",
     type=click.Path(writable=True),
 )
 @click.option("-i", "--ignore", help="Comma-separated names of checks to skip.")
@@ -36,9 +36,9 @@ from .utils import FilePathType, PathType, OptionalListOfStrings
     help="Ignores tests with an assigned importance below this threshold.",
 )
 def inspect_all_cli(
-    path: PathType,
+    path: str,
     modules: OptionalListOfStrings = None,
-    log_file_name: FilePathType = "nwbinspector_log_file.txt",
+    log_file_path: str = "nwbinspector_log_file.txt",
     overwrite: bool = False,
     ignore: OptionalListOfStrings = None,
     select: OptionalListOfStrings = None,
@@ -48,7 +48,7 @@ def inspect_all_cli(
     inspect_all(
         path,
         modules=modules,
-        log_file_name=log_file_name,
+        log_file_path=log_file_path,
         ignore=ignore if ignore is None else ignore.split(","),
         select=select if select is None else select.split(","),
         importance_threshold=Importance[threshold],
@@ -59,7 +59,7 @@ def inspect_all_cli(
 def inspect_all(
     path: PathType,
     modules: OptionalListOfStrings = None,
-    log_file_name: FilePathType = "nwbinspector_log_file.txt",
+    log_file_path: FilePathType = "nwbinspector_log_file.txt",
     overwrite=False,
     ignore: OptionalListOfStrings = None,
     select: OptionalListOfStrings = None,
@@ -67,6 +67,8 @@ def inspect_all(
 ):
     """Inspect all NWBFiles at the specified path."""
     modules = modules or []
+    path = Path(path)
+    log_file_path = Path(log_file_path)
 
     in_path = Path(path)
     if in_path.is_dir():
@@ -107,7 +109,6 @@ def inspect_all(
             print("ERROR: ", ex)
             traceback.print_exc()
     if len(organized_results):
-        log_file_path = nwbfiles[0].parent / log_file_name
         write_results(log_file_path=log_file_path, organized_results=organized_results, overwrite=overwrite)
         print_to_console(log_file_path=log_file_path)
         print(f"{os.linesep*2}Log file saved at {str(log_file_path.absolute())}!")

--- a/nwbinspector/nwbinspector.py
+++ b/nwbinspector/nwbinspector.py
@@ -110,7 +110,7 @@ def inspect_all(
         log_file_path = nwbfiles[0].parent / log_file_name
         write_results(log_file_path=log_file_path, organized_results=organized_results, overwrite=overwrite)
         print_to_console(log_file_path=log_file_path)
-        print(f"{os.linesep*2}Log file saved at {str(log_file_name)}!")
+        print(f"{os.linesep*2}Log file saved at {str(log_file_path.absolute())}!")
     if num_invalid_files:
         print(f"{num_exceptions}/{num_nwbfiles} files are invalid.")
     if num_exceptions:

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -226,13 +226,13 @@ class TestInspector(TestCase):
         self.assertListofDictEqual(test_list=test_results, true_list=true_results)
 
     def test_command_line_runs(self):
-        os.system(f"nwbinspector {str(self.nwbfile_paths[0])}")
+        os.system(f"nwbinspector {str(self.nwbfile_paths[0])} -f {self.tempdir / 'nwbinspector_log_file.txt'}")
         self.assertFileExists(path=self.tempdir / "nwbinspector_log_file.txt")
 
     def test_command_line_on_directory_matches_file(self):
         os.system(
             f"nwbinspector {str(self.tempdir)} -o -s check_timestamps_match_first_dimension,check_data_orientation,"
-            f"check_regular_timestamps,check_dataset_compression"
+            f"check_regular_timestamps,check_dataset_compression -f {self.tempdir / 'nwbinspector_log_file.txt'}"
         )
         self.assertLogFileContentsEqual(
             test_file_path=self.tempdir / "nwbinspector_log_file.txt",

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -227,7 +227,7 @@ class TestInspector(TestCase):
 
     def test_command_line_runs(self):
         os.system(f"nwbinspector {str(self.nwbfile_paths[0])}")
-        self.assertFileExists(path="nwbinspector_log_file.txt")
+        self.assertFileExists(path=self.tempdir / "nwbinspector_log_file.txt")
 
     def test_command_line_on_directory_matches_file(self):
         os.system(
@@ -235,7 +235,7 @@ class TestInspector(TestCase):
             f"check_regular_timestamps,check_dataset_compression"
         )
         self.assertLogFileContentsEqual(
-            test_file_path="nwbinspector_log_file.txt",
+            test_file_path=self.tempdir / "nwbinspector_log_file.txt",
             true_file_path=Path(__file__).parent / "true_nwbinspector_log_file.txt",
         )
 

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -226,13 +226,16 @@ class TestInspector(TestCase):
         self.assertListofDictEqual(test_list=test_results, true_list=true_results)
 
     def test_command_line_runs(self):
-        os.system(f"nwbinspector {str(self.nwbfile_paths[0])} -f {self.tempdir / 'nwbinspector_log_file.txt'}")
+        os.system(
+            f"nwbinspector {str(self.nwbfile_paths[0])} --log-file-path {self.tempdir / 'nwbinspector_log_file.txt'}"
+        )
         self.assertFileExists(path=self.tempdir / "nwbinspector_log_file.txt")
 
     def test_command_line_on_directory_matches_file(self):
         os.system(
             f"nwbinspector {str(self.tempdir)} -o -s check_timestamps_match_first_dimension,check_data_orientation,"
-            f"check_regular_timestamps,check_dataset_compression -f {self.tempdir / 'nwbinspector_log_file.txt'}"
+            "check_regular_timestamps,check_dataset_compression "
+            f"--log-file-path {self.tempdir / 'nwbinspector_log_file.txt'}"
         )
         self.assertLogFileContentsEqual(
             test_file_path=self.tempdir / "nwbinspector_log_file.txt",


### PR DESCRIPTION
## Motivation

Previously, the `nwbinspector` would save the log file to the location the `nwbinspector` was called via CLI. When the CLI points to an absolute path of an NWBFile in a different directory, the two no longer correspond.
