### PR TITLE
[Documentation]: added links to main library page

### DIFF
--- a/docs/api/nwbinspector.rst
+++ b/docs/api/nwbinspector.rst
@@ -1,20 +1,4 @@
 Core Library
 ============
 
-.. automodule:: nwbinspector
-    :members:
-    :no-undoc-members:
-
-.. toctree::
-    :maxdepth: 4
-
-.. autofunction:: nwbinspector.nwbinspector.inspect_all
-    :noindex:
-.. autofunction:: nwbinspector.nwbinspector.inspect_nwb
-    :noindex:
-.. autofunction:: nwbinspector.nwbinspector.run_checks
-    :noindex:
-.. autofunction:: nwbinspector.nwbinspector.validate_config
-    :noindex:
-.. autofunction:: nwbinspector.nwbinspector.configure_checks
-    :noindex:
+.. automodule:: nwbinspector.nwbinspector

--- a/docs/api/register_check.rst
+++ b/docs/api/register_check.rst
@@ -3,13 +3,4 @@ Data Classes and Check Registration
 
 All common data class used across the package, as well as the decorator for adding a check function to the registry.
 
-.. automodule:: nwbinspector
-    :members:
-    :no-undoc-members:
-    :noindex:
-
-.. toctree::
-    :maxdepth: 4
-
 .. automodule:: nwbinspector.register_checks
-    :noindex:

--- a/docs/user_guide/advanced_usage.rst
+++ b/docs/user_guide/advanced_usage.rst
@@ -4,13 +4,14 @@ Using the Library: Advanced
 This is a collection of tutorials illustrating some of the more advanced uses of the NWBInspector
 
 
+
 Yielding and Iterating
 ----------------------
 
-Both the :code:`inspect_all` and :code:`inspect_nwb` functions directly return generators. That is, they do not actually run any
-checks on any NWBFile until the user performs an iteration command on them. In the basic usage, we recommend the
-simplest way of doing this as simply casting the generator as a list, i.e, :code:`list(inspect_nwb(...))` which will
-automatically collapse the iteration.
+Both the :py:class:`~nwbinspector.nwbinspector.inspect_all` and :py:class:`~nwbinspector.nwbinspector.inspect_nwb`
+functions directly return generators. That is, they do not actually run any checks on any NWBFile until the user
+performs an iteration command on them. In the basic usage, we recommend the simplest way of doing this as simply
+casting the generator as a ``list``, *i.e.*, ``list(inspect_nwb(...))`` which will automatically collapse the iteration.
 
 However, if a user chooses, they can harness these generators in more sophisticated ways, such as
 
@@ -20,8 +21,9 @@ However, if a user chooses, they can harness these generators in more sophistica
 
     first_message = next(results_generator)
 
-which will return either the first :code:`InspectorMessage` for the first Best Practice issue detected in the file (if any),
-or it will raise a :code:`StopIteration` error. This error can be caught in the following manner
+which will return either the first :py:class:`~nwbinspector.register_checks.InspectorMessage` for the first Best
+Practice issue detected in the file (if any), or it will raise a ``StopIteration`` error. This error can be caught in
+the following manner
 
 .. code-block:: python
 
@@ -32,7 +34,7 @@ or it will raise a :code:`StopIteration` error. This error can be caught in the 
     except StopIteration:
         print("There are no messages!")
 
-Of course, the generator can be treated as any other iterable as well, such as with :code:`for` loops
+Of course, the generator can be treated as any other iterable as well, such as with ``for`` loops
 
 .. code-block:: python
 
@@ -42,17 +44,19 @@ Of course, the generator can be treated as any other iterable as well, such as w
         print(message)
 
 
+
 Running on a DANDISets (ros3)
 -----------------------------
 
 It is a common use case to want to inspect and review entire datasets of NWBFiles that have already been
 uploaded to the :dandi-archive:`DANDI Archive <>`. While one could technically just download the DANDISet and
 use the NWBInspector as normal, there is another, less expensive possibility in terms of bandwith. This is especially
-useful when the underlying dataset is quite large and thus impractical to download - some DANDISets can even be on the TB scale!
+useful when the underlying dataset is quite large and thus impractical to download - some DANDISets can even be on the
+TB scale!
 
-The general tutorial for using the :code:`ros3` driver can be found :ros3-tutorial:`here <>`. This driver can be passed directly
-into our core inspection functions, and the :code:`path` or :code:`nwbfile_path` arguments in this case become the S3 path on the
-DANDI archive. Resolution of these paths can be performed via the following code
+The general tutorial for using the :code:`ros3` driver can be found :ros3-tutorial:`here <>`. This driver can be passed
+directly into our core inspection functions, and the ``path`` or ``nwbfile_path`` arguments in this case become the
+S3 path on the DANDI archive. Resolution of these paths can be performed via the following code
 
 .. code-block:: python
 
