### PR TITLE
[Dev Feature]: auto-publish to PyPI

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -1,0 +1,30 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Upload Package to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.7"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install wheel
+      - name: Build package
+        run: python setup.py sdist bdist_wheel
+      - name: pypi-publish
+        uses: pypa/gh-action-pypi-publish@v1.4.2
+        with:
+          verbose: true
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Motivation

Very similar to lines https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/.circleci/config.yml#L336-L359, but in a self-contained GitHub action for automatically uploading the package to PyPI upon an official tagged GitHub Release (which keeps the two in constant synch).

To-Do:

- [x] Either Ben or Ryan needs to add the secret token ('PYPI_API_TOKEN') from the https://pypi.org/project/nwbinspector/ project (or add me as a maintainer for it and I can do it too)
- [X] ~~Probably want to update documentation on https://pypi.org/project/nwbinspector/~~ (Apparently it autosets all that from the setup stuff, which should pull from our now updated README)

## Checklist

- [X] Have you ensured the PR description clearly describes the problem and solutions?
- [X] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/nwbinspector/pulls) for the same change?
- [X] Is your code contribution compliant with `black` format? If not, simply `pip install black` and run `black .` inside your fork.
- [X] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?
