### PR TITLE
added parallelization

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,6 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     url="https://github.com/NeurodataWithoutBorders/nwbinspector",
-    install_requires=["pynwb", "natsort", "click", "PyYAML", "jsonschema", "joblib"],
+    install_requires=["pynwb", "natsort", "click", "PyYAML", "jsonschema"],
     entry_points={"console_scripts": ["nwbinspector=nwbinspector.nwbinspector:inspect_all_cli"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@ from setuptools import setup, find_packages
 # Get the long description from the README file
 with open("README.md", "r") as f:
     long_description = f.read()
-
 setup(
     name="nwbinspector",
     version="0.2.3",
@@ -15,6 +14,6 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     url="https://github.com/NeurodataWithoutBorders/nwbinspector",
-    install_requires=["pynwb", "natsort", "click", "PyYAML", "jsonschema"],
+    install_requires=["pynwb", "natsort", "click", "PyYAML", "jsonschema", "joblib"],
     entry_points={"console_scripts": ["nwbinspector=nwbinspector.nwbinspector:inspect_all_cli"]},
 )

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -107,6 +107,12 @@ class TestInspector(TestCase):
         for dictionary in true_list:
             self.assertIn(member=dictionary, container=test_list)
 
+    def assertListsEquivalent(self, test_list: list, true_list: list):
+        for member in test_list:
+            self.assertIn(member=member, container=true_list)
+        for member in true_list:
+            self.assertIn(member=member, container=test_list)
+
     def assertFileExists(self, path: FilePathType):
         path = Path(path)
         assert path.exists()
@@ -195,7 +201,7 @@ class TestInspector(TestCase):
                 file="testing1.nwb",
             ),
         ]
-        self.assertListEqual(list1=test_results, list2=true_results)
+        self.assertListsEquivalent(test_list=test_results, true_list=true_results)
 
         def test_inspect_all_parallel(self):
             test_results = []
@@ -264,7 +270,7 @@ class TestInspector(TestCase):
                     file="testing1.nwb",
                 ),
             ]
-            self.assertListEqual(list1=test_results, list2=true_results)
+            self.assertListsEquivalent(test_list=test_results, true_list=true_results)
 
     def test_inspect_nwb(self):
         test_results = list(inspect_nwb(nwbfile_path=self.nwbfile_paths[0], checks=self.checks))
@@ -314,7 +320,7 @@ class TestInspector(TestCase):
                 file="testing0.nwb",
             ),
         ]
-        self.assertListEqual(list1=test_results, list2=true_results)
+        self.assertListsEquivalent(test_list=test_results, true_list=true_results)
 
     def test_inspect_nwb_importance_threshold(self):
         test_results = list(
@@ -345,7 +351,7 @@ class TestInspector(TestCase):
                 file="testing0.nwb",
             ),
         ]
-        self.assertListEqual(list1=test_results, list2=true_results)
+        self.assertListsEquivalent(test_list=test_results, true_list=true_results)
 
     def test_command_line_runs_cli_only(self):
         console_output_file = self.tempdir / "test_console_output.txt"
@@ -410,7 +416,7 @@ class TestInspector(TestCase):
                 file="testing0.nwb",
             ),
         ]
-        self.assertListEqual(list1=test_results, list2=true_results)
+        self.assertListsEquivalent(test_list=test_results, true_list=true_results)
 
 
 def test_configure_checks():

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -70,6 +70,8 @@ def add_simple_table(nwbfile: NWBFile):
 
 
 class TestInspector(TestCase):
+    maxDiff = None
+
     @classmethod
     def setUpClass(cls):
         cls.tempdir = Path(mkdtemp())
@@ -99,12 +101,6 @@ class TestInspector(TestCase):
     @classmethod
     def tearDownClass(cls):
         rmtree(cls.tempdir)
-
-    def assertListsEquivalent(self, test_list: list, true_list: list):
-        for member in test_list:
-            self.assertIn(member=member, container=true_list)
-        for member in true_list:
-            self.assertIn(member=member, container=test_list)
 
     def assertFileExists(self, path: FilePathType):
         path = Path(path)
@@ -194,7 +190,7 @@ class TestInspector(TestCase):
                 file_path=self.nwbfile_paths[1],
             ),
         ]
-        self.assertListsEquivalent(test_list=test_results, true_list=true_results)
+        self.assertCountEqual(first=test_results, second=true_results)
 
         def test_inspect_all_parallel(self):
             test_results = list(
@@ -261,7 +257,7 @@ class TestInspector(TestCase):
                     file_path=self.nwbfile_paths[1],
                 ),
             ]
