### PR TITLE
[Reduction]: remove coloration

### DIFF
--- a/nwbinspector/inspector_tools.py
+++ b/nwbinspector/inspector_tools.py
@@ -269,7 +269,7 @@ def format_messages(
     return formatted_messages
 
 
-def print_to_console(formatted_messages: List[str], no_color: bool = False):
+def print_to_console(formatted_messages: List[str]):
     """Print report file contents to console."""
     sys.stdout.write(os.linesep * 2)
     for line in formatted_messages:

--- a/nwbinspector/inspector_tools.py
+++ b/nwbinspector/inspector_tools.py
@@ -269,74 +269,8 @@ def format_messages(
     return formatted_messages
 
 
-def supports_color():  # pragma: no cover
-    """
-    Return True if the running system's terminal supports color, and False otherwise.
-
-    From https://github.com/django/django/blob/main/django/core/management/color.py
-    """
-
-    def vt_codes_enabled_in_windows_registry():
-        """Check the Windows Registry to see if VT code handling has been enabled by default."""
-        try:
-            # winreg is only available on Windows.
-            import winreg
-        except ImportError:
-            return False
-        else:
-            reg_key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, "Console")
-            try:
-                reg_key_value, _ = winreg.QueryValueEx(reg_key, "VirtualTerminalLevel")
-            except FileNotFoundError:
-                return False
-            else:
-                return reg_key_value == 1
-
-    # isatty is not always implemented, #6223.
-    is_a_tty = hasattr(sys.stdout, "isatty") and sys.stdout.isatty()
-
-    return is_a_tty and (
-        sys.platform != "win32"
-        or "ANSICON" in os.environ
-        or "WT_SESSION" in os.environ  # Windows Terminal supports VT codes.
-        or os.environ.get("TERM_PROGRAM") == "vscode"  # Microsoft Visual Studio Code's built-in terminal.
-        or vt_codes_enabled_in_windows_registry()
-    )
-
-
-def wrap_color(formatted_messages: List[str], no_color: bool = False):  # pragma: no cover
-    """Wrap the file output with colors for console output."""
-    if not supports_color():
-        return formatted_messages
-    reset_color = "\x1b[0m"
-    color_map = {
-        "CRITICAL IMPORTANCE": "\x1b[31m",
-        "BEST PRACTICE VIOLATION": "\x1b[33m",
-        "BEST PRACTICE SUGGESTION": reset_color,
-        "NWBFile": reset_color,
-    }
-
-    color_shift_points = dict()
-    for line_index, line in enumerate(formatted_messages):
-        for color_trigger in color_map:
-            if color_trigger in line:
-                color_shift_points.update(
-                    {line_index: color_map[color_trigger], line_index + 1: color_map[color_trigger]}
-                )
-    colored_output = list()
-    current_color = None
-    for line in formatted_messages:
-        transition_point = line_index in color_shift_points
-        if transition_point:
-            current_color = color_shift_points[line_index]
-            colored_output.append(f"{current_color}{line}{reset_color}")
-        if current_color is not None and not transition_point:
-            colored_output.append(f"{current_color}{line[:6]}{reset_color}{line[6:]}")
-
-
 def print_to_console(formatted_messages: List[str], no_color: bool = False):
     """Print report file contents to console."""
-    wrap_color(formatted_messages=formatted_messages, no_color=no_color)
     sys.stdout.write(os.linesep * 2)
     for line in formatted_messages:
         sys.stdout.write(line + "\n")

--- a/nwbinspector/nwbinspector.py
+++ b/nwbinspector/nwbinspector.py
@@ -152,7 +152,6 @@ def configure_checks(
 @click.command()
 @click.argument("path")
 @click.option("--modules", help="Modules to import prior to reading the file(s).")
-@click.option("--no-color", help="Disable coloration for console display of output.", is_flag=True)
 @click.option(
     "--report-file-path",
     default=None,
@@ -203,7 +202,6 @@ def configure_checks(
 def inspect_all_cli(
     path: str,
     modules: Optional[str] = None,
-    no_color: bool = False,
     report_file_path: str = None,
     levels: str = None,
     reverse: Optional[str] = None,
@@ -269,7 +267,7 @@ def inspect_all_cli(
             print(f"{os.linesep*2}Report saved to {str(Path(json_file_path).absolute())}!{os.linesep}")
     if len(messages):
         formatted_messages = format_messages(messages=messages, levels=levels, reverse=reverse, detailed=detailed)
-        print_to_console(formatted_messages=formatted_messages, no_color=no_color)
+        print_to_console(formatted_messages=formatted_messages)
         if report_file_path is not None:
             save_report(report_file_path=report_file_path, formatted_messages=formatted_messages, overwrite=overwrite)
             print(f"{os.linesep*2}Report saved to {str(Path(report_file_path).absolute())}!{os.linesep}")

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -89,7 +89,7 @@ class TestInspector(TestCase):
     @classmethod
     def setUpClass(cls):
         cls.tempdir = Path(mkdtemp())
-        # cls.tempdir = Path("E:/test_inspector/output2")
+        cls.tempdir = Path("E:/test_inspector/output2")
         cls.checks = [
             check_small_dataset_compression,
             check_regular_timestamps,
@@ -113,9 +113,9 @@ class TestInspector(TestCase):
             with NWBHDF5IO(path=nwbfile_path, mode="w") as io:
                 io.write(nwbfile)
 
-    @classmethod
-    def tearDownClass(cls):
-        rmtree(cls.tempdir)
+    # @classmethod
+    # def tearDownClass(cls):
+    #     rmtree(cls.tempdir)
 
     def assertFileExists(self, path: FilePathType):
         path = Path(path)
@@ -377,8 +377,8 @@ class TestInspector(TestCase):
     def test_command_line_runs_cli_only_parallel(self):
         console_output_file = self.tempdir / "test_console_output_2.txt"
         os.system(
-            f"nwbinspector {str(self.tempdir)} --overwrite --select check_timestamps_match_first_dimension,"
-            "check_data_orientation,check_regular_timestamps,check_small_dataset_compression --n-jobs 2"
+            f"nwbinspector {str(self.tempdir)} --n-jobs 2 --overwrite --select check_timestamps_match_first_dimension,"
+            "check_data_orientation,check_regular_timestamps,check_small_dataset_compression"
             f"> {console_output_file}"
         )
         self.assertLogFileContentsEqual(
@@ -414,8 +414,8 @@ class TestInspector(TestCase):
     def test_command_line_on_directory_matches_file(self):
         console_output_file = self.tempdir / "test_console_output_5.txt"
         os.system(
-            f"nwbinspector {str(self.tempdir)} --overwrite --select check_timestamps_match_first_dimension,check_data_orientation,"
-            "check_regular_timestamps,check_small_dataset_compression"
+            f"nwbinspector {str(self.tempdir)} --overwrite --select check_timestamps_match_first_dimension,"
+            "check_data_orientation,check_regular_timestamps,check_small_dataset_compression"
             f" --report-file-path {self.tempdir / 'test_nwbinspector_report_3.txt'}"
             f"> {console_output_file}"
         )

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -89,7 +89,6 @@ class TestInspector(TestCase):
     @classmethod
     def setUpClass(cls):
         cls.tempdir = Path(mkdtemp())
-        cls.tempdir = Path("E:/test_inspector/output2")
         cls.checks = [
             check_small_dataset_compression,
             check_regular_timestamps,
@@ -113,9 +112,9 @@ class TestInspector(TestCase):
             with NWBHDF5IO(path=nwbfile_path, mode="w") as io:
                 io.write(nwbfile)
 
-    # @classmethod
-    # def tearDownClass(cls):
-    #     rmtree(cls.tempdir)
+    @classmethod
+    def tearDownClass(cls):
+        rmtree(cls.tempdir)
 
     def assertFileExists(self, path: FilePathType):
         path = Path(path)

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -365,7 +365,7 @@ class TestInspector(TestCase):
         console_output_file = self.tempdir / "test_console_output.txt"
         os.system(
             f"nwbinspector {str(self.tempdir)} --overwrite --select check_timestamps_match_first_dimension,"
-            "check_data_orientation,check_regular_timestamps,check_small_dataset_compression --no-color "
+            "check_data_orientation,check_regular_timestamps,check_small_dataset_compression"
             f"> {console_output_file}"
         )
         self.assertLogFileContentsEqual(
@@ -378,7 +378,7 @@ class TestInspector(TestCase):
         console_output_file = self.tempdir / "test_console_output_2.txt"
         os.system(
             f"nwbinspector {str(self.tempdir)} --overwrite --select check_timestamps_match_first_dimension,"
-            "check_data_orientation,check_regular_timestamps,check_small_dataset_compression --n-jobs 2 --no-color"
+            "check_data_orientation,check_regular_timestamps,check_small_dataset_compression --n-jobs 2"
             f"> {console_output_file}"
         )
         self.assertLogFileContentsEqual(


### PR DESCRIPTION
As per discussion, coloration has been broken since the use of generalized formatting (technically it might still work if you use `levels=["file_path", "importance"]`). Given what a minor feature this is, even though it's 'nice' to have, it is proving to be quite the time investment to actually maintain.

If we end up with some free time we can always revisit getting this to work and maybe even how to make nice tests for it, but until then I think it's best to remove from the main code base. It'll always be here in these commit hashes and previous versions if we need to refer to it again.