### PR TITLE
[Modify Check]: elevated species binomial form to violation

### DIFF
--- a/nwbinspector/checks/nwbfile_metadata.py
+++ b/nwbinspector/checks/nwbfile_metadata.py
@@ -119,11 +119,16 @@ def check_subject_sex(subject: Subject):
 
 
 @register_check(importance=Importance.BEST_PRACTICE_SUGGESTION, neurodata_type=Subject)
-def check_subject_species(subject: Subject):
-    """Check if the subject species has been specified and follows latin binomial form."""
+def check_subject_species_exists(subject: Subject):
+    """Check if the subject species has been specified."""
     if not subject.species:
         return InspectorMessage(message="Subject species is missing.")
-    if not re.fullmatch(species_regex, subject.species):
+
+
+@register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=Subject)
+def check_subject_species(subject: Subject):
+    """Check if the subject species follows latin binomial form."""
+    if subject.species and not re.fullmatch(species_regex, subject.species):
         return InspectorMessage(
             message="Species should be in latin binomial form, e.g. 'Mus musculus' and 'Homo sapiens'",
         )

--- a/nwbinspector/checks/nwbfile_metadata.py
+++ b/nwbinspector/checks/nwbfile_metadata.py
@@ -126,7 +126,7 @@ def check_subject_species_exists(subject: Subject):
 
 
 @register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=Subject)
-def check_subject_species(subject: Subject):
+def check_subject_species_latin_binomial(subject: Subject):
     """Check if the subject species follows latin binomial form."""
     if subject.species and not re.fullmatch(species_regex, subject.species):
         return InspectorMessage(

--- a/nwbinspector/checks/nwbfile_metadata.py
+++ b/nwbinspector/checks/nwbfile_metadata.py
@@ -118,7 +118,7 @@ def check_subject_sex(subject: Subject):
         )
 
 
-@register_check(importance=Importance.BEST_PRACTICE_SUGGESTION, neurodata_type=Subject)
+@register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=Subject)
 def check_subject_species_exists(subject: Subject):
     """Check if the subject species has been specified."""
     if not subject.species:

--- a/tests/unit_tests/test_nwbfile_metadata.py
+++ b/tests/unit_tests/test_nwbfile_metadata.py
@@ -261,7 +261,7 @@ def test_check_subject_species_exists_missing():
     subject = Subject(subject_id="001")
     assert check_subject_species_exists(subject) == InspectorMessage(
         message="Subject species is missing.",
-        importance=Importance.BEST_PRACTICE_SUGGESTION,
+        importance=Importance.BEST_PRACTICE_VIOLATION,
         check_function_name="check_subject_species_exists",
         object_type="Subject",
         object_name="subject",

--- a/tests/unit_tests/test_nwbfile_metadata.py
+++ b/tests/unit_tests/test_nwbfile_metadata.py
@@ -17,7 +17,7 @@ from nwbinspector.checks.nwbfile_metadata import (
     check_subject_sex,
     check_subject_age,
     check_subject_species_exists,
-    check_subject_species,
+    check_subject_species_latin_binomial,
     check_processing_module_name,
     check_session_start_time_old_date,
     check_session_start_time_future_date,
@@ -257,7 +257,7 @@ def test_pass_check_subject_species_exists():
     assert check_subject_species_exists(subject) is None
 
 
-def test_check_subject_species_exists_missing():
+def test_check_subject_species_missing():
     subject = Subject(subject_id="001")
     assert check_subject_species_exists(subject) == InspectorMessage(
         message="Subject species is missing.",
@@ -269,18 +269,18 @@ def test_check_subject_species_exists_missing():
     )
 
 
-def test_pass_check_subject_species():
+def check_subject_species_latin_binomial_pass():
     subject = Subject(subject_id="001", species="Homo sapiens")
-    assert check_subject_species(subject) is None
+    assert check_subject_species_latin_binomial(subject) is None
 
 
 def test_check_subject_species_not_binomial():
     subject = Subject(subject_id="001", species="Human")
 
-    assert check_subject_species(subject) == InspectorMessage(
+    assert check_subject_species_latin_binomial(subject) == InspectorMessage(
         message="Species should be in latin binomial form, e.g. 'Mus musculus' and 'Homo sapiens'",
         importance=Importance.BEST_PRACTICE_VIOLATION,
-        check_function_name="check_subject_species",
+        check_function_name="check_subject_species_latin_binomial",
         object_type="Subject",
         object_name="subject",
         location="/general/subject",

--- a/tests/unit_tests/test_nwbfile_metadata.py
+++ b/tests/unit_tests/test_nwbfile_metadata.py
@@ -16,6 +16,7 @@ from nwbinspector.checks.nwbfile_metadata import (
     check_subject_id_exists,
     check_subject_sex,
     check_subject_age,
+    check_subject_species_exists,
     check_subject_species,
     check_processing_module_name,
     check_session_start_time_old_date,
@@ -233,18 +234,6 @@ def test_check_subject_age_missing():
     )
 
 
-def test_check_subject_species():
-    subject = Subject(subject_id="001")
-    assert check_subject_species(subject) == InspectorMessage(
-        message="Subject species is missing.",
-        importance=Importance.BEST_PRACTICE_SUGGESTION,
-        check_function_name="check_subject_species",
-        object_type="Subject",
-        object_name="subject",
-        location="/general/subject",
-    )
-
-
 def test_check_subject_age_iso8601():
     subject = Subject(subject_id="001", sex="Male", age="9 months")
     assert check_subject_age(subject) == InspectorMessage(
@@ -263,12 +252,34 @@ def test_pass_check_subject_age_with_dob():
     assert check_subject_age(subject) is None
 
 
-def test_check_subject_species_not_iso8601():
+def test_pass_check_subject_species_exists():
+    subject = Subject(subject_id="001", species="Homo sapiens")
+    assert check_subject_species_exists(subject) is None
+
+
+def test_check_subject_species_exists_missing():
+    subject = Subject(subject_id="001")
+    assert check_subject_species_exists(subject) == InspectorMessage(
+        message="Subject species is missing.",
+        importance=Importance.BEST_PRACTICE_SUGGESTION,
+        check_function_name="check_subject_species_exists",
+        object_type="Subject",
+        object_name="subject",
+        location="/general/subject",
+    )
+
+
+def test_pass_check_subject_species():
+    subject = Subject(subject_id="001", species="Homo sapiens")
+    assert check_subject_species(subject) is None
+
+
+def test_check_subject_species_not_binomial():
     subject = Subject(subject_id="001", species="Human")
 
     assert check_subject_species(subject) == InspectorMessage(
         message="Species should be in latin binomial form, e.g. 'Mus musculus' and 'Homo sapiens'",
-        importance=Importance.BEST_PRACTICE_SUGGESTION,
+        importance=Importance.BEST_PRACTICE_VIOLATION,
         check_function_name="check_subject_species",
         object_type="Subject",
         object_name="subject",
@@ -310,19 +321,9 @@ def test_check_subject_id_exists():
     )
 
 
-def test_pass_check_subject_species():
-    subject = Subject(subject_id="001", species="Homo sapiens")
-    assert check_subject_species(subject) is None
-
-
 def test_pass_check_subject_id_exist():
     subject = Subject(subject_id="001", sex="Male")
     assert check_subject_id_exists(subject) is None
-
-
-@pytest.mark.skip(reason="TODO")
-def test_check_subject_species():
-    pass
 
 
 def test_check_processing_module_name():


### PR DESCRIPTION
As per our discussion the other day, this elevates the check for species being in binomial form to be a violation if caught. If the species metadata is missing, it's still just a suggestion however.