### PR TITLE
Combine the two Importance classes into one

### DIFF
--- a/nwbinspector/inspector_tools.py
+++ b/nwbinspector/inspector_tools.py
@@ -8,17 +8,8 @@ from pathlib import Path
 
 import numpy as np
 
+from .register_checks import Importance
 from .utils import FilePathType
-
-
-class ReportCollectorImportance(Enum):
-    """Additional importance levels applied to violations outside of NWBInspector."""
-
-    ERROR = 4
-    PYNWB_VALIDATION = 3
-    CRITICAL = 2
-    BEST_PRACTICE_VIOLATION = 1
-    BEST_PRACTICE_SUGGESTION = 0
 
 
 def sort_by_descending_severity(check_results: list):
@@ -30,7 +21,7 @@ def sort_by_descending_severity(check_results: list):
 
 def organize_check_results(check_results: list):
     """Format the list of returned results from checks."""
-    initial_results = OrderedDict({importance.name: list() for importance in ReportCollectorImportance})
+    initial_results = OrderedDict({importance.name: list() for importance in Importance})
     for check_result in check_results:
         initial_results[check_result.importance.name].append(check_result)
     organized_check_results = OrderedDict()

--- a/nwbinspector/nwbinspector.py
+++ b/nwbinspector/nwbinspector.py
@@ -12,13 +12,12 @@ from natsort import natsorted
 
 from . import available_checks, Importance
 from .inspector_tools import (
-    ReportCollectorImportance,
     organize_check_results,
     format_organized_results_output,
     print_to_console,
     save_report,
 )
-from .register_checks import InspectorMessage
+from .register_checks import InspectorMessage, Importance
 from .utils import FilePathType, PathType, OptionalListOfStrings
 
 
@@ -147,14 +146,14 @@ def inspect_nwb(
             f"Indicated importance_threshold ({importance_threshold}) is not a valid importance level! Please choose "
             "from [CRITICAL_IMPORTANCE, BEST_PRACTICE_VIOLATION, BEST_PRACTICE_SUGGESTION]."
         )
-    unorganized_results = OrderedDict({importance.name: list() for importance in ReportCollectorImportance})
+    unorganized_results = OrderedDict({importance.name: list() for importance in Importance})
     try:
         with pynwb.NWBHDF5IO(path=str(nwbfile_path), mode="r", load_namespaces=True, driver=driver) as io:
             validation_errors = pynwb.validate(io=io)
             if any(validation_errors):
                 for validation_error in validation_errors:
                     message = InspectorMessage(message=validation_error.reason)
-                    message.importance = ReportCollectorImportance.PYNWB_VALIDATION
+                    message.importance = Importance.PYNWB_VALIDATION
                     message.check_function_name = validation_error.name
                     message.location = validation_error.location
                     unorganized_results["PYNWB_VALIDATION"].append(message)
