### PR TITLE
[Add Check]: table column data is not None

### DIFF
--- a/docs/best_practices/tables.rst
+++ b/docs/best_practices/tables.rst
@@ -5,6 +5,19 @@ The DynamicTable data type that NWB uses allows you to define custom columns, wh
 
 
 
+.. _best_practice_column_data_is_not_none:
+
+Do Not Store Data as ``None``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Specific to the :pynwb-docs:`PyNWB API <>`, when writing data to rows or columns of a :nwb-schema:`Dynamictable`, do
+not use the native Python type of ``None``, as it is not a :nwb-schema:ref:`supported value <common-attributes>` in the
+NWB schema.
+
+Check function :py:meth:`~nwbinspector.checks.table.check_column_data_is_not_none`
+
+
+
 .. _best_practice_dynamic_table_region_data_validity:
 
 Unassigned

--- a/nwbinspector/checks/tables.py
+++ b/nwbinspector/checks/tables.py
@@ -32,6 +32,14 @@ def check_empty_table(table: DynamicTable):
         return InspectorMessage(message="This table has no data added to it.")
 
 
+@register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=DynamicTable)
+def check_column_data_is_not_none(table: DynamicTable, nelems: int = 200):
+    """Check column values in a DynamicTable to ensure they are not None."""
+    for column in table.columns:
+        if any((x is None for x in column.data[:nelems])):
+            yield InspectorMessage(message=f"The column '{column.name}' has 'data' set to None.")
+
+
 @register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=TimeIntervals)
 def check_time_interval_time_columns(time_intervals: TimeIntervals, nelems: int = 200):
     """
@@ -140,17 +148,6 @@ def check_column_binary_capability(table: DynamicTable, nelems: int = 200):
 #         if len(tab.id) == 1:
 #             print("NOTE: '%s' %s has one row" % (tab.name, type(tab).__name__))
 #             continue
-
-
-# @register_check(importance="Best Practice Violation", neurodata_type=pynwb.core.DynamicTable)
-# def check_column_data_is_not_none(nwbfile):
-#     """Check column values in DynamicTable to enssure they are not None."""
-#     for tab in all_of_type(nwbfile, pynwb.core.DynamicTable):
-#         for col in tab.columns:
-#             if not isinstance(col, hdmf.common.table.DynamicTableRegion) and col.data is None:
-#                 return f"'{tab.name}' {type(tab).__name__} column {col.name} data is None"
-#                 # continue
-#                 # TODO: think about how to handle this continuable logic in new refactor
 
 
 # # TODO, continue to break this up

--- a/tests/unit_tests/test_tables.py
+++ b/tests/unit_tests/test_tables.py
@@ -12,6 +12,7 @@ from nwbinspector import (
     check_time_intervals_stop_after_start,
     check_dynamic_table_region_data_validity,
     check_column_binary_capability,
+    check_column_data_is_not_none,
 )
 from nwbinspector.register_checks import InspectorMessage, Importance, Severity
 
@@ -215,6 +216,25 @@ def test_check_single_tables():
     pass
 
 
-@pytest.mark.skip(reason="TODO")
-def test_check_column_data_is_not_none():
-    pass
+def test_check_column_data_is_not_none_pass():
+    table = DynamicTable(name="test_table", description="")
+    table.add_column(name="test_column", description="")
+    table.add_row(test_column=1)
+    assert check_column_data_is_not_none(table=table) is None
+
+
+def test_check_column_data_is_not_none_fail():
+    table = DynamicTable(name="test_table", description="")
+    table.add_column(name="test_column", description="")
+    table.add_row(test_column=1)
+    table["test_column"].data[0] = None  # Unable to set to None in line above using latest pynwb/hdmf
+    assert check_column_data_is_not_none(table=table) == [
+        InspectorMessage(
+            message="The column 'test_column' has 'data' set to None.",
+            importance=Importance.BEST_PRACTICE_VIOLATION,
+            check_function_name="check_column_data_is_not_none",
+            object_type="DynamicTable",
+            object_name="test_table",
+            location="/",
+        )
+    ]


### PR DESCRIPTION
Uncommented check, added tests and BP section for when the data in a column is None.

One case that isn't currently being checked (and would actually fail to detect) is when a user adds data that is an `Iterable` (`list` or `array`, etc.) that itself contains some values set to `None`.

Is there a general way we could flatten any arbitrary nesting of such objects in a data field to examine the first `nelems` raw contents? I.e., such as when `data = [[[1, 2, None]]]`.

EDIT: switching to draft based on similarity to #135 and possibility of merging the two into a general check