### PR TITLE
Add copy button to code blocks

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -14,3 +14,12 @@ dl.class em:not([class]):last-of-type::after {
 dl.class > dt:first-of-type {
     display: block !important;
 }
+
+button.copybtn {
+    height:25px;
+    width:25px;
+    opacity: 0.5;
+    padding: 0;
+    border: none;
+    background: none;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,6 +18,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "myst_parser",
     "sphinx.ext.extlinks",
+    'sphinx_copybutton',
 ]
 templates_path = ["_templates"]
 master_doc = "index"

--- a/requirements-rtd.txt
+++ b/requirements-rtd.txt
@@ -5,3 +5,4 @@ Jinja2<3.1
 sphinx==3.5.1
 sphinx_rtd_theme==0.5.1
 readthedocs-sphinx-search==0.1.0rc3
+sphinx-copybutton==0.5.0


### PR DESCRIPTION
## Motivation

Add a copy button to the right side of the code blocks. 
Size, opacity and other properties can be changed in `custom.css`

## How to test the behavior?

Check the appearance of the button with `sphinx-build`

## Checklist

- [ ] Have you ensured the PR description clearly describes the problem and solutions?
- [ ] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/nwbinspector/pulls) for the same change?
- [ ] Is your code contribution compliant with `black` format? If not, simply `pip install black` and run `black .` inside your fork.
- [ ] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?
