### PR TITLE
[Add Check]: Spike times not in unobserved intervals

### DIFF
--- a/nwbinspector/checks/ecephys.py
+++ b/nwbinspector/checks/ecephys.py
@@ -55,7 +55,8 @@ def check_electrical_series_reference_electrodes_table(electrical_series: Electr
 @register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=Units)
 def check_spike_times_not_in_unobserved_interval(units_table: Units, nelems: int = 200):
     """Check if a Units table has spike times that occur outside of observed intervals."""
-    if units_table.obs_intervals:
+    if not units_table.obs_intervals:
+        return
         for spike_time in units_table.spike_times.data[:nelems]:
             if not any((obs_int[0] <= spike_time <= obs_int[1] for obs_int in units_table.obs_intervals.data)):
                 return InspectorMessage(

--- a/nwbinspector/checks/ecephys.py
+++ b/nwbinspector/checks/ecephys.py
@@ -50,3 +50,17 @@ def check_electrical_series_dims(electrical_series: ElectricalSeries):
 def check_electrical_series_reference_electrodes_table(electrical_series: ElectricalSeries):
     if electrical_series.electrodes.table.name != "electrodes":
         return InspectorMessage(message="electrodes does not  reference an electrodes table.")
+
+
+@register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=Units)
+def check_spike_times_not_in_unobserved_interval(units_table: Units, nelems: int = 200):
+    """Check if a Units table has spike times that occur outside of observed intervals."""
+    if units_table.obs_intervals:
+        for spike_time in units_table.spike_times.data[:nelems]:
+            if not any((obs_int[0] <= spike_time <= obs_int[1] for obs_int in units_table.obs_intervals.data)):
+                return InspectorMessage(
+                    message=(
+                        "This Units table contains spike times that occur during periods of time not labeled as being "
+                        "observed intervals."
+                    )
+                )