@@ -180,7 +179,7 @@ def inspect_nwb(
                 unorganized_results.update(organize_check_results(check_results=check_results))
     except Exception as ex:
         message = InspectorMessage(message=traceback.format_exc())
-        message.importance = ReportCollectorImportance.ERROR
+        message.importance = Importance.ERROR
         message.check_function_name = ex
         unorganized_results["ERROR"].append(message)
     organized_result = OrderedDict()

--- a/nwbinspector/register_checks.py
+++ b/nwbinspector/register_checks.py
@@ -11,6 +11,8 @@ import h5py
 class Importance(Enum):
     """A definition of the valid importance levels for a given check function."""
 
+    ERROR = 4
+    PYNWB_VALIDATION = 3
     CRITICAL = 2
     BEST_PRACTICE_VIOLATION = 1
     BEST_PRACTICE_SUGGESTION = 0
@@ -80,7 +82,11 @@ def register_check(importance: Importance, neurodata_type):
     """Wrap a check function to add it to the list of default checks for that severity and neurodata type."""
 
     def register_check_and_auto_parse(check_function) -> InspectorMessage:
-        if importance not in Importance:
+        if importance not in [
+            Importance.CRITICAL,
+            Importance.BEST_PRACTICE_VIOLATION,
+            Importance.BEST_PRACTICE_SUGGESTION,
+        ]:
             raise ValueError(
                 f"Indicated importance ({importance}) of custom check ({check_function.__name__}) is not a valid "
                 "importance level! Please choose one of Importance.CRITICAL, Importance.BEST_PRACTICE_VIOLATION, "

--- a/tests/test_register_check.py
+++ b/tests/test_register_check.py
@@ -78,7 +78,6 @@ class TestRegisterClass(TestCase):
                     return InspectorMessage(severity=bad_severity, message="")
 
                 bad_severity_function(time_series=self.default_time_series)
-
         else:
             with self.assertRaisesWith(
                 exc_type=ValueError,
@@ -181,7 +180,11 @@ class TestRegisterClass(TestCase):
         from nwbinspector import available_checks
 
         neurodata_type = DynamicTable
-        for importance in Importance:
+        for importance in [
+            Importance.CRITICAL,
+            Importance.BEST_PRACTICE_VIOLATION,
+            Importance.BEST_PRACTICE_SUGGESTION,
+        ]:
 
             @register_check(importance=importance, neurodata_type=neurodata_type)
             def good_check_function():

--- a/tests/test_register_check.py
+++ b/tests/test_register_check.py
@@ -58,8 +58,8 @@ class TestRegisterClass(TestCase):
             with self.assertRaisesWith(
                 exc_type=ValueError,
                 exc_msg=(
-                    f"Indicated importance ({forbidden_importance}) of custom check (bad_severity_function) is not a "
-                    "valid importance level! Please choose one of Importance.CRITICAL, "
+                    f"Indicated importance ({forbidden_importance}) of custom check (forbidden_importance_function) is "
+                    "not a valid importance level! Please choose one of Importance.CRITICAL, "
                     "Importance.BEST_PRACTICE_VIOLATION, or Importance.BEST_PRACTICE_SUGGESTION."
                 ),
             ):

--- a/tests/test_register_check.py
+++ b/tests/test_register_check.py
@@ -21,29 +21,18 @@ class TestRegisterClass(TestCase):
     def test_register_importance_error_non_enum_type(self):
         bad_importance = "test_bad_importance"
 
-        if version.parse(python_version()) >= version.parse("3.8"):
-            with self.assertRaisesWith(
-                exc_type=TypeError,
-                exc_msg="unsupported operand type(s) for 'in': 'str' and 'EnumMeta'",
-            ):
+        with self.assertRaisesWith(
+            exc_type=ValueError,
+            exc_msg=(
+                f"Indicated importance ({bad_importance}) of custom check (bad_importance_function) is not a valid "
+                "importance level! Please choose one of Importance.CRITICAL, Importance.BEST_PRACTICE_VIOLATION, "
+                "or Importance.BEST_PRACTICE_SUGGESTION."
+            ),
+        ):
 
-                @register_check(importance=bad_importance, neurodata_type=None)
-                def bad_importance_function():
-                    pass
-
-        else:
-            with self.assertRaisesWith(
-                exc_type=ValueError,
-                exc_msg=(
-                    f"Indicated importance ({bad_importance}) of custom check (bad_importance_function) is not a valid "
-                    "importance level! Please choose one of Importance.CRITICAL, Importance.BEST_PRACTICE_VIOLATION, "
-                    "or Importance.BEST_PRACTICE_SUGGESTION."
-                ),
-            ):
-
-                @register_check(importance=bad_importance, neurodata_type=None)
-                def bad_importance_function():
-                    pass
+            @register_check(importance=bad_importance, neurodata_type=None)
+            def bad_importance_function():
+                pass
 
     def test_register_importance_error_enum_type(self):
         class SomeRandomEnum(Enum):
@@ -54,15 +43,30 @@ class TestRegisterClass(TestCase):
         with self.assertRaisesWith(
             exc_type=ValueError,
             exc_msg=(
-                f"Indicated importance ({bad_importance}) of custom check (bad_severity_function) is not a valid "
+                f"Indicated importance ({bad_importance}) of custom check (bad_importance_function) is not a valid "
                 "importance level! Please choose one of Importance.CRITICAL, Importance.BEST_PRACTICE_VIOLATION, "
                 "or Importance.BEST_PRACTICE_SUGGESTION."
             ),
         ):
 
             @register_check(importance=bad_importance, neurodata_type=None)
-            def bad_severity_function():
+            def bad_importance_function():
                 pass
+
+    def test_register_importance_error_both_forbidden_check_levels(self):
+        for forbidden_importance in [Importance.ERROR, Importance.PYNWB_VALIDATION]:
+            with self.assertRaisesWith(
+                exc_type=ValueError,
+                exc_msg=(
+                    f"Indicated importance ({forbidden_importance}) of custom check (bad_severity_function) is not a "
+                    "valid importance level! Please choose one of Importance.CRITICAL, "
+                    "Importance.BEST_PRACTICE_VIOLATION, or Importance.BEST_PRACTICE_SUGGESTION."
+                ),
+            ):
+
+                @register_check(importance=forbidden_importance, neurodata_type=None)
+                def forbidden_importance_function():
+                    pass
 
     def test_register_severity_error_non_enum_type(self):
         bad_severity = "test_bad_severity"


### PR DESCRIPTION
## Motivation

Error and validation levels now exist in normal Importance, but classical usage of Importance is still asserted for check definitions.

## Checklist

- [X] Have you ensured the PR description clearly describes the problem and solutions?
- [X] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/nwbinspector/pulls) for the same change?
- [X] Is your code contribution compliant with `black` format? If not, simply `pip install black` and run `black .` inside your fork.
- [X] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?
