### PR TITLE
[Bug]: session_start_time not readable

### DIFF
--- a/nwbinspector/__init__.py
+++ b/nwbinspector/__init__.py
@@ -1,7 +1,7 @@
 from .register_checks import available_checks, Importance
 from .nwbinspector import inspect_nwb, inspect_all, load_config
-from .checks.nwbfile_metadata import *
 from .checks.general import *
+from .checks.nwbfile_metadata import *
 from .checks.nwb_containers import *
 from .checks.time_series import *
 from .checks.tables import *

--- a/nwbinspector/__init__.py
+++ b/nwbinspector/__init__.py
@@ -1,8 +1,9 @@
 from .register_checks import available_checks, Importance
 from .nwbinspector import inspect_nwb, inspect_all, load_config
-from .checks.general import *
 from .checks.nwbfile_metadata import *
+from .checks.general import *
 from .checks.nwb_containers import *
 from .checks.time_series import *
 from .checks.tables import *
 from .checks.ecephys import *
+from .checks.ogen import *

--- a/nwbinspector/nwbinspector.py
+++ b/nwbinspector/nwbinspector.py
@@ -271,7 +271,6 @@ def inspect_all(
         importlib.import_module(module)
     # Filtering of checks should apply after external modules are imported, in case those modules have their own checks
     checks = configure_checks(config=config, ignore=ignore, select=select, importance_threshold=importance_threshold)
-
     if n_jobs != 1:
 
         # max_workers for threading is a different concept to number of processes; from the documentation

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -405,7 +405,6 @@ class TestInspector(TestCase):
                 check_function_name="iterable_check_function",
                 object_type="TimeIntervals",
                 object_name="test_table",
-                location="/acquisition/",
                 file_path=self.nwbfile_paths[0],
             ),
             InspectorMessage(
@@ -414,7 +413,6 @@ class TestInspector(TestCase):
                 check_function_name="iterable_check_function",
                 object_type="TimeIntervals",
                 object_name="test_table",
-                location="/acquisition/",
                 file_path=self.nwbfile_paths[0],
             ),
         ]
@@ -439,55 +437,3 @@ class TestInspector(TestCase):
         generator = inspect_nwb(nwbfile_path=self.nwbfile_paths[2], checks=self.checks)
         with self.assertRaises(expected_exception=StopIteration):
             next(generator)
-
-
-class TestSessionStartTimesOnFile(TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.tempdir = Path(mkdtemp())
-        cls.nwbfile_path = cls.tempdir / "test.nwb"
-        nwbfile = make_minimal_nwbfile()
-        nwbfile.add_acquisition(DynamicTable(name="test", description=""))
-        with NWBHDF5IO(path=cls.nwbfile_path, mode="w") as io:
-            io.write(nwbfile)
-
-    @classmethod
-    def tearDownClass(cls):
-        rmtree(cls.tempdir)
-
-    def test_check_session_start_time_old_date_through_inspect_nwb(self):
-        results = list(
-            inspect_nwb(
-                # nwbfile_path=self.nwbfile_path,
-                nwbfile_path=self.nwbfile_path,
-                checks=[check_session_start_time_old_date],
-            )
-        )
-        results_errors = [x for x in results if x.importance.name == "ERROR"]
-        assert results_errors == []
-
-    def test_check_session_start_time_old_date_through_inspect_nwb_before_description_check(self):
-        results = list(
-            inspect_nwb(
-                nwbfile_path=self.nwbfile_path,
-                checks=[check_session_start_time_old_date, check_description],
-            )
-        )
-        results_errors = [x for x in results if x.importance.name == "ERROR"]
-        assert results_errors == []
-
-    def test_check_session_start_time_old_date_through_inspect_nwb_with_description_check(self):
-        results = list(
-            inspect_nwb(
-                # nwbfile_path=self.nwbfile_path,
-                nwbfile_path=self.nwbfile_path,
-                checks=[check_description, check_session_start_time_old_date],
-            )
-        )
-        results_errors = [x for x in results if x.importance.name == "ERROR"]
-        assert len(results_errors) != 0
-        # TODO: what this test really should call is below; need to figure out source cause
-        # print(results_errors)
-        # if results_errors:
-        #     print(results_errors[0].message)
-        # assert results_errors  == []

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -485,8 +485,9 @@ class TestSessionStartTimesOnFile(TestCase):
             )
         )
         results_errors = [x for x in results if x.importance.name == "ERROR"]
+        assert len(results_errors) != 0
+        # TODO: what this test really should call is below; need to figure out source cause
         # print(results_errors)
         # if results_errors:
         #     print(results_errors[0].message)
         # assert results_errors  == []
-        assert len(results_errors) != 0