@@ -71,11 +75,11 @@ DANDI archive. Resolution of these paths can be performed via the following code
 
 
 
-
 Organization of Reports
 -----------------------
 
-Our organization functions are capable of arbitrary nesting based on attributes of the InspectorMessage class...
+Our organization functions are capable of arbitrary nesting based on attributes of the
+:py:class:`~nwbinspector.register_checks.InspectorMessage` class...
 
 .. code-block:: python
 
@@ -83,6 +87,7 @@ Our organization functions are capable of arbitrary nesting based on attributes 
 
     organized_messages = organized_messages(messagess=list(inspect_all(...)), levels=["file_path", "importance"])
 
-This will return a nested dictionary of the same depth as as `levels`, with each key being the unique values within
-that nested condition. While `levels = ["file_path", "importance"]` is the default behavior, any combination and order
-of `InspectorMessage` attributes can be utilized to produce a more easily readable structure.
+This will return a nested dictionary of the same depth as as ``levels``, with each key being the unique values within
+that nested condition. While ``levels = ["file_path", "importance"]`` is the default behavior, any combination and order
+of :py:class:`~nwbinspector.register_checks.InspectorMessage` attributes can be utilized to produce a more easily
+readable structure.

--- a/docs/user_guide/library_usage.rst
+++ b/docs/user_guide/library_usage.rst
@@ -1,24 +1,28 @@
 Using the Library
 =================
 
-For users familiar with Python, our core functions may also be used directly to allow greater freedom in handling input and output.
+For users familiar with Python, our core functions may also be used directly to allow greater freedom in handling input
+and output.
+
 
 
 InspectorMesssage objects
 -------------------------
 
 In order to understand the output of the core functions, we must first explain the most important data structure in our
-library, the :code:`InspectorMessage`. This is a standalone data class that contains all values that could be useful or
-related to a detected Best Practice issue. These values include the text-based :code:`message` displayed in the report,
-the :code:`importance` of the check (how crucial it is to fix), the name of the object that triggered the issue, where that
-object can be found within the NWBFile itself, and the file path of the NWBFile relative to the directory the inspection
-function was called from.
+library, the :py:class:`~nwbinspector.register_checks.InspectorMessage`. This is a standalone data class that contains
+all values that could be useful or related to a detected Best Practice issue. These values include the text-based
+``message`` displayed in the report, the ``importance`` of the check (how crucial it is to fix), the ``object_name``
+and ``object_type`` that triggered the issue, the ``location`` of that object within the NWBFile, and the ``file_path``
+of the NWBFile relative to the directory the inspection function was called from.
+
 
 
 Inspect a single NWBFile
 ------------------------
 
-The most basic function to use when inspecting a single NWBFile is the :code:`inspect_nwb` function.
+The most basic function to use when inspecting a single NWBFile is the
+:py:class:`~nwbinspector.nwbinspector.inspect_nwb` function.
 
 .. code-block:: python
 
@@ -26,13 +30,15 @@ The most basic function to use when inspecting a single NWBFile is the :code:`in
 
     results = list(inspect_nwb(nwbfile_path="path_to_single_nwbfile"))
 
-This returns a :code:`list` of :code:`InspectorMessage` objects.
+This returns a ``list`` of :py:class:`~nwbinspector.register_checks.InspectorMessage` objects.
+
 
 
 Inspect a Directory or List of Paths to NWBFiles
 ------------------------------------------------
 
-If you want to run essentially the same code as the CLI, use the :code:`inspect_all` function.
+If you want to run essentially the same code as the CLI, use the :py:class:`~nwbinspector.nwbinspector.inspect_all`
+function.
 
 .. code-block:: python
 
@@ -40,18 +46,19 @@ If you want to run essentially the same code as the CLI, use the :code:`inspect_
 
     all_results = list(inspect_all(path=file_paths_or_folder, ...))
 
-This has the same return structure as :code:`inspect_nwb`
+This has the same return structure as :py:class:`~nwbinspector.nwbinspector.inspect_nwb`.
 
 
 .. note::
 
-    For convenience, all path-based arguments in the NWBInspector library support both :code:`str` and :code:`pathlib.Path` types.
+    For convenience, all path-based arguments in the NWBInspector library support both ``str`` and ``pathlib.Path`` types.
+
 
 
 Examining the Default Check Registry
 ------------------------------------
 
-While it does not need to be imported directly for default usage, an interested user may inspect the :code:`list` of all
+While it does not need to be imported directly for default usage, an interested user may inspect the ``list`` of all
 available check functions via
 
 .. code-block:: python


### PR DESCRIPTION
WIP shifting all references to core functions to point to API docs

@bendichter What would you think about linking basic python data types like `str` to their external Python docs, _e.g._, [str](https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str).