--- a/nwbinspector/checks/ecephys.py
+++ b/nwbinspector/checks/ecephys.py
@@ -58,7 +58,7 @@ def check_spike_times_not_in_unobserved_interval(units_table: Units, nelems: int
     if not units_table.obs_intervals:
         return
     for spike_time in units_table.spike_times.data[:nelems]:
-        if not any((obs_int[0] <= spike_time <= obs_int[1] for obs_int in units_table.obs_intervals.data)):
+        if not any((start <= spike_time <= stop for start, stop in units_table.obs_intervals.data)):
             return InspectorMessage(
                 message=(
                     "This Units table contains spike times that occur during periods of time not labeled as being "

--- a/nwbinspector/checks/ecephys.py
+++ b/nwbinspector/checks/ecephys.py
@@ -57,11 +57,11 @@ def check_spike_times_not_in_unobserved_interval(units_table: Units, nelems: int
     """Check if a Units table has spike times that occur outside of observed intervals."""
     if not units_table.obs_intervals:
         return
-        for spike_time in units_table.spike_times.data[:nelems]:
-            if not any((obs_int[0] <= spike_time <= obs_int[1] for obs_int in units_table.obs_intervals.data)):
-                return InspectorMessage(
-                    message=(
-                        "This Units table contains spike times that occur during periods of time not labeled as being "
-                        "observed intervals."
-                    )
+    for spike_time in units_table.spike_times.data[:nelems]:
+        if not any((obs_int[0] <= spike_time <= obs_int[1] for obs_int in units_table.obs_intervals.data)):
+            return InspectorMessage(
+                message=(
+                    "This Units table contains spike times that occur during periods of time not labeled as being "
+                    "observed intervals."
                 )
+            )

--- a/tests/unit_tests/test_ecephys.py
+++ b/tests/unit_tests/test_ecephys.py
@@ -197,3 +197,20 @@ def test_check_spike_times_not_in_unobserved_interval_2():
         object_name="TestUnits",
         location="/",
     )
+
+
+def test_check_spike_times_not_in_unobserved_interval_multiple_units():
+    units_table = Units(name="TestUnits")
+    units_table.add_unit(spike_times=[1, 2, 3, 4, 5, 6], obs_intervals=[[0, 3.2], [3.5, 7]])
+    units_table.add_unit(spike_times=[6.5, 12, 13, 14, 15, 16], obs_intervals=[[10, 15.2], [15.8, 17]])
+    assert check_spike_times_not_in_unobserved_interval(units_table=units_table) == InspectorMessage(
+        message=(
+            "This Units table contains spike times that occur during periods of time not labeled as being "
+            "observed intervals."
+        ),
+        importance=Importance.BEST_PRACTICE_VIOLATION,
+        check_function_name="check_spike_times_not_in_unobserved_interval",
+        object_type="Units",
+        object_name="TestUnits",
+        location="/",
+    )

--- a/tests/unit_tests/test_ecephys.py
+++ b/tests/unit_tests/test_ecephys.py
@@ -60,7 +60,13 @@ class TestCheckElectricalSeries(TestCase):
 
         for _ in range(5):
             nwbfile.add_electrode(
-                x=3.0, y=3.0, z=3.0, imp=-1.0, location="unknown", filtering="unknown", group=group,
+                x=3.0,
+                y=3.0,
+                z=3.0,
+                imp=-1.0,
+                location="unknown",
+                filtering="unknown",
+                group=group,
             )
         self.nwbfile = nwbfile
 
@@ -69,7 +75,11 @@ class TestCheckElectricalSeries(TestCase):
         electrodes = self.nwbfile.create_electrode_table_region(region=[1, 2, 3], description="three elecs")
 
         electrical_series = ElectricalSeries(
-            name="elec_series", description="desc", data=np.zeros((100, 10)), electrodes=electrodes, rate=30.0,
+            name="elec_series",
+            description="desc",
+            data=np.zeros((100, 10)),
+            electrodes=electrodes,
+            rate=30.0,
         )
 
         self.nwbfile.add_acquisition(electrical_series)
@@ -87,7 +97,11 @@ class TestCheckElectricalSeries(TestCase):
         electrodes = self.nwbfile.create_electrode_table_region(region=[0, 1, 2, 3, 4], description="all")
 
         electrical_series = ElectricalSeries(
-            name="elec_series", description="desc", data=np.zeros((5, 100)), electrodes=electrodes, rate=30.0,
+            name="elec_series",
+            description="desc",
+            data=np.zeros((5, 100)),
+            electrodes=electrodes,
+            rate=30.0,
         )
 
         self.nwbfile.add_acquisition(electrical_series)
@@ -105,7 +119,11 @@ class TestCheckElectricalSeries(TestCase):
         electrodes = self.nwbfile.create_electrode_table_region(region=[0, 1, 2, 3, 4], description="all")
 
         electrical_series = ElectricalSeries(
-            name="elec_series", description="desc", data=np.zeros((100, 5)), electrodes=electrodes, rate=30.0,
+            name="elec_series",
+            description="desc",
+            data=np.zeros((100, 5)),
+            electrodes=electrodes,
+            rate=30.0,
         )
 
         self.nwbfile.add_acquisition(electrical_series)
@@ -124,7 +142,11 @@ class TestCheckElectricalSeries(TestCase):
         )
 
         electrical_series = ElectricalSeries(
-            name="elec_series", description="desc", data=np.zeros((100, 5)), electrodes=dynamic_table_region, rate=30.0,
+            name="elec_series",
+            description="desc",
+            data=np.zeros((100, 5)),
+            electrodes=dynamic_table_region,
+            rate=30.0,
         )
 
         assert (

--- a/tests/unit_tests/test_ecephys.py
+++ b/tests/unit_tests/test_ecephys.py
@@ -167,9 +167,25 @@ def test_check_spike_times_not_in_unobserved_interval_pass_no_intervals():
     assert check_spike_times_not_in_unobserved_interval(units_table=units_table) is None
 
 
-def test_check_spike_times_not_in_unobserved_interval():
+def test_check_spike_times_not_in_unobserved_interval_1():
     units_table = Units(name="TestUnits")
     units_table.add_unit(spike_times=[1, 2, 3], obs_intervals=[[0, 2.5], [3.5, 4]])
+    assert check_spike_times_not_in_unobserved_interval(units_table=units_table) == InspectorMessage(
+        message=(
+            "This Units table contains spike times that occur during periods of time not labeled as being "
+            "observed intervals."
+        ),
+        importance=Importance.BEST_PRACTICE_VIOLATION,
+        check_function_name="check_spike_times_not_in_unobserved_interval",
+        object_type="Units",
+        object_name="TestUnits",
+        location="/",
+    )
+
+
+def test_check_spike_times_not_in_unobserved_interval_2():
+    units_table = Units(name="TestUnits")
+    units_table.add_unit(spike_times=[1, 2, 3, 4, 5, 6], obs_intervals=[[0, 2.5], [3.5, 7]])
     assert check_spike_times_not_in_unobserved_interval(units_table=units_table) == InspectorMessage(
         message=(
             "This Units table contains spike times that occur during periods of time not labeled as being "


### PR DESCRIPTION
fix #5 

Pretty self-explanatory. Note that all logic is done with generators so it will scan each spike time separately and terminate the first time it finds the issue.

That said, our standard `200` elements to extract seems a tad low for typical units tables. Even a single neuron firing at 10 Hz would produce 200 spikes after only 20 seconds, and most experiments go much longer than that and have more detected units. Note if this was manually increased, we are still in some sense scanning each unit in order (not the first # of spikes of each unit, which would have separate slicing logic).