### PR TITLE
[Modify Check]: allow single row check to skip special tables

### DIFF
--- a/nwbinspector/checks/tables.py
+++ b/nwbinspector/checks/tables.py
@@ -136,7 +136,9 @@ def check_column_binary_capability(table: DynamicTable, nelems: int = 200):
 
 @register_check(importance=Importance.BEST_PRACTICE_SUGGESTION, neurodata_type=DynamicTable)
 def check_single_row(
-    table: DynamicTable, exclude_types: Optional[list] = None, exclude_names: Optional[List[str]] = None
+    table: DynamicTable,
+    exclude_types: Optional[list] = (Units, ),
+    exclude_names: Optional[List[str]] = ("electrodes", ),
 ):
     """
     Check if DynamicTable has only a single row; may be better represented by another data type.
@@ -144,8 +146,6 @@ def check_single_row(
     Skips the Units table since it is OK to have only a single spiking unit.
     Skips the Electrode table since it is OK to have only a single electrode.
     """
-    exclude_types = [Units] if exclude_types is None else exclude_types
-    exclude_names = ["electrodes"] if exclude_names is None else exclude_names
     if any((isinstance(table, exclude_type) for exclude_type in exclude_types)):
         return
     if any((table.name == exclude_name for exclude_name in exclude_names)):

--- a/nwbinspector/checks/tables.py
+++ b/nwbinspector/checks/tables.py
@@ -1,11 +1,11 @@
 """Check functions that can apply to any descendant of DynamicTable."""
 from numbers import Real
-from typing import List
+from typing import List, Optional
 
 import numpy as np
 from hdmf.common import DynamicTable, DynamicTableRegion, VectorIndex
 from hdmf.utils import get_data_shape
-from pynwb.file import TimeIntervals
+from pynwb.file import TimeIntervals, Units
 
 from ..register_checks import register_check, InspectorMessage, Importance
 from ..utils import format_byte_size, is_ascending_series
@@ -135,13 +135,19 @@ def check_column_binary_capability(table: DynamicTable, nelems: int = 200):
 
 
 @register_check(importance=Importance.BEST_PRACTICE_SUGGESTION, neurodata_type=DynamicTable)
-def check_single_row(table: DynamicTable, exclude_names: List[str] = ["Units", "electrodes"]):
+def check_single_row(
+    table: DynamicTable, exclude_types: Optional[list] = None, exclude_names: Optional[List[str]] = None
+):
     """
     Check if DynamicTable has only a single row; may be better represented by another data type.
 
     Skips the Units table since it is OK to have only a single spiking unit.
     Skips the Electrode table since it is OK to have only a single electrode.
     """
+    exclude_types = [Units] if exclude_types is None else exclude_types
+    exclude_names = ["electrodes"] if exclude_names is None else exclude_names
+    if any((isinstance(table, exclude_type) for exclude_type in exclude_types)):
+        return
     if any((table.name == exclude_name for exclude_name in exclude_names)):
         return
     if len(table.id) == 1:

--- a/nwbinspector/checks/tables.py
+++ b/nwbinspector/checks/tables.py
@@ -1,5 +1,6 @@
 """Check functions that can apply to any descendant of DynamicTable."""
 from numbers import Real
+from typing import List
 
 import numpy as np
 from hdmf.common import DynamicTable, DynamicTableRegion, VectorIndex
@@ -134,8 +135,15 @@ def check_column_binary_capability(table: DynamicTable, nelems: int = 200):
 
 
 @register_check(importance=Importance.BEST_PRACTICE_SUGGESTION, neurodata_type=DynamicTable)
-def check_single_row(table: DynamicTable):
-    """Check if DynamicTable has only a single row; may be better represented by another data type."""
+def check_single_row(table: DynamicTable, exclude_names: List[str] = ["Units", "electrodes"]):
+    """
+    Check if DynamicTable has only a single row; may be better represented by another data type.
+
+    Skips the Units table since it is OK to have only a single spiking unit.
+    Skips the Electrode table since it is OK to have only a single electrode.
+    """
+    if any((table.name == exclude_name for exclude_name in exclude_names)):
+        return
     if len(table.id) == 1:
         return InspectorMessage(
             message="This table has only a single row; it may be better represented by another data type."

--- a/nwbinspector/checks/tables.py
+++ b/nwbinspector/checks/tables.py
@@ -137,8 +137,8 @@ def check_column_binary_capability(table: DynamicTable, nelems: int = 200):
 @register_check(importance=Importance.BEST_PRACTICE_SUGGESTION, neurodata_type=DynamicTable)
 def check_single_row(
     table: DynamicTable,
-    exclude_types: Optional[list] = (Units, ),
-    exclude_names: Optional[List[str]] = ("electrodes", ),
+    exclude_types: Optional[list] = (Units,),
+    exclude_names: Optional[List[str]] = ("electrodes",),
 ):
     """
     Check if DynamicTable has only a single row; may be better represented by another data type.

--- a/tests/unit_tests/test_tables.py
+++ b/tests/unit_tests/test_tables.py
@@ -4,7 +4,7 @@ from unittest import TestCase
 import pytest
 import numpy as np
 from hdmf.common import DynamicTable, DynamicTableRegion
-from pynwb.file import TimeIntervals
+from pynwb.file import TimeIntervals, Units, ElectrodeTable, ElectrodeGroup, Device
 
 from nwbinspector import (
     check_empty_table,
@@ -216,6 +216,31 @@ def test_check_single_row_pass():
     table.add_column(name="test_column", description="")
     table.add_row(test_column=1)
     table.add_row(test_column=2)
+    assert check_single_row(table=table) is None
+
+
+def test_check_single_row_ignore_units():
+    table = Units(
+        name="Units",  # default name when building through nwbfile
+    )
+    table.add_unit(spike_times=[1, 2, 3])
+    assert check_single_row(table=table) is None
+
+
+def test_check_single_row_ignore_electrodes():
+    table = ElectrodeTable(
+        name="electrodes",  # default name when building through nwbfile
+    )
+    table.add_row(
+        x=np.nan,
+        y=np.nan,
+        z=np.nan,
+        imp=np.nan,
+        location="unknown",
+        filtering="unknown",
+        group=ElectrodeGroup(name="test_group", description="", device=Device(name="test_device"), location="unknown"),
+        group_name="test_group",
+    )
     assert check_single_row(table=table) is None
 
 


### PR DESCRIPTION
As per discussion the other day, it is possible for Units tables to have only a single spiking Unit, so that's now allowed and will not trigger the check.

I also extended this to the ElectrodeTable, since it is likewise OK to only have a single electrode. Granted that, in practice, mostly applies to `icephys` where they should be using separate `IcephysElectrode` objects anyway, but I guess it's possible for an `ecephys` tetrode to have 3 bad or non-neural ones plugged in, too.