### PR TITLE
[Documentation]: local API links

### DIFF
--- a/docs/best_practices/time_series.rst
+++ b/docs/best_practices/time_series.rst
@@ -1,7 +1,7 @@
 Time Series
 ===========
 
-Many of the neurodata_types in NWB inherit from the TimeSeries (:py:class:`TimeSeries <pynwb.TimeSeries>`) neurodata_type.
+Many of the neurodata_types in NWB inherit from the TimeSeries neurodata_type.
 
 When using TimeSeries or any of its descendants, make sure the following are followed.
 

--- a/docs/best_practices/time_series.rst
+++ b/docs/best_practices/time_series.rst
@@ -7,8 +7,9 @@ When using TimeSeries or any of its descendants, make sure the following are fol
 
 
 .. _best_practice_data_orientation:
-Dimension Order
-~~~~~~~~~~~~~~~
+
+Data Orientation
+~~~~~~~~~~~~~~~~
 
 The time dimension always goes first. In TimeSeries.data, the first dimension on the disk is always time.
 
@@ -20,6 +21,7 @@ Check function: :py:meth:`check_data_orientation <nwbinspector.checks.time_serie
 
 
 .. _best_practice_unit_of_measurement
+
 Units of Measurement
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -30,6 +32,7 @@ measurement of that data. We advise using SI units.
 
 
 .. _best_practice_time_series_global_time_reference
+
 Global Time Reference
 ~~~~~~~~~~~~~~~~~~~~~
 
@@ -37,6 +40,7 @@ Global Time Reference
 
 
 .. _best_practice_time_series_subtypes
+
 Subtypes
 ~~~~~~~~
 
@@ -45,6 +49,7 @@ activity, and only those electrodes should be in the electrodes table.
 
 
 .. _best_practice_time_series_break_in_continuity
+
 Breaks in Continuity
 ~~~~~~~~~~~~~~~~~~~~
 TimeSeries data should be stored as one continuous stream.
@@ -61,6 +66,7 @@ One could use timestamps for this, even if there is a constant sampling rate wit
 
 
 .. _best_practice_regular_timestamps:
+
 Timestamps vs. Start & Rate
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/best_practices/time_series.rst
+++ b/docs/best_practices/time_series.rst
@@ -17,7 +17,7 @@ Keep in mind that the dimensions are reversed in MatNWB, so in memory in MatNWB 
 
 In PyNWB the order of the dimensions is the same in memory as on disk, so the time index should be first.
 
-Check function: :py:meth:`check_data_orientation <nwbinspector.checks.time_series.check_data_orientation>`
+Check function: :py:meth:`~nwbinspector.checks.time_series.check_data_orientation`
 
 
 .. _best_practice_unit_of_measurement
@@ -76,7 +76,7 @@ If the sampling rate is constant, use rate. TimeSeries allows you to specify tim
 For TimeSeries objects that have a constant sampling rate, rate should be used instead of timestamps. This will ensure that you can use analysis and
 visualization tools that rely on a constant sampling rate.
 
-Check function: :py:meth:`check_regular_timestamps <nwbinspector.checks.time_series.check_regular_timestamps>`
+Check function: :py:meth:`~nwbinspector.checks.time_series.check_regular_timestamps`
 
 
 

--- a/docs/best_practices/time_series.rst
+++ b/docs/best_practices/time_series.rst
@@ -1,13 +1,12 @@
 Time Series
 ===========
 
-Many of the neurodata_types in NWB inherit from the TimeSeries neurodata_type.
+Many of the neurodata_types in NWB inherit from the TimeSeries (:py:class:`TimeSeries <pynwb.TimeSeries>`) neurodata_type.
 
 When using TimeSeries or any of its descendants, make sure the following are followed.
 
 
 .. _best_practice_data_orientation:
-
 Dimension Order
 ~~~~~~~~~~~~~~~
 
@@ -17,10 +16,10 @@ Keep in mind that the dimensions are reversed in MatNWB, so in memory in MatNWB 
 
 In PyNWB the order of the dimensions is the same in memory as on disk, so the time index should be first.
 
+Check function: :py:meth:`check_data_orientation <nwbinspector.checks.time_series.check_data_orientation>`
 
-Check function: :ref:`check_data_orientation <check_data_orientation>`
 
-
+.. _best_practice_unit_of_measurement
 Units of Measurement
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -30,11 +29,14 @@ Every TimeSeries instance has a unit as an attribute of the data Dataset, which 
 measurement of that data. We advise using SI units.
 
 
+.. _best_practice_time_series_global_time_reference
 Global Time Reference
 ~~~~~~~~~~~~~~~~~~~~~
 
 ```timestamps``` or ```starting_time``` should be in seconds with respect to the global ```timestamps_reference_time``` of the NWBFile.
 
+
+.. _best_practice_time_series_subtypes
 Subtypes
 ~~~~~~~~
 
@@ -42,6 +44,7 @@ ElectrialSeries are reserved for neural data. ElectrialSeries holds signal from 
 activity, and only those electrodes should be in the electrodes table.
 
 
+.. _best_practice_time_series_break_in_continuity
 Breaks in Continuity
 ~~~~~~~~~~~~~~~~~~~~
 TimeSeries data should be stored as one continuous stream.
@@ -58,8 +61,6 @@ One could use timestamps for this, even if there is a constant sampling rate wit
 
 
 .. _best_practice_regular_timestamps:
-
-
 Timestamps vs. Start & Rate
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -69,7 +70,8 @@ If the sampling rate is constant, use rate. TimeSeries allows you to specify tim
 For TimeSeries objects that have a constant sampling rate, rate should be used instead of timestamps. This will ensure that you can use analysis and
 visualization tools that rely on a constant sampling rate.
 
-Check function: :ref:`check_regular_timestamps <check_regular_timestamps>`
+Check function: :py:meth:`check_regular_timestamps <nwbinspector.checks.time_series.check_regular_timestamps>`
+
 
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,7 +65,8 @@ add_module_names = False
 
 def add_refs_to_docstrings(app, what, name, obj, options, lines):
     if what == "function" and obj.__name__.startswith("check_"):
-        lines.append(f"Best Practice: :ref:`best_practice_{obj.__name__[6:]} <best_practice_{obj.__name__[6:]}>`")
+        obj_name = obj.__name__.split("check_")[1]
+        lines.append(f"Best Practice: :ref:`{obj_name.replace('_', ' ').title()} <best_practice_{obj_name}>`")
 
 
 def setup(app):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,8 +65,7 @@ add_module_names = False
 
 def add_refs_to_docstrings(app, what, name, obj, options, lines):
     if what == "function" and obj.__name__.startswith("check_"):
-        obj_name = obj.__name__.split("check_")[1]
-        lines.append(f"Best Practice: :ref:`{obj_name.replace('_', ' ').title()} <best_practice_{obj_name}>`")
+        lines.append(f"Best Practice: :ref:`best_practice_{obj.__name__.split('check_')[1]}`")
 
 
 def setup(app):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,9 +64,6 @@ add_module_names = False
 
 
 def add_refs_to_docstrings(app, what, name, obj, options, lines):
-    if what == "module" and name[:20] == "nwbinspector.checks.":
-        for check_function_name in [x for x in obj.__dict__ if "check_" in x]:
-            lines.append(f".. _{check_function_name}:")
     if what == "function" and name[:6] == "check_":
         lines.append("Best Practice: :ref:`best_practice_{obj.__name__[6:]}`")
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,8 +64,8 @@ add_module_names = False
 
 
 def add_refs_to_docstrings(app, what, name, obj, options, lines):
-    if what == "function" and name[:6] == "check_":
-        lines.append("Best Practice: :ref:`best_practice_{obj.__name__[6:]}`")
+    if what == "function" and obj.__name__.startswith("check_"):
+        lines.append(f"Best Practice: :ref:`best_practice_{obj.__name__[6:]} <best_practice_{obj.__name__[6:]}>`")
 
 
 def setup(app):

--- a/docs/conf_extlinks.py
+++ b/docs/conf_extlinks.py
@@ -52,7 +52,7 @@ intersphinx_mapping = {
     # "matplotlib": ("https://matplotlib.org", None),
     # "h5py": ("https://docs.h5py.org/en/latest/", None),
     # "hdmf": ("https://hdmf.readthedocs.io/en/latest/", None),
-    # "pynwb": ("https://pynwb.readthedocs.io/en/stable/", None),
+    "pynwb": ("https://pynwb.readthedocs.io/en/stable/", None),
     # "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
     # "nct": ("https://nwb-conversion-tools.readthedocs.io/", None),
 }

--- a/docs/conf_extlinks.py
+++ b/docs/conf_extlinks.py
@@ -52,7 +52,7 @@ intersphinx_mapping = {
     # "matplotlib": ("https://matplotlib.org", None),
     # "h5py": ("https://docs.h5py.org/en/latest/", None),
     # "hdmf": ("https://hdmf.readthedocs.io/en/latest/", None),
-    "pynwb": ("https://pynwb.readthedocs.io/en/stable/", None),
+    # "pynwb": ("https://pynwb.readthedocs.io/en/stable/", None),
     # "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
     # "nct": ("https://nwb-conversion-tools.readthedocs.io/", None),
 }


### PR DESCRIPTION
- using direct py:meth: links is working for local API functions
- more work needs to be done for the same thing to apply to inter-sphinx cross-repo method/class API links, which is the next step


Visible from the Best Practices: Time Series section and the API checks for Time Series