### PR TITLE
[Add Check]: external file existence for ImageSeries

### DIFF
--- a/nwbinspector/__init__.py
+++ b/nwbinspector/__init__.py
@@ -7,3 +7,4 @@ from .checks.time_series import *
 from .checks.tables import *
 from .checks.ecephys import *
 from .checks.ogen import *
+from .checks.image_series import *

--- a/nwbinspector/checks/image_series.py
+++ b/nwbinspector/checks/image_series.py
@@ -7,7 +7,7 @@ from ..register_checks import register_check, Importance, InspectorMessage
 
 
 @register_check(importance=Importance.CRITICAL, neurodata_type=ImageSeries)
-def check_image_series_external_file(image_series: ImageSeries):
+def check_image_series_external_file_valid(image_series: ImageSeries):
     """Check if the external_file specified by an ImageSeries actually exists at the relative location."""
     if image_series.external_file is None:
         return

--- a/nwbinspector/checks/image_series.py
+++ b/nwbinspector/checks/image_series.py
@@ -16,5 +16,8 @@ def check_image_series_external_file_valid(image_series: ImageSeries):
     for file_path in image_series.external_file:
         if not Path(file_path).is_absolute() and not (nwbfile_path / file_path).exists():
             yield InspectorMessage(
-                message=f"The external file {file_path} does not exist. Please confirm the relative location to the NWBFile."
+                message=(
+                    f"The external file '{file_path}' does not exist. Please confirm the relative location to the"
+                    " NWBFile."
+                )
             )

--- a/nwbinspector/checks/image_series.py
+++ b/nwbinspector/checks/image_series.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from pynwb.image import ImageSeries
 
 from ..register_checks import register_check, Importance, InspectorMessage
+from ..tools import get_nwbfile_path_from_internal_object
 
 
 @register_check(importance=Importance.CRITICAL, neurodata_type=ImageSeries)
@@ -11,8 +12,9 @@ def check_image_series_external_file_valid(image_series: ImageSeries):
     """Check if the external_file specified by an ImageSeries actually exists at the relative location."""
     if image_series.external_file is None:
         return
+    nwbfile_path = Path(get_nwbfile_path_from_internal_object(obj=image_series))
     for file_path in image_series.external_file:
-        if not Path(file_path).exists():
+        if not Path(file_path).is_absolute() and not (nwbfile_path / file_path).exists():
             yield InspectorMessage(
                 message="The external file does not exist. Please confirm the relative location to the NWBFile."
             )

--- a/nwbinspector/checks/image_series.py
+++ b/nwbinspector/checks/image_series.py
@@ -16,5 +16,5 @@ def check_image_series_external_file_valid(image_series: ImageSeries):
     for file_path in image_series.external_file:
         if not Path(file_path).is_absolute() and not (nwbfile_path / file_path).exists():
             yield InspectorMessage(
-                message="The external file does not exist. Please confirm the relative location to the NWBFile."
+                message=f"The external file {file_path} does not exist. Please confirm the relative location to the NWBFile."
             )

--- a/nwbinspector/checks/image_series.py
+++ b/nwbinspector/checks/image_series.py
@@ -1,0 +1,18 @@
+"""Check functions specific to ImageSeries."""
+from pathlib import Path
+
+from pynwb.image import ImageSeries
+
+from ..register_checks import register_check, Importance, InspectorMessage
+
+
+@register_check(importance=Importance.CRITICAL, neurodata_type=ImageSeries)
+def check_image_series_external_file(image_series: ImageSeries):
+    """Check if the external_file specified by an ImageSeries actually exists at the relative location."""
+    if image_series.external_file is None:
+        return
+    for file_path in image_series.external_file:
+        if not Path(file_path).exists():
+            yield InspectorMessage(
+                message="The external file does not exist. Please confirm the relative location to the NWBFile."
+            )