--- a/tests/unit_tests/test_ecephys.py
+++ b/tests/unit_tests/test_ecephys.py
@@ -89,7 +89,6 @@ class TestCheckElectricalSeries(TestCase):
             check_function_name="check_electrical_series_dims",
             object_type="ElectricalSeries",
             object_name="elec_series",
-            location="/acquisition/",
         )
 
     def test_check_electrical_series_flipped(self):
@@ -112,7 +111,6 @@ class TestCheckElectricalSeries(TestCase):
             check_function_name="check_electrical_series_dims",
             object_type="ElectricalSeries",
             object_name="elec_series",
-            location="/acquisition/",
         )
 
     def test_pass(self):
@@ -138,7 +136,6 @@ class TestCheckElectricalSeries(TestCase):
         dyn_tab.add_column("name", "desc")
         for i in range(5):
             dyn_tab.add_row(name=1)
-
         dynamic_table_region = DynamicTableRegion(
             name="electrodes", description="I am wrong", data=[0, 1, 2, 3, 4], table=dyn_tab
         )

--- a/tests/unit_tests/test_nwbfile_metadata.py
+++ b/tests/unit_tests/test_nwbfile_metadata.py
@@ -204,7 +204,7 @@ def test_check_subject_sex():
         check_function_name="check_subject_sex",
         object_type="Subject",
         object_name="subject",
-        location="/subject"
+        location="/subject",
     )
 
 

--- a/tests/unit_tests/test_nwbfile_metadata.py
+++ b/tests/unit_tests/test_nwbfile_metadata.py
@@ -204,7 +204,7 @@ def test_check_subject_sex():
         check_function_name="check_subject_sex",
         object_type="Subject",
         object_name="subject",
-        location="",
+        location="/subject"
     )
 
 

--- a/tests/unit_tests/test_ophys.py
+++ b/tests/unit_tests/test_ophys.py
@@ -11,7 +11,7 @@ from nwbinspector.checks.ophys import (
     check_roi_response_series_dims,
     check_roi_response_series_link_to_plane_segmentation,
 )
-from nwbinspector.register_checks import InspectorMessage, Importance, Severity
+from nwbinspector.register_checks import InspectorMessage, Importance
 
 
 class TestCheckRoiResponseSeries(TestCase):
@@ -84,7 +84,6 @@ class TestCheckRoiResponseSeries(TestCase):
             check_function_name="check_roi_response_series_dims",
             object_type="RoiResponseSeries",
             object_name="RoiResponseSeries",
-            location="/processing/ophys/",
         )
 
     def test_check_wrong_dims(self):
@@ -110,7 +109,6 @@ class TestCheckRoiResponseSeries(TestCase):
             check_function_name="check_roi_response_series_dims",
             object_type="RoiResponseSeries",
             object_name="RoiResponseSeries",
-            location="/processing/ophys/",
         )
 
     def test_pass_check_roi_response_series_dims(self):
@@ -134,7 +132,6 @@ class TestCheckRoiResponseSeries(TestCase):
         dt.add_column("a", "desc")
         for _ in range(5):
             dt.add_row(a=1)
-
         dtr = DynamicTableRegion(name="n", description="desc", data=[0, 1, 2, 3, 4], table=dt)
         roi_resp_series = RoiResponseSeries(
             name="RoiResponseSeries",
@@ -152,7 +149,6 @@ class TestCheckRoiResponseSeries(TestCase):
             check_function_name="check_roi_response_series_link_to_plane_segmentation",
             object_type="RoiResponseSeries",
             object_name="RoiResponseSeries",
-            location="/processing/ophys/",
         )
 
     def test_pass_check_roi_response_series_link_to_plane_segmentation(self):


### PR DESCRIPTION
A very, very strange bug that I detected while testing the new generalized formatting on real NWBFiles.

Took a while to pin down but I added some tests that show the unintended behavior at the level of core functions (unit tests, and core functions with unit-like usage, do not exhibit the error).

What appears to happen is that the [new check for the `description` field of an object](https://github.com/NeurodataWithoutBorders/nwbinspector/blob/dev/nwbinspector/checks/general.py#L14-L23), if run before the [new checks on the `session_start_time`](https://github.com/NeurodataWithoutBorders/nwbinspector/blob/dev/nwbinspector/checks/nwbfile_metadata.py#L19-L38), corrupts the `session_start_time` of the in-memory `nwbfile` object by setting it to `None`, or something of that nature. Still trying to reduce the issue down to absolutely minimally reproducing components through PyNWB only.

This issue is specific only to the most recent version of the NWBInspector as of a day ago when these checks were merged together; the issue was not discoverable independently.

This PR includes a temporary band-aid fix by allowing the default ordering to run `nwbfile_metadata` checks before the `general` ones, but I'll continue working on a more sophisticated fix.