-            self.assertListsEquivalent(test_list=test_results, true_list=true_results)
+            self.assertCountEqual(first=test_results, second=true_results)
 
     def test_inspect_nwb(self):
         test_results = list(inspect_nwb(nwbfile_path=self.nwbfile_paths[0], checks=self.checks))
@@ -311,7 +307,7 @@ class TestInspector(TestCase):
                 file_path=self.nwbfile_paths[0],
             ),
         ]
-        self.assertListsEquivalent(test_list=test_results, true_list=true_results)
+        self.assertCountEqual(first=test_results, second=true_results)
 
     def test_inspect_nwb_importance_threshold(self):
         test_results = list(
@@ -342,7 +338,7 @@ class TestInspector(TestCase):
                 file_path=self.nwbfile_paths[0],
             ),
         ]
-        self.assertListsEquivalent(test_list=test_results, true_list=true_results)
+        self.assertCountEqual(first=test_results, second=true_results)
 
     def test_command_line_runs_cli_only(self):
         console_output_file = self.tempdir / "test_console_output.txt"
@@ -419,7 +415,7 @@ class TestInspector(TestCase):
                 file_path=self.nwbfile_paths[0],
             ),
         ]
-        self.assertListsEquivalent(test_list=test_results, true_list=true_results)
+        self.assertCountEqual(first=test_results, second=true_results)
 
     def test_inspect_nwb_manual_iteration(self):
         generator = inspect_nwb(nwbfile_path=self.nwbfile_paths[0], checks=self.checks)

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -2,7 +2,6 @@ import os
 from shutil import rmtree
 from tempfile import mkdtemp
 from pathlib import Path
-from typing import List
 from unittest import TestCase
 
 import numpy as np
@@ -198,11 +197,9 @@ class TestInspector(TestCase):
         self.assertListsEquivalent(test_list=test_results, true_list=true_results)
 
         def test_inspect_all_parallel(self):
