### PR TITLE
Suppress cached namespace warnings

### DIFF
--- a/nwbinspector/nwbinspector.py
+++ b/nwbinspector/nwbinspector.py
@@ -10,7 +10,7 @@ from enum import Enum
 from typing import Optional, List
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from types import FunctionType
-from warning import filterwarnings
+from warnings import filterwarnings
 
 import click
 import pynwb

--- a/nwbinspector/nwbinspector.py
+++ b/nwbinspector/nwbinspector.py
@@ -4,13 +4,13 @@ import importlib
 import traceback
 import json
 import jsonschema
-import warnings
 from pathlib import Path
 from collections.abc import Iterable
 from enum import Enum
-from typing import Optional, Union, List
+from typing import Optional, List
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from types import FunctionType
+from warning import filterwarnings
 
 import click
 import pynwb
@@ -342,7 +342,7 @@ def inspect_nwb(
             checks=checks, config=config, ignore=ignore, select=select, importance_threshold=importance_threshold
         )
     nwbfile_path = str(nwbfile_path)
-    warnings.simplefilter("ignore")
+    filterwarnings(action="ignore", message="No cached namespaces found in .*")
     with pynwb.NWBHDF5IO(path=nwbfile_path, mode="r", load_namespaces=True, driver=driver) as io:
         if skip_validate:
             validation_errors = pynwb.validate(io=io)

--- a/nwbinspector/nwbinspector.py
+++ b/nwbinspector/nwbinspector.py
@@ -4,6 +4,7 @@ import importlib
 import traceback
 import json
 import jsonschema
+import warnings
 from pathlib import Path
 from collections.abc import Iterable
 from enum import Enum
@@ -341,6 +342,7 @@ def inspect_nwb(
             checks=checks, config=config, ignore=ignore, select=select, importance_threshold=importance_threshold
         )
     nwbfile_path = str(nwbfile_path)
+    warnings.simplefilter("ignore")
     with pynwb.NWBHDF5IO(path=nwbfile_path, mode="r", load_namespaces=True, driver=driver) as io:
         if skip_validate:
             validation_errors = pynwb.validate(io=io)


### PR DESCRIPTION
Currently, if you run the inspector on a directory of older files that didn't cache namespaces, you get a massive flood of warnings about that.

Example:

![image](https://user-images.githubusercontent.com/51133164/160877442-8d3a726e-1d4a-42d2-a1e6-d0d96163a384.png)

This not only clogs up the console for the final report display, but also seems to slow down the runtime by having the flush the `stdout` repeatedly.

This PR suppresses this simple warning (using `warnings.simplefilter`) but allows any other stronger warnings to continue through (as opposed to using `warnings.filterwarnings("ignore")`).