### PR TITLE
added optional disabling of color from CLI

### DIFF
--- a/nwbinspector/inspector_tools.py
+++ b/nwbinspector/inspector_tools.py
@@ -71,10 +71,10 @@ def supports_color():
     return supported_platform and is_a_tty
 
 
-def print_to_console(log_file_path: FilePathType, disable_color: bool = False):
+def print_to_console(log_file_path: FilePathType, no_color: bool = False):
     """Print log file contents to console."""
     if not supports_color():
-        disable_color = True
+        no_color = True
     reset_color = "\x1b[0m"
     color_map = {
         "CRITICAL IMPORTANCE": "\x1b[31m",
@@ -85,7 +85,7 @@ def print_to_console(log_file_path: FilePathType, disable_color: bool = False):
 
     with open(file=log_file_path, mode="r") as file:
         log_output = file.readlines()
-    if not disable_color:
+    if not no_color:
         color_shift_points = dict()
         for line_index, line in enumerate(log_output):
             for color_trigger in color_map:

--- a/nwbinspector/inspector_tools.py
+++ b/nwbinspector/inspector_tools.py
@@ -67,7 +67,7 @@ def write_results(log_file_path: FilePathType, organized_results: Dict[str, Dict
                 file.write("\n\n\n")
 
 
-def supports_color():
+def supports_color():  # pragma: no cover
     """
     Return True if the running system's terminal supports color, and False otherwise.
 

--- a/nwbinspector/inspector_tools.py
+++ b/nwbinspector/inspector_tools.py
@@ -9,6 +9,15 @@ from pathlib import Path
 from . import Importance
 from .utils import FilePathType
 
+try:
+    import colorama
+
+    colorama.init()
+except (ImportError, OSError):
+    HAS_COLORAMA = False
+else:
+    HAS_COLORAMA = True
+
 
 def sort_by_descending_severity(check_results: list):
     """Order the dictionaries in the check_list by severity."""
@@ -64,11 +73,38 @@ def supports_color():
 
     From https://github.com/django/django/blob/main/django/core/management/color.py
     """
-    plat = sys.platform
-    supported_platform = plat != "Pocket PC" and (plat != "win32" or "ANSICON" in os.environ)
+
+    def vt_codes_enabled_in_windows_registry():
+        """Check the Windows Registry to see if VT code handling has been enabled by default."""
+        try:
+            # winreg is only available on Windows.
+            import winreg
+        except ImportError:
+            return False
+        else:
+            reg_key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, "Console")
+            try:
+                reg_key_value, _ = winreg.QueryValueEx(reg_key, "VirtualTerminalLevel")
+            except FileNotFoundError:
+                return False
+            else:
+                return reg_key_value == 1
+
     # isatty is not always implemented, #6223.
     is_a_tty = hasattr(sys.stdout, "isatty") and sys.stdout.isatty()
-    return supported_platform and is_a_tty
+
+    return is_a_tty and (
+        sys.platform != "win32"
+        or HAS_COLORAMA
+        or "ANSICON" in os.environ
+        or
+        # Windows Terminal supports VT codes.
+        "WT_SESSION" in os.environ
+        or
+        # Microsoft Visual Studio Code's built-in terminal supports colors.
+        os.environ.get("TERM_PROGRAM") == "vscode"
+        or vt_codes_enabled_in_windows_registry()
+    )
 
 
 def print_to_console(log_file_path: FilePathType, no_color: bool = False):

--- a/nwbinspector/nwbinspector.py
+++ b/nwbinspector/nwbinspector.py
@@ -19,6 +19,7 @@ from .utils import FilePathType, PathType, OptionalListOfStrings
 @click.argument("path")
 @click.option("-m", "--modules", help="Modules to import prior to reading the file(s).")
 @click.option("-o", "--overwrite", help="Overwrite an existing log file at the location.", is_flag=True)
+@click.option("-c", "--disable-color", help="Enable coloration for console display of output.", is_flag=True)
 @click.option(
     "-n",
     "--log-file-name",
@@ -43,6 +44,7 @@ def inspect_all_cli(
     ignore: OptionalListOfStrings = None,
     select: OptionalListOfStrings = None,
     threshold: str = "BEST_PRACTICE_SUGGESTION",
+    disable_color: bool = False,
 ):
     """Primary CLI usage."""
     inspect_all(
@@ -53,6 +55,7 @@ def inspect_all_cli(
         select=select if select is None else select.split(","),
         importance_threshold=Importance[threshold],
         overwrite=overwrite,
+        disable_color=disable_color,
     )
 
 
@@ -64,6 +67,7 @@ def inspect_all(
     ignore: OptionalListOfStrings = None,
     select: OptionalListOfStrings = None,
     importance_threshold: Importance = Importance.BEST_PRACTICE_SUGGESTION,
+    disable_color: bool = False,
 ):
     """Inspect all NWBFiles at the specified path."""
     modules = modules or []
@@ -108,7 +112,7 @@ def inspect_all(
             traceback.print_exc()
     if len(organized_results):
         write_results(log_file_path=log_file_name, organized_results=organized_results, overwrite=overwrite)
-        print_to_console(log_file_path=log_file_name)
+        print_to_console(log_file_path=log_file_name, disable_color=disable_color)
         print(f"{os.linesep*2}Log file saved at {str(log_file_name)}!")
     if num_invalid_files:
         print(f"{num_exceptions}/{num_nwbfiles} files are invalid.")

--- a/nwbinspector/nwbinspector.py
+++ b/nwbinspector/nwbinspector.py
@@ -19,7 +19,7 @@ from .utils import FilePathType, PathType, OptionalListOfStrings
 @click.argument("path")
 @click.option("-m", "--modules", help="Modules to import prior to reading the file(s).")
 @click.option("-o", "--overwrite", help="Overwrite an existing log file at the location.", is_flag=True)
-@click.option("-c", "--disable-color", help="Enable coloration for console display of output.", is_flag=True)
+@click.option("--no-color", help="Disable coloration for console display of output.", is_flag=True)
 @click.option(
     "-n",
     "--log-file-name",
@@ -44,7 +44,7 @@ def inspect_all_cli(
     ignore: OptionalListOfStrings = None,
     select: OptionalListOfStrings = None,
     threshold: str = "BEST_PRACTICE_SUGGESTION",
-    disable_color: bool = False,
+    no_color: bool = False,
 ):
     """Primary CLI usage."""
     inspect_all(
@@ -55,7 +55,7 @@ def inspect_all_cli(
         select=select if select is None else select.split(","),
         importance_threshold=Importance[threshold],
         overwrite=overwrite,
-        disable_color=disable_color,
+        no_color=no_color,
     )
 
 
@@ -67,7 +67,7 @@ def inspect_all(
     ignore: OptionalListOfStrings = None,
     select: OptionalListOfStrings = None,
     importance_threshold: Importance = Importance.BEST_PRACTICE_SUGGESTION,
-    disable_color: bool = False,
+    no_color: bool = False,
 ):
     """Inspect all NWBFiles at the specified path."""
     modules = modules or []
@@ -112,7 +112,7 @@ def inspect_all(
             traceback.print_exc()
     if len(organized_results):
         write_results(log_file_path=log_file_name, organized_results=organized_results, overwrite=overwrite)
-        print_to_console(log_file_path=log_file_name, disable_color=disable_color)
+        print_to_console(log_file_path=log_file_name, no_color=no_color)
         print(f"{os.linesep*2}Log file saved at {str(log_file_name)}!")
     if num_invalid_files:
         print(f"{num_exceptions}/{num_nwbfiles} files are invalid.")


### PR DESCRIPTION
## Motivation

On certain consoles, coloration of output is not supported; when it is not supported it adds a bunch of garbage characters to the left of every line of the output.

We still want to print colors by default, so I've added an optional flag for it to be disabled, as well as a safety fall-back function from Django that attempts (but may not always succeed) in determining a console environments ability to render the color.

## How to test the behavior?
No clue how to test color output in a CI console.
