### PR TITLE
[Feature]: swap to ProcessPool and add progress bar

### DIFF
--- a/nwbinspector/nwbinspector.py
+++ b/nwbinspector/nwbinspector.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from collections.abc import Iterable
 from enum import Enum
 from typing import Optional, List
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import ProcessPoolExecutor, as_completed
 from types import FunctionType
 from warnings import filterwarnings
 from distutils.util import strtobool
@@ -16,6 +16,7 @@ from distutils.util import strtobool
 import click
 import pynwb
 import yaml
+from tqdm import tqdm
 
 from . import available_checks
 from .inspector_tools import (
@@ -184,6 +185,7 @@ def configure_checks(
     ),
     is_flag=True,
 )
+@click.option("--progress-bar", help="Sett this flag to False to disable the display of the progress bar.")
 def inspect_all_cli(
     path: str,
     modules: Optional[str] = None,
@@ -200,10 +202,17 @@ def inspect_all_cli(
     n_jobs: int = 1,
     skip_validate: bool = False,
     detailed: bool = False,
+    progress_bar: Optional[str] = None,
 ):
-    """Primary CLI usage of the NWBInspector."""
+    """
+    Run the NWBInspector via the command line.
+
+    path :
+    Path to either a local NWBFile, a local folder containing NWBFiles.
+    """
     levels = ["importance", "file_path"] if levels is None else levels.split(",")
     reverse = [False] * len(levels) if reverse is None else [strtobool(x) for x in reverse.split(",")]
+    progress_bar = strtobool(progress_bar) if progress_bar is not None else True
     if config is not None:
         config = load_config(filepath_or_keyword=config)
     messages = list(
@@ -216,6 +225,7 @@ def inspect_all_cli(
             config=config,
             n_jobs=n_jobs,
             skip_validate=skip_validate,
+            progress_bar=progress_bar,
         )
     )
     if json_file_path is not None:
@@ -242,9 +252,11 @@ def inspect_all(
     importance_threshold: Importance = Importance.BEST_PRACTICE_SUGGESTION,
     n_jobs: int = 1,
     skip_validate: bool = False,
+    progress_bar: bool = True,
+    progress_bar_options: Optional[dict] = None,
 ):
     """
-    Inspect a NWBFile object and return suggestions for improvements according to best practices.
+    Inspect a local NWBFile or folder of NWBFiles and return suggestions for improvements according to best practices.
 
     Parameters
     ----------
@@ -274,13 +286,18 @@ def inspect_all(
     n_jobs : int
         Number of jobs to use in parallel. Set to -1 to use all available resources.
         Set to 1 (also the default) to disable.
-    skip_validate : bool
+    skip_validate : bool, optional
         Skip the PyNWB validation step. This may be desired for older NWBFiles (< schema version v2.10).
         The default is False, which is also recommended.
+    progress_bar : bool, optional
+        Display a progress bar while scanning NWBFiles.
+        Defaults to True.
+    progress_bar_options : dict, optional
+        Dictionary of keyword arguments to pass directly to tqdm.
     """
     modules = modules or []
-    path = Path(path)
-
+    if progress_bar_options is None:
+        progress_bar_options = dict(desc="Inspecting NWBFiles...")
     in_path = Path(path)
     if in_path.is_dir():
         nwbfiles = list(in_path.rglob("*.nwb"))
@@ -292,26 +309,37 @@ def inspect_all(
         importlib.import_module(module)
     # Filtering of checks should apply after external modules are imported, in case those modules have their own checks
     checks = configure_checks(config=config, ignore=ignore, select=select, importance_threshold=importance_threshold)
-    if n_jobs != 1:
 
-        # max_workers for threading is a different concept to number of processes; from the documentation
-        # https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor
-        # we can multiply the specified number of jobs by 5
-        if n_jobs != -1:
-            max_workers = n_jobs * 5
-        else:
-            max_workers = None  # concurrents doesn't have a -1 flag like joblib; set to None to achieve this
-        with ThreadPoolExecutor(max_workers=max_workers) as executor:
-            futures = []
+    if n_jobs != 1:
+        progress_bar_options.update(total=len(nwbfiles))
+        futures = []
+        n_jobs = None if n_jobs == -1 else n_jobs  # concurrents uses None instead of -1 for 'auto' mode
+        with ProcessPoolExecutor(max_workers=n_jobs) as executor:
             for nwbfile_path in nwbfiles:
-                futures.append(executor.submit(inspect_nwb, nwbfile_path=nwbfile_path, checks=checks))
-            for future in as_completed(futures):
-                for message in future.result():
-                    yield message
+                futures.append(
+                    executor.submit(
+                        _pickle_inspect_nwb, nwbfile_path=nwbfile_path, checks=checks, skip_validate=skip_validate
+                    )
+                )
+            if progress_bar:
+                for future in tqdm(as_completed(futures), **progress_bar_options):
+                    for message in future.result():
+                        yield message
+            else:
+                for future in as_completed(futures):
+                    for message in future.result():
+                        yield message
     else:
+        if progress_bar:
+            nwbfiles = tqdm(nwbfiles, **progress_bar_options)
         for nwbfile_path in nwbfiles:
             for message in inspect_nwb(nwbfile_path=nwbfile_path, checks=checks):
                 yield message
+
+
+def _pickle_inspect_nwb(nwbfile_path: str, checks: list = available_checks, skip_validate: bool = False):
+    """Auxilliary function for inspect_all to run in parallel using the ProcessPoolExecutor."""
+    return list(inspect_nwb(nwbfile_path=nwbfile_path, checks=checks, skip_validate=skip_validate))
 
 
 def inspect_nwb(

--- a/nwbinspector/nwbinspector.py
+++ b/nwbinspector/nwbinspector.py
@@ -321,14 +321,12 @@ def inspect_all(
                         _pickle_inspect_nwb, nwbfile_path=nwbfile_path, checks=checks, skip_validate=skip_validate
                     )
                 )
+            completed_futures = as_completed(futures)
             if progress_bar:
-                for future in tqdm(as_completed(futures), **progress_bar_options):
-                    for message in future.result():
-                        yield message
-            else:
-                for future in as_completed(futures):
-                    for message in future.result():
-                        yield message
+                completed_futures = tqdm(completed_futures, **progress_bar_options)
+            for future in completed_futures:
+                for message in future.result():
+                    yield message
     else:
         if progress_bar:
             nwbfiles = tqdm(nwbfiles, **progress_bar_options)

--- a/nwbinspector/nwbinspector.py
+++ b/nwbinspector/nwbinspector.py
@@ -185,7 +185,7 @@ def configure_checks(
     ),
     is_flag=True,
 )
-@click.option("--progress-bar", help="Sett this flag to False to disable the display of the progress bar.")
+@click.option("--progress-bar", help="Set this flag to False to disable display of the progress bar.")
 def inspect_all_cli(
     path: str,
     modules: Optional[str] = None,

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     url="https://github.com/NeurodataWithoutBorders/nwbinspector",
-    install_requires=["pynwb", "natsort", "click", "PyYAML", "jsonschema"],
+    install_requires=["pynwb", "natsort", "click", "PyYAML", "jsonschema", "tqdm"],
     entry_points={"console_scripts": ["nwbinspector=nwbinspector.nwbinspector:inspect_all_cli"]},
     license="BSD-3-Clause",
 )


### PR DESCRIPTION
# Motivation

While adding a progress bar, it was revealed that my previous timings comparing normal usage to multithreading were biased to running on files not subject to a disk bottle-neck (original files were located on a built-in SSD). When moved to an external USB drive, this became I/O bound and behaved similarly to what we see with S3 streaming in PR #166. Easy fix for this is just swap to using the `ProcessPoolExecutor` all the time, since it gives nearly equivalent speed increase without relying on system properties.

The first attached video ('inspector_progress_bar_demo.wmv') shows how there is no noticeable speed difference between non-threading and multithreading in this case. The second video ('inspector_progress_bar_demo_process_instead_of_threading') confirms that multiple processes speeds up inspection, similar to what we saw in PR #166. The movies also demonstrate the progress bar.


### Small change to behavior
Another original reason for using threading was to have allow message-by-message generator behavior  even when `n_jobs` is specified, which is not possible with the `ProcessPoolExecutor` (generators cannot be pickled, so we have to scan an entire individual NWBFile at once within each process).

However, I would say that if a true message-by-message generator is what someone really wants to do (*e.g.* to find if there is a single error or not; `next(inspect_all(..., n_jobs=-1))`), they should not be using parallelization unless they're looking for a very small needle (like a single check) in a very large haystack (a very large number of NWBFiles). And in that case, they might as well just grab all checks instead of doing lazy iteration.  Otherwise, so many of our tests have early exit conditions that violation-free files take next to no time to scan. Instead, they'd have better performance just doing `next(inspect_all(..., n_jobs=1))`.

https://user-images.githubusercontent.com/51133164/163027835-44681382-0b04-4b85-ad3a-cb1e39f0c050.mp4


https://user-images.githubusercontent.com/51133164/163027837-b7dd3f25-9980-45ab-8796-3ca0cbf17388.mp4
