### PR TITLE
Fix collections

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.7", "3.9"]
+        python-version: ["3.7", "3.10"]
     steps:
       - uses: actions/checkout@v2
       - run: git fetch --prune --unshallow --tags

--- a/nwbinspector/nwbinspector.py
+++ b/nwbinspector/nwbinspector.py
@@ -5,7 +5,7 @@ import traceback
 import json
 import jsonschema
 from pathlib import Path
-from collections import Iterable
+from collections.abc import Iterable
 from enum import Enum
 from typing import Optional, List
 from concurrent.futures import ThreadPoolExecutor, as_completed

--- a/nwbinspector/register_checks.py
+++ b/nwbinspector/register_checks.py
@@ -1,5 +1,5 @@
 """Primary decorator used on a check function to add it to the registry and automatically parse its output."""
-from collections import Iterable
+from collections.abc import Iterable
 from functools import wraps
 from enum import Enum
 from dataclasses import dataclass


### PR DESCRIPTION
## Motivation

While integrating with the DANDI CLI, I noticed they support Python v3.10 which turns a deprecation warning from `collections` into an actual error, so trying to get ahead of that here.

Also experimenting with the CI to see if we need to change anything else to be compatible with v3.10

EDIT: it appears that with this change, we are compatible.

