### PR TITLE
Declare & bundle license

### DIFF
--- a/nwbinspector/checks/nwb_containers.py
+++ b/nwbinspector/checks/nwb_containers.py
@@ -41,9 +41,9 @@ def check_small_dataset_compression(
     """
     for field in getattr(nwb_container, "fields", dict()).values():
         if (
-                isinstance(field, h5py.Dataset)
-                and field.compression is None
-                and mb_lower_bound * 1e6 < field.size * field.dtype.itemsize < gb_upper_bound * 1e9
+            isinstance(field, h5py.Dataset)
+            and field.compression is None
+            and mb_lower_bound * 1e6 < field.size * field.dtype.itemsize < gb_upper_bound * 1e9
         ):
             if field.size * field.dtype.itemsize > gb_severity_threshold * 1e9:
                 severity = Severity.HIGH

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[metadata]
+license_files = license.txt
+
 [flake8]
 max-line-length = 120
 exclude =

--- a/setup.py
+++ b/setup.py
@@ -16,4 +16,5 @@ setup(
     url="https://github.com/NeurodataWithoutBorders/nwbinspector",
     install_requires=["pynwb", "natsort", "click", "PyYAML", "jsonschema"],
     entry_points={"console_scripts": ["nwbinspector=nwbinspector.nwbinspector:inspect_all_cli"]},
+    license="BSD-3-Clause",
 )


### PR DESCRIPTION
This PR declares the project's license type in the metadata and also causes `license.txt` to be included in both sdists and wheels.  Such practice is strongly recommended so that there are no doubts by users about the project's licensing status.

**Note:** You may also want to change the name of the project at the start of `license.txt` from pynwb to nwbinspector, depending on whether you consider this project to be part of pynwb or not.  Also, unless NeurodataWithoutBorders is actually run by Berkeley, the license has fallen victim to blind copy & paste and needs to be corrected to list the actual copyright holders.

## Checklist

- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/nwbinspector/pulls) for the same change?
- [x] Is your code contribution compliant with `black` format? If not, simply `pip install black` and run `black .` inside your fork.
- [x] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?