### PR TITLE
[Add Check]: string-valued table elements contain dictionaries

### DIFF
--- a/nwbinspector/checks/tables.py
+++ b/nwbinspector/checks/tables.py
@@ -168,7 +168,7 @@ def check_table_values_for_dict(table: DynamicTable, nelems: int = 200):
             if any((is_dict_in_string(string=string) for string in column.data[:nelems])):
                 yield InspectorMessage(
                     message=(
-                        f"The column '{column}' contains a string value that contains a dictionary! Please unpack "
+                        f"The column '{column.name}' contains a string value that contains a dictionary! Please unpack "
                         "dictionaries as additional rows or columns of the table."
                     )
                 )

--- a/nwbinspector/checks/tables.py
+++ b/nwbinspector/checks/tables.py
@@ -8,7 +8,7 @@ from hdmf.utils import get_data_shape
 from pynwb.file import TimeIntervals, Units
 
 from ..register_checks import register_check, InspectorMessage, Importance
-from ..utils import format_byte_size, is_ascending_series, is_dict_in_string
+from ..utils import format_byte_size, is_ascending_series, is_dict_in_string, is_string_json_loadable
 
 
 @register_check(importance=Importance.CRITICAL, neurodata_type=DynamicTableRegion)
@@ -162,16 +162,17 @@ def check_single_row(
 def check_table_values_for_dict(table: DynamicTable, nelems: int = 200):
     """Check if any values in a row or column of a table contain a string casting of a Python dictionary."""
     for column in table.columns:
-        if hasattr(column, "data") and not isinstance(column, VectorIndex):
-            if not isinstance(column.data[0], str):
-                continue
-            if any((is_dict_in_string(string=string) for string in column.data[:nelems])):
-                yield InspectorMessage(
-                    message=(
-                        f"The column '{column.name}' contains a string value that contains a dictionary! Please unpack "
-                        "dictionaries as additional rows or columns of the table."
-                    )
+        if not hasattr(column, "data") or isinstance(column, VectorIndex) or not isinstance(column.data[0], str):
+            continue
+        for string in column.data[:nelems]:
+            if is_dict_in_string(string=string):
+                message = (
+                    f"The column '{column.name}' contains a string value that contains a dictionary! Please "
+                    "unpack dictionaries as additional rows or columns of the table."
                 )
+                if is_string_json_loadable(string=string):
+                    message += " This string is also JSON loadable, so call `json.loads(...)` on the string to unpack."
+                yield InspectorMessage(message=message)
 
 
 # @register_check(importance="Best Practice Violation", neurodata_type=pynwb.core.DynamicTable)

--- a/nwbinspector/checks/tables.py
+++ b/nwbinspector/checks/tables.py
@@ -150,7 +150,7 @@ def check_table_values_for_dict(table: DynamicTable, nelems: int = 200):
             if not isinstance(column.data[0], str):
                 continue
             if any((is_dict_in_string(string=string) for string in column.data[:nelems])):
-                return InspectorMessage(
+                yield InspectorMessage(
                     message=(
                         f"The column '{column}' contains a string value that contains a dictionary! Please unpack "
                         "dictionaries as additional rows or columns of the table."

--- a/nwbinspector/utils.py
+++ b/nwbinspector/utils.py
@@ -1,5 +1,6 @@
 """Commonly reused logic for evaluating conditions; must not have external dependencies."""
 import re
+import json
 import numpy as np
 from typing import TypeVar, Optional, List
 from pathlib import Path
@@ -53,8 +54,21 @@ def is_ascending_series(series: np.ndarray, nelems=None):
 
 def is_dict_in_string(string: str):
     """
-    Determine if the string value contains an encoded dictionary, such as a JSON object.
+    Determine if the string value contains an encoded Python dictionary.
 
     Can also be the direct results of string casting a dictionary, *e.g.*, ``str(dict(a=1))``.
     """
     return any(re.findall(pattern=dict_regex, string=string))
+
+
+def is_string_json_loadable(string: str):
+    """
+    Determine if the serialized dictionary is a JSON object.
+
+    Rather than constructing a complicated regex pattern, a simple try/except of the json.load should suffice.
+    """
+    try:
+        json.loads(string)
+        return True
+    except json.JSONDecodeError:
+        return False

--- a/nwbinspector/utils.py
+++ b/nwbinspector/utils.py
@@ -8,7 +8,7 @@ PathType = TypeVar("PathType", str, Path)  # For types that can be either files 
 FilePathType = TypeVar("FilePathType", str, Path)
 OptionalListOfStrings = Optional[List[str]]
 
-dict_regex = r"({.*?:.*?})"
+dict_regex = r"({.+:.+})"
 
 
 def format_byte_size(byte_size: int, units: str = "SI"):

--- a/nwbinspector/utils.py
+++ b/nwbinspector/utils.py
@@ -1,4 +1,5 @@
 """Commonly reused logic for evaluating conditions; must not have external dependencies."""
+import re
 import numpy as np
 from typing import TypeVar, Optional, List
 from pathlib import Path
@@ -6,6 +7,8 @@ from pathlib import Path
 PathType = TypeVar("PathType", str, Path)  # For types that can be either files or folders
 FilePathType = TypeVar("FilePathType", str, Path)
 OptionalListOfStrings = Optional[List[str]]
+
+dict_regex = r"([{\[].*?[}\]])$"
 
 
 def format_byte_size(byte_size: int, units: str = "SI"):
@@ -46,3 +49,12 @@ def check_regular_series(series: np.ndarray, tolerance_decimals: int = 9):
 
 def is_ascending_series(series: np.ndarray, nelems=None):
     return np.all(np.diff(series[:nelems]) > 0)
+
+
+def is_dict_in_string(string: str):
+    """
+    Determine if the string value contains an encoded dictionary, such as a JSON object.
+
+    Can also be the direct results of string casting a dictionary, *e.g.*, ``str(dict(a=1))``.
+    """
+    return any(re.findall(pattern=dict_regex, string=string))

--- a/nwbinspector/utils.py
+++ b/nwbinspector/utils.py
@@ -8,7 +8,7 @@ PathType = TypeVar("PathType", str, Path)  # For types that can be either files 
 FilePathType = TypeVar("FilePathType", str, Path)
 OptionalListOfStrings = Optional[List[str]]
 
-dict_regex = r"([{\[].*?[}\]])$"
+dict_regex = r"({.*?:.*?})"
 
 
 def format_byte_size(byte_size: int, units: str = "SI"):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 from hdmf.testing import TestCase
 
-from nwbinspector.utils import format_byte_size, check_regular_series
+from nwbinspector.utils import format_byte_size, check_regular_series, is_dict_in_string
 
 
 def test_format_byte_size():
@@ -23,3 +23,28 @@ class TestFormatByteException(TestCase):
 def test_check_regular_series():
     assert check_regular_series(series=[1, 2, 3])
     assert not check_regular_series(series=[1, 2, 4])
+
+
+def test_is_dict_in_string_none():
+    string = "not a dict"
+    assert is_dict_in_string(string=string) is False
+
+
+def test_is_dict_in_string_1():
+    string = str(dict(a=1))
+    assert is_dict_in_string(string=string) is True
+
+
+def test_is_dict_in_string_2():
+    string = str([dict(a=1), dict(b=2)])
+    assert is_dict_in_string(string=string) is True
+
+
+def test_is_dict_in_string_3():
+    string = str(dict(a=dict(b=2)))
+    assert is_dict_in_string(string=string) is True
+
+
+def test_is_dict_in_string_4():
+    string = "some text: {'then': 'a dict'}"
+    assert is_dict_in_string(string=string) is True

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 from hdmf.testing import TestCase
 
+from nwbinspector import Importance
 from nwbinspector.utils import format_byte_size, check_regular_series, is_dict_in_string
 
 
@@ -25,26 +26,47 @@ def test_check_regular_series():
     assert not check_regular_series(series=[1, 2, 4])
 
 
-def test_is_dict_in_string_none():
+def test_is_dict_in_string_false_1():
     string = "not a dict"
     assert is_dict_in_string(string=string) is False
 
 
-def test_is_dict_in_string_1():
+def test_is_dict_in_string_false_2():
+    string = "not a dict, {but also fancy format text!}"
+    assert is_dict_in_string(string=string) is False
+
+
+def test_is_dict_in_string_false_3():
+    string = "[not] a dict, {[but] also} fancy format text!"
+    assert is_dict_in_string(string=string) is False
+
+
+def test_is_dict_in_string_true_1():
     string = str(dict(a=1))
     assert is_dict_in_string(string=string) is True
 
 
-def test_is_dict_in_string_2():
+def test_is_dict_in_string_true_2():
     string = str([dict(a=1), dict(b=2)])
     assert is_dict_in_string(string=string) is True
 
 
-def test_is_dict_in_string_3():
+def test_is_dict_in_string_true_3():
     string = str(dict(a=dict(b=2)))
     assert is_dict_in_string(string=string) is True
 
 
-def test_is_dict_in_string_4():
+def test_is_dict_in_string_true_4():
     string = "some text: {'then': 'a dict'}"
+    assert is_dict_in_string(string=string) is True
+
+
+def test_is_dict_in_string_true_5():
+    string = "{'then': 'a dict'} more text"
+    assert is_dict_in_string(string=string) is True
+
+
+def test_is_dict_in_string_true_6():
+    """Not a JSON encodable object."""
+    string = str({1.2: Importance.CRITICAL})
     assert is_dict_in_string(string=string) is True

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -41,11 +41,6 @@ def test_is_dict_in_string_false_3():
     assert is_dict_in_string(string=string) is False
 
 
-def test_is_dict_in_string_false_4():
-    string = "not a dict, {but: it sure looks like one}!"
-    assert is_dict_in_string(string=string) is False
-
-
 def test_is_dict_in_string_true_1():
     string = str(dict(a=1))
     assert is_dict_in_string(string=string) is True
@@ -74,4 +69,28 @@ def test_is_dict_in_string_true_5():
 def test_is_dict_in_string_true_6():
     """Not a JSON encodable object."""
     string = str({1.2: Importance.CRITICAL})
+    assert is_dict_in_string(string=string) is True
+
+
+def test_is_dict_in_string_true_7():
+    """
+    A more aggressive demonstration of the general dictionary regex.
+
+    But it is technically possible to achieve via `str({custom_object_1: custom_object_2})` if 'custom_object_1' is
+    hashable and both custom objects have manual `__repr__` that do not include apostrophe's within their return.
+
+    Example
+    -------
+    from dataclasses import dataclass
+
+    @dataclass
+    class Test():
+        prop = 1
+
+        def __repr__(self):
+            return "This is a test"
+
+    str({1: Test()})
+    """
+    string = "example, {this is not a dict: but it sure looks like one}!"
     assert is_dict_in_string(string=string) is True

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -41,6 +41,11 @@ def test_is_dict_in_string_false_3():
     assert is_dict_in_string(string=string) is False
 
 
+def test_is_dict_in_string_false_4():
+    string = "not a dict, {but: it sure looks like one}!"
+    assert is_dict_in_string(string=string) is False
+
+
 def test_is_dict_in_string_true_1():
     string = str(dict(a=1))
     assert is_dict_in_string(string=string) is True

--- a/tests/unit_tests/test_tables.py
+++ b/tests/unit_tests/test_tables.py
@@ -277,7 +277,7 @@ def test_check_table_values_for_dict():
     table = DynamicTable(name="test_table", description="")
     table.add_column(name="test_column", description="")
     table.add_row(test_column=str(dict(a=1)))
-    assert check_table_values_for_dict(table=table) == InspectorMessage(
+    assert check_table_values_for_dict(table=table)[0] == InspectorMessage(
         message=(
             "The column 'test_column' contains a string value that contains a dictionary! Please unpack "
             "dictionaries as additional rows or columns of the table."

--- a/tests/unit_tests/test_tables.py
+++ b/tests/unit_tests/test_tables.py
@@ -1,4 +1,5 @@
 import platform
+import json
 from unittest import TestCase
 
 import pytest
@@ -281,6 +282,24 @@ def test_check_table_values_for_dict():
         message=(
             "The column 'test_column' contains a string value that contains a dictionary! Please unpack "
             "dictionaries as additional rows or columns of the table."
+        ),
+        importance=Importance.BEST_PRACTICE_VIOLATION,
+        check_function_name="check_table_values_for_dict",
+        object_type="DynamicTable",
+        object_name="test_table",
+        location="/",
+    )
+
+
+def test_check_table_values_for_dict_json_case():
+    table = DynamicTable(name="test_table", description="")
+    table.add_column(name="test_column", description="")
+    table.add_row(test_column=json.dumps(dict(a=1)))
+    assert check_table_values_for_dict(table=table)[0] == InspectorMessage(
+        message=(
+            "The column 'test_column' contains a string value that contains a dictionary! Please unpack "
+            "dictionaries as additional rows or columns of the table. This string is also JSON loadable, so call "
+            "`json.loads(...)` on the string to unpack."
         ),
         importance=Importance.BEST_PRACTICE_VIOLATION,
         check_function_name="check_table_values_for_dict",

--- a/tests/unit_tests/test_tables.py
+++ b/tests/unit_tests/test_tables.py
@@ -13,6 +13,7 @@ from nwbinspector import (
     check_dynamic_table_region_data_validity,
     check_column_binary_capability,
     check_single_row,
+    check_table_values_for_dict,
 )
 from nwbinspector.register_checks import InspectorMessage, Importance
 
@@ -258,21 +259,21 @@ def test_check_single_row_fail():
     )
 
 
-def check_table_values_for_dict_non_str():
+def test_check_table_values_for_dict_non_str():
     table = DynamicTable(name="test_table", description="")
     table.add_column(name="test_column", description="")
     table.add_row(test_column=123)
     assert check_table_values_for_dict(table=table) is None
 
 
-def check_table_values_for_dict_pass():
+def test_check_table_values_for_dict_pass():
     table = DynamicTable(name="test_table", description="")
     table.add_column(name="test_column", description="")
     table.add_row(test_column="123")
     assert check_table_values_for_dict(table=table) is None
 
 
-def check_table_values_for_dict():
+def test_check_table_values_for_dict():
     table = DynamicTable(name="test_table", description="")
     table.add_column(name="test_column", description="")
     table.add_row(test_column=str(dict(a=1)))

--- a/tests/unit_tests/test_tables.py
+++ b/tests/unit_tests/test_tables.py
@@ -233,6 +233,37 @@ def test_check_single_row_fail():
     )
 
 
+def check_table_values_for_dict_non_str():
+    table = DynamicTable(name="test_table", description="")
+    table.add_column(name="test_column", description="")
+    table.add_row(test_column=123)
+    assert check_table_values_for_dict(table=table) is None
+
+
+def check_table_values_for_dict_pass():
+    table = DynamicTable(name="test_table", description="")
+    table.add_column(name="test_column", description="")
+    table.add_row(test_column="123")
+    assert check_table_values_for_dict(table=table) is None
+
+
+def check_table_values_for_dict():
+    table = DynamicTable(name="test_table", description="")
+    table.add_column(name="test_column", description="")
+    table.add_row(test_column=str(dict(a=1)))
+    assert check_table_values_for_dict(table=table) == InspectorMessage(
+        message=(
+            "The column 'test_column' contains a string value that contains a dictionary! Please unpack "
+            "dictionaries as additional rows or columns of the table."
+        ),
+        importance=Importance.BEST_PRACTICE_VIOLATION,
+        check_function_name="check_table_values_for_dict",
+        object_type="DynamicTable",
+        object_name="test_table",
+        location="/",
+    )
+
+
 @pytest.mark.skip(reason="TODO")
 def test_check_column_data_is_not_none():
     pass


### PR DESCRIPTION
As per discussion the other day, we've found cases where actual elements of a DynamicTable contained string casts of Python dictionary objects.

Technically this might be doable in MATLAB as well, but they would have to explicitly type out the string form to exactly match what Python would output. What I'm not sure of is if MATLAB has any other valid parallels to this, such as casting a struct as a string?

I'll add a Best Practice section highlighting the correct way to go about adding the dictionary information as additional rows and columns for this in a separate PR after #125.