--- a/nwbinspector/tools.py
+++ b/nwbinspector/tools.py
@@ -19,9 +19,7 @@ def all_of_type(nwbfile: NWBFile, neurodata_type):
 
 def get_nwbfile_path_from_internal_object(obj):
     """Determine the file path on disk for a NWBFile given only an internal object of that file."""
-    ancestor = obj.get_ancestor()
-    if ancestor is None:
-        return
-    while ancestor.get_ancestor() is not None:
+    ancestor = obj
+    while not isinstance(ancestor, NWBFile):
         ancestor = ancestor.get_ancestor()
     return ancestor.container_source

--- a/nwbinspector/tools.py
+++ b/nwbinspector/tools.py
@@ -15,3 +15,13 @@ def all_of_type(nwbfile: NWBFile, neurodata_type):
     for obj in nwbfile.objects.values():
         if isinstance(obj, neurodata_type):
             yield obj
+
+
+def get_nwbfile_path_from_internal_object(obj):
+    """Determine the file path on disk for a NWBFile given only an internal object of that file."""
+    ancestor = obj.get_ancestor()
+    if ancestor is None:
+        return
+    while ancestor.get_ancestor() is not None:
+        ancestor = ancestor.get_ancestor()
+    return ancestor.container_source

--- a/nwbinspector/tools.py
+++ b/nwbinspector/tools.py
@@ -21,5 +21,4 @@ def get_nwbfile_path_from_internal_object(obj):
     """Determine the file path on disk for a NWBFile given only an internal object of that file."""
     if isinstance(obj, NWBFile):
         return obj.container_source
-    else:
-        return obj.get_ancestor("NWBFile").container_source
+    return obj.get_ancestor("NWBFile").container_source

--- a/nwbinspector/tools.py
+++ b/nwbinspector/tools.py
@@ -19,7 +19,7 @@ def all_of_type(nwbfile: NWBFile, neurodata_type):
 
 def get_nwbfile_path_from_internal_object(obj):
     """Determine the file path on disk for a NWBFile given only an internal object of that file."""
-    ancestor = obj
-    while not isinstance(ancestor, NWBFile):
-        ancestor = ancestor.get_ancestor()
-    return ancestor.container_source
+    if isinstance(obj, NWBFile):
+        return obj.container_source
+    else:
+        return obj.get_ancestor("NWBFile").container_source

--- a/tests/unit_tests/test_image_series.py
+++ b/tests/unit_tests/test_image_series.py
@@ -4,8 +4,10 @@ from shutil import rmtree
 from pathlib import Path
 
 import numpy as np
+from pynwb import NWBHDF5IO
 from pynwb.image import ImageSeries
 
+from nwbinspector.tools import make_minimal_nwbfile
 from nwbinspector.checks.image_series import check_image_series_external_file_valid
 from nwbinspector.register_checks import InspectorMessage, Importance
 
@@ -14,29 +16,46 @@ class TestExternalFileValid(TestCase):
     def setUp(self):
         self.tempdir = Path(mkdtemp())
         self.tempfile = self.tempdir / "tempfile.mov"
+        self.nested_tempdir_2 = self.tempdir / "nested_dir"
+        self.nested_tempdir_2.mkdir(parents=True)
+        self.tempfile2 = self.nested_tempdir_2 / "tempfile2.avi"
         with open(file=self.tempfile, mode="w") as fp:
             fp.write("Not a movie file, but at least it exists.")
+        self.nwbfile = make_minimal_nwbfile()
+        self.nwbfile.add_acquisition(
+            ImageSeries(name="TestImageSeries", rate=1.0, external_file=[self.tempfile, self.tempfile2])
+        )
+        self.nwbfile.add_acquisition(
+            ImageSeries(name="TestImageSeriesBad", rate=1.0, external_file=["madeup_file.mp4"])
+        )
+        image_module = self.nwbfile.create_processing_module(name="behavior", description="testing imageseries")
+        image_module.add(ImageSeries(name="TestImageSeries2", rate=1.0, external_file=[self.tempfile, self.tempfile2]))
+        with NWBHDF5IO(path=self.tempdir / "tempnwbfile.nwb", mode="w") as io:
+            io.write(self.nwbfile)
 
     def tearDown(self):
         rmtree(self.tempdir)
 
     def test_check_image_series_external_file_valid_pass(self):
-        image_series = ImageSeries(name="TestImageSeries", rate=1.0, external_file=[self.tempfile])
-        assert check_image_series_external_file_valid(image_series=image_series) is None
+        with NWBHDF5IO(path=self.tempdir / "tempnwbfile.nwb", mode="r") as io:
+            nwbfile = io.read()
+            assert check_image_series_external_file_valid(image_series=nwbfile.acquisition["TestImageSeries"]) is None
+
+    def test_check_image_series_external_file_valid(self):
+        with NWBHDF5IO(path=self.tempdir / "tempnwbfile.nwb", mode="r") as io:
+            nwbfile = io.read()
+            image_series = nwbfile.acquisition["TestImageSeriesBad"]
+            print(check_image_series_external_file_valid(image_series=image_series)[0])
+            assert check_image_series_external_file_valid(image_series=image_series)[0] == InspectorMessage(
+                message="The external file does not exist. Please confirm the relative location to the NWBFile.",
+                importance=Importance.CRITICAL,
+                check_function_name="check_image_series_external_file_valid",
+                object_type="ImageSeries",
+                object_name="TestImageSeriesBad",
+                location="/acquisition/TestImageSeriesBad",
+            )
 
 
 def test_check_image_series_external_file_valid_pass_non_external():
     image_series = ImageSeries(name="TestImageSeries", rate=1.0, data=np.zeros(shape=(3, 3, 3, 3)), unit="TestUnit")
     assert check_image_series_external_file_valid(image_series=image_series) is None
-
-
-def test_check_image_series_external_file_valid():
-    image_series = ImageSeries(name="TestImageSeries", rate=1.0, external_file=["madeup_file.mov"])
-    assert check_image_series_external_file_valid(image_series=image_series)[0] == InspectorMessage(
-        message="The external file does not exist. Please confirm the relative location to the NWBFile.",
-        importance=Importance.CRITICAL,
-        check_function_name="check_image_series_external_file_valid",
-        object_type="ImageSeries",
-        object_name="TestImageSeries",
-        location="/",
-    )

--- a/tests/unit_tests/test_image_series.py
+++ b/tests/unit_tests/test_image_series.py
@@ -6,11 +6,11 @@ from pathlib import Path
 import numpy as np
 from pynwb.image import ImageSeries
 
-from nwbinspector.checks.image_series import check_image_series_external_file
+from nwbinspector.checks.image_series import check_image_series_external_file_valid
 from nwbinspector.register_checks import InspectorMessage, Importance
 
 
-class TestExternalFile(TestCase):
+class TestExternalFileValid(TestCase):
     def setUp(self):
         self.tempdir = Path(mkdtemp())
         self.tempfile = self.tempdir / "tempfile.mov"
@@ -20,22 +20,22 @@ class TestExternalFile(TestCase):
     def tearDown(self):
         rmtree(self.tempdir)
 
-    def test_check_image_series_external_file_pass(self):
+    def test_check_image_series_external_file_valid_pass(self):
         image_series = ImageSeries(name="TestImageSeries", rate=1.0, external_file=[self.tempfile])
-        assert check_image_series_external_file(image_series=image_series) is None
+        assert check_image_series_external_file_valid(image_series=image_series) is None
 
 
-def test_check_image_series_external_file_pass_non_external():
+def test_check_image_series_external_file_valid_pass_non_external():
     image_series = ImageSeries(name="TestImageSeries", rate=1.0, data=np.zeros(shape=(3, 3, 3, 3)), unit="TestUnit")