-            test_results = []
-            for test_result in inspect_all(
-                path=Path(self.nwbfile_paths[0]).parent, select=[x.__name__ for x in self.checks], n_jobs=2
-            ):
-                test_results.extend(test_result)
+            test_results = list(
+                inspect_all(path=Path(self.nwbfile_paths[0]).parent, select=[x.__name__ for x in self.checks], n_jobs=2)
+            )
             true_results = [
                 InspectorMessage(
                     message="data is not compressed. Consider enabling compression when writing a dataset.",

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -143,7 +143,7 @@ class TestInspector(TestCase):
                 object_type="TimeSeries",
                 object_name="test_time_series_1",
                 location="/acquisition/",
-                file="testing0.nwb",
+                file_path=self.nwbfile_paths[0],
             ),
             InspectorMessage(
                 message=(
@@ -156,7 +156,7 @@ class TestInspector(TestCase):
                 object_type="TimeSeries",
                 object_name="test_time_series_2",
                 location="/acquisition/",
-                file="testing0.nwb",
+                file_path=self.nwbfile_paths[0],
             ),
             InspectorMessage(
                 message=(
@@ -169,7 +169,7 @@ class TestInspector(TestCase):
                 object_type="SpatialSeries",
                 object_name="my_spatial_series",
                 location="/processing/behavior/Position/",
-                file="testing0.nwb",
+                file_path=self.nwbfile_paths[0],
             ),
             InspectorMessage(
                 message="The length of the first dimension of data does not match the length of timestamps.",
@@ -179,7 +179,7 @@ class TestInspector(TestCase):
                 object_type="TimeSeries",
                 object_name="test_time_series_3",
                 location="/acquisition/",
-                file="testing0.nwb",
+                file_path=self.nwbfile_paths[0],
             ),
             InspectorMessage(
                 message=(
@@ -192,7 +192,7 @@ class TestInspector(TestCase):
                 object_type="TimeSeries",
                 object_name="test_time_series_2",
                 location="/acquisition/",
-                file="testing1.nwb",
+                file_path=self.nwbfile_paths[1],
             ),
         ]
         self.assertListsEquivalent(test_list=test_results, true_list=true_results)
@@ -212,7 +212,7 @@ class TestInspector(TestCase):
                     object_type="TimeSeries",
                     object_name="test_time_series_1",
                     location="/acquisition/",
-                    file="testing0.nwb",
+                    file_path=self.nwbfile_paths[0],
                 ),
                 InspectorMessage(
                     message=(
@@ -225,7 +225,7 @@ class TestInspector(TestCase):
                     object_type="TimeSeries",
                     object_name="test_time_series_2",
                     location="/acquisition/",
-                    file="testing0.nwb",
+                    file_path=self.nwbfile_paths[0],
                 ),
                 InspectorMessage(
                     message=(
@@ -238,7 +238,7 @@ class TestInspector(TestCase):
                     object_type="SpatialSeries",
                     object_name="my_spatial_series",
                     location="/processing/behavior/Position/",
-                    file="testing0.nwb",
+                    file_path=self.nwbfile_paths[0],
                 ),
                 InspectorMessage(
                     message="The length of the first dimension of data does not match the length of timestamps.",
@@ -248,7 +248,7 @@ class TestInspector(TestCase):
                     object_type="TimeSeries",
                     object_name="test_time_series_3",
                     location="/acquisition/",
-                    file="testing0.nwb",
+                    file_path=self.nwbfile_paths[0],
                 ),
                 InspectorMessage(
                     message=(
@@ -261,7 +261,7 @@ class TestInspector(TestCase):
                     object_type="TimeSeries",
                     object_name="test_time_series_2",
                     location="/acquisition/",
-                    file="testing1.nwb",
+                    file_path=self.nwbfile_paths[1],
                 ),
             ]
             self.assertListsEquivalent(test_list=test_results, true_list=true_results)

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -357,6 +357,19 @@ class TestInspector(TestCase):
             skip_first_newlines=True,
         )
 
+    def test_command_line_runs_cli_only_parallel(self):
+        console_output_file = self.tempdir / "test_console_output_2.txt"
+        os.system(
+            f"nwbinspector {str(self.tempdir)} -o -s check_timestamps_match_first_dimension,"
+            f"check_data_orientation,check_regular_timestamps,check_small_dataset_compression --no-color "
+            f"> {console_output_file} --n-jobs 2"
+        )
+        self.assertLogFileContentsEqual(
+            test_file_path=console_output_file,
+            true_file_path=Path(__file__).parent / "true_nwbinspector_report.txt",
+            skip_first_newlines=True,
+        )
+
     def test_command_line_runs_saves_report(self):
         os.system(
             f"nwbinspector {str(self.nwbfile_paths[0])} --report-file-path {self.tempdir / 'nwbinspector_report.txt'}"


### PR DESCRIPTION
fix #83 

## Motivation

@bendichter Added simple parallelization via ~~`joblib`~~ `concurrent.futures`. Not the most sophisticated we could possibly do, but from past experience dealing with parallel access within and across NWBFiles, this gets the job done best with the least amount of hassle.

Already seeing a massive speedup when applying this to DANDISet `000004` (87 files) even just using 4 jobs. Run it on the Hub with 80+ jobs and I'm sure it'll feel practically instant.

## How to test the behavior?

Added new tests to assure the output matches when `n_jobs` passed to the library function.

The one weird thing to note, because I can't seem to get it to shape the way I wanted...

When calling `inspect_all` without parallel, what we've been doing to force the yields to collapse is calling 
```python
list(inspect_all(path=...))
```

This gives a simple, flat list of InspectorMessages same as `inspect_nwb`, but of course this one will have messages that span multiple files.

Now, when calling `inspect_all` with `n_jobs`, I have to do the following to reproduce this structure, otherwise I end up with a list-of-lists, the outer list being the number of NWBFiles in the iteration path, and the inner list being the list of actual messages.

```python
            test_results = []
            for test_result in inspect_all(
                path=Path(self.nwbfile_paths[0]).parent, select=[x.__name__ for x in self.checks], n_jobs=2
            ):
                test_results.extend(test_result)
```

This is likely due to the way I constructed the dispatcher

```python
        def dispatch_inspection(nwbfile_path: FilePathType, checks: list):
            # can't be a generator b/c it needs to be pickled
            return list(inspect_nwb(nwbfile_path=nwbfile_path, checks=checks))

        for message in Parallel(n_jobs=n_jobs)(
            delayed(dispatch_inspection)(nwbfile_path=nwbfile_path, checks=checks) for nwbfile_path in nwbfiles
        ):
            yield message
```

And it doesn't seem to matter if you try to `return` instead of `yield` the message in that last step; the function seems to always behave like a generator when you call it, although the `Parallel` doesn't dispatch until the first call to iterate that generator (including even a single `next`), and then it iterates over all the `nwbfiles` at once.

## Checklist

- [X] Have you ensured the PR description clearly describes the problem and solutions?
- [X] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/nwbinspector/pulls) for the same change?
- [X] Is your code contribution compliant with `black` format? If not, simply `pip install black` and run `black .` inside your fork.
- [X] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?


## Still Need To...

- [ ] add `-j, --n-jobs` flag to CLI
- [ ] add tests for CLI usage of the multiple jobs (kind of tough to actually make sure it's using multiple processes, but at least we can trust the argument passing and just ensure output matches expectations). 