### PR TITLE
[Reduction]: Remove single flags to avoid confusion

### DIFF
--- a/nwbinspector/nwbinspector.py
+++ b/nwbinspector/nwbinspector.py
@@ -172,9 +172,7 @@ def configure_checks(
     type=click.Choice(["CRITICAL", "BEST_PRACTICE_VIOLATION", "BEST_PRACTICE_SUGGESTION"]),
     help="Ignores tests with an assigned importance below this threshold.",
 )
-@click.option(
-    "--config", help="Name of config or path of config .yaml file that overwrites importance of checks."
-)
+@click.option("--config", help="Name of config or path of config .yaml file that overwrites importance of checks.")
 @click.option("--json-file-path", help="Write json output to this location.")
 @click.option("--n-jobs", help="Number of jobs to use in parallel.", default=1)
 @click.option("--skip-validate", help="Skip the PyNWB validation step.", is_flag=True)

--- a/nwbinspector/nwbinspector.py
+++ b/nwbinspector/nwbinspector.py
@@ -151,7 +151,7 @@ def configure_checks(
 
 @click.command()
 @click.argument("path")
-@click.option("-m", "--modules", help="Modules to import prior to reading the file(s).")
+@click.option("--modules", help="Modules to import prior to reading the file(s).")
 @click.option("--no-color", help="Disable coloration for console display of output.", is_flag=True)
 @click.option(
     "--report-file-path",
@@ -159,24 +159,23 @@ def configure_checks(
     help="Save path for the report file.",
     type=click.Path(writable=True),
 )
-@click.option("-o", "--overwrite", help="Overwrite an existing report file at the location.", is_flag=True)
+@click.option("--overwrite", help="Overwrite an existing report file at the location.", is_flag=True)
 @click.option("--levels", help="Comma-separated names of InspectorMessage attributes to organize by.")
 @click.option(
     "--reverse", help="Comma-separated booleans corresponding to reversing the order for each value of 'levels'."
 )
-@click.option("-i", "--ignore", help="Comma-separated names of checks to skip.")
-@click.option("-s", "--select", help="Comma-separated names of checks to run.")
+@click.option("--ignore", help="Comma-separated names of checks to skip.")
+@click.option("--select", help="Comma-separated names of checks to run.")
 @click.option(
-    "-t",
     "--threshold",
     default="BEST_PRACTICE_SUGGESTION",
     type=click.Choice(["CRITICAL", "BEST_PRACTICE_VIOLATION", "BEST_PRACTICE_SUGGESTION"]),
     help="Ignores tests with an assigned importance below this threshold.",
 )
 @click.option(
-    "-c", "--config", help="Name of config or path of config .yaml file that overwrites importance of checks."
+    "--config", help="Name of config or path of config .yaml file that overwrites importance of checks."
 )
-@click.option("-j", "--json-file-path", help="Write json output to this location.")
+@click.option("--json-file-path", help="Write json output to this location.")
 @click.option("--n-jobs", help="Number of jobs to use in parallel.", default=1)
 @click.option("--skip-validate", help="Skip the PyNWB validation step.", is_flag=True)
 @click.option(

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -364,7 +364,7 @@ class TestInspector(TestCase):
     def test_command_line_runs_cli_only(self):
         console_output_file = self.tempdir / "test_console_output.txt"
         os.system(
-            f"nwbinspector {str(self.tempdir)} -o -s check_timestamps_match_first_dimension,"
+            f"nwbinspector {str(self.tempdir)} --overwrite --select check_timestamps_match_first_dimension,"
             "check_data_orientation,check_regular_timestamps,check_small_dataset_compression --no-color "
             f"> {console_output_file}"
         )
@@ -377,7 +377,7 @@ class TestInspector(TestCase):
     def test_command_line_runs_cli_only_parallel(self):
         console_output_file = self.tempdir / "test_console_output_2.txt"
         os.system(
-            f"nwbinspector {str(self.tempdir)} -o -s check_timestamps_match_first_dimension,"
+            f"nwbinspector {str(self.tempdir)} --overwrite --select check_timestamps_match_first_dimension,"
             "check_data_orientation,check_regular_timestamps,check_small_dataset_compression --n-jobs 2 --no-color"
             f"> {console_output_file}"
         )
@@ -414,7 +414,7 @@ class TestInspector(TestCase):
     def test_command_line_on_directory_matches_file(self):
         console_output_file = self.tempdir / "test_console_output_5.txt"
         os.system(
-            f"nwbinspector {str(self.tempdir)} -o -s check_timestamps_match_first_dimension,check_data_orientation,"
+            f"nwbinspector {str(self.tempdir)} --overwrite --select check_timestamps_match_first_dimension,check_data_orientation,"
             "check_regular_timestamps,check_small_dataset_compression"
             f" --report-file-path {self.tempdir / 'test_nwbinspector_report_3.txt'}"
             f"> {console_output_file}"


### PR DESCRIPTION
As per discussion, over time our number of CLI arguments/flags has grown significantly and many of the full names start with the same letter, which can cause confusion when attempting to attribute single-character shortcuts for the flags.

A couple examples include

`-j`, which one might confuse between `--json-file-path` or `--n-jobs`
`-s` which one might confuse between `--select` and `--stream`

As such, we'll simply be enforcing people to use the full name of each flag for maximum clarity, rather than trying to go down the time-consuming and messy road of trying to keep single-character flags standardized w.r.t. other common CLI packages.