-    assert check_image_series_external_file(image_series=image_series) is None
+    assert check_image_series_external_file_valid(image_series=image_series) is None
 
 
-def test_check_image_series_external_file():
+def test_check_image_series_external_file_valid():
     image_series = ImageSeries(name="TestImageSeries", rate=1.0, external_file=["madeup_file.mov"])
-    assert check_image_series_external_file(image_series=image_series)[0] == InspectorMessage(
+    assert check_image_series_external_file_valid(image_series=image_series)[0] == InspectorMessage(
         message="The external file does not exist. Please confirm the relative location to the NWBFile.",
         importance=Importance.CRITICAL,
-        check_function_name="check_image_series_external_file",
+        check_function_name="check_image_series_external_file_valid",
         object_type="ImageSeries",
         object_name="TestImageSeries",
         location="/",

--- a/tests/unit_tests/test_image_series.py
+++ b/tests/unit_tests/test_image_series.py
@@ -45,9 +45,11 @@ class TestExternalFileValid(TestCase):
         with NWBHDF5IO(path=self.tempdir / "tempnwbfile.nwb", mode="r") as io:
             nwbfile = io.read()
             image_series = nwbfile.acquisition["TestImageSeriesBad"]
-            print(check_image_series_external_file_valid(image_series=image_series)[0])
             assert check_image_series_external_file_valid(image_series=image_series)[0] == InspectorMessage(
-                message="The external file does not exist. Please confirm the relative location to the NWBFile.",
+                message=(
+                    "The external file 'madeup_file.mp4' does not exist. Please confirm the relative location to the"
+                    " NWBFile."
+                ),
                 importance=Importance.CRITICAL,
                 check_function_name="check_image_series_external_file_valid",
                 object_type="ImageSeries",

--- a/tests/unit_tests/test_image_series.py
+++ b/tests/unit_tests/test_image_series.py
@@ -1,0 +1,42 @@
+from unittest import TestCase
+from tempfile import mkdtemp
+from shutil import rmtree
+from pathlib import Path
+
+import numpy as np
+from pynwb.image import ImageSeries
+
+from nwbinspector.checks.image_series import check_image_series_external_file
+from nwbinspector.register_checks import InspectorMessage, Importance
+
+
+class TestExternalFile(TestCase):
+    def setUp(self):
+        self.tempdir = Path(mkdtemp())
+        self.tempfile = self.tempdir / "tempfile.mov"
+        with open(file=self.tempfile, mode="w") as fp:
+            fp.write("Not a movie file, but at least it exists.")
+
+    def tearDown(self):
+        rmtree(self.tempdir)
+
+    def test_check_image_series_external_file_pass(self):
+        image_series = ImageSeries(name="TestImageSeries", rate=1.0, external_file=[self.tempfile])
+        assert check_image_series_external_file(image_series=image_series) is None
+
+
+def test_check_image_series_external_file_pass_non_external():
+    image_series = ImageSeries(name="TestImageSeries", rate=1.0, data=np.zeros(shape=(3, 3, 3, 3)), unit="TestUnit")
+    assert check_image_series_external_file(image_series=image_series) is None
+
+
+def test_check_image_series_external_file():
+    image_series = ImageSeries(name="TestImageSeries", rate=1.0, external_file=["madeup_file.mov"])
+    assert check_image_series_external_file(image_series=image_series)[0] == InspectorMessage(
+        message="The external file does not exist. Please confirm the relative location to the NWBFile.",
+        importance=Importance.CRITICAL,
+        check_function_name="check_image_series_external_file",
+        object_type="ImageSeries",
+        object_name="TestImageSeries",
+        location="/",
+    )


### PR DESCRIPTION
First step to resolving #87 

If an ImageSeries uses `external_file` rather than `data`; this value can either be an external link or a local uri. If local, checks that the file referenced exists. A future check will also verify that it is a relative instead of absolute path. If a url, then verifies the url can be accessed.