### PR TITLE
[Bug] encapsulate nwbfile after io.read() in same try/except

### DIFF
--- a/nwbinspector/nwbinspector.py
+++ b/nwbinspector/nwbinspector.py
@@ -454,8 +454,8 @@ def inspect_nwb(
     nwbfile_path = str(nwbfile_path)
     filterwarnings(action="ignore", message="No cached namespaces found in .*")
     filterwarnings(action="ignore", message="Ignoring cached namespace .*")
-    if not skip_validate:
-        with pynwb.NWBHDF5IO(path=nwbfile_path, mode="r", load_namespaces=True, driver=driver) as io:
+    with pynwb.NWBHDF5IO(path=nwbfile_path, mode="r", load_namespaces=True, driver=driver) as io:
+        if not skip_validate:
             validation_errors = pynwb.validate(io=io)
             for validation_error in validation_errors:
                 yield InspectorMessage(
@@ -466,19 +466,18 @@ def inspect_nwb(
                     file_path=nwbfile_path,
                 )
 
-    try:
-        with pynwb.NWBHDF5IO(path=nwbfile_path, mode="r", load_namespaces=True, driver=driver) as io:
+        try:
             nwbfile = io.read()
             for inspector_message in run_checks(nwbfile=nwbfile, checks=checks):
                 inspector_message.file_path = nwbfile_path
                 yield inspector_message
-    except Exception as ex:
-        yield InspectorMessage(
-            message=traceback.format_exc(),
-            importance=Importance.ERROR,
-            check_function_name=f"During io.read() - {type(ex)}: {str(ex)}",
-            file_path=nwbfile_path,
-        )
+        except Exception as ex:
+            yield InspectorMessage(
+                message=traceback.format_exc(),
+                importance=Importance.ERROR,
+                check_function_name=f"During io.read() - {type(ex)}: {str(ex)}",
+                file_path=nwbfile_path,
+            )
 
 
 def run_checks(nwbfile: pynwb.NWBFile, checks: list):

--- a/nwbinspector/nwbinspector.py
+++ b/nwbinspector/nwbinspector.py
@@ -469,7 +469,8 @@ def inspect_nwb(
     try:
         nwbfile = io.read()
     except Exception as ex:
-        yield InspectorMessage(
+        io.close()
+        return InspectorMessage(
             message=traceback.format_exc(),
             importance=Importance.ERROR,
             check_function_name=f"During io.read() - {type(ex)}: {str(ex)}",
@@ -479,7 +480,7 @@ def inspect_nwb(
         for inspector_message in run_checks(nwbfile=nwbfile, checks=checks):
             inspector_message.file_path = nwbfile_path
             yield inspector_message
-    io.close()
+        io.close()
 
 
 def run_checks(nwbfile: pynwb.NWBFile, checks: list):

--- a/nwbinspector/nwbinspector.py
+++ b/nwbinspector/nwbinspector.py
@@ -455,28 +455,43 @@ def inspect_nwb(
     filterwarnings(action="ignore", message="No cached namespaces found in .*")
     filterwarnings(action="ignore", message="Ignoring cached namespace .*")
     try:
-        with pynwb.NWBHDF5IO(path=nwbfile_path, mode="r", load_namespaces=True, driver=driver) as io:
-            if skip_validate:
-                validation_errors = pynwb.validate(io=io)
-                if any(validation_errors):
-                    for validation_error in validation_errors:
-                        yield InspectorMessage(
-                            message=validation_error.reason,
-                            importance=Importance.PYNWB_VALIDATION,
-                            check_function_name=validation_error.name,
-                            location=validation_error.location,
-                            file_path=nwbfile_path,
-                        )
-
-            nwbfile = io.read()
-            for inspector_message in run_checks(nwbfile, checks=checks):
-                inspector_message.file_path = nwbfile_path
-                yield inspector_message
+        io = pynwb.NWBHDF5IO(path=nwbfile_path, mode="r", load_namespaces=True, driver=driver)
     except Exception as ex:
         yield InspectorMessage(
             message=traceback.format_exc(),
             importance=Importance.ERROR,
-            check_function_name=f"{type(ex)}: {str(ex)}",
+            check_function_name=f"During io=NWBHDF5IO(...) - {type(ex)}: {str(ex)}",
+            file_path=nwbfile_path,
+        )
+    if not skip_validate:
+        try:
+            validation_errors = pynwb.validate(io=io)
+            for validation_error in validation_errors:
+                yield InspectorMessage(
+                    message=validation_error.reason,
+                    importance=Importance.PYNWB_VALIDATION,
+                    check_function_name=validation_error.name,
+                    location=validation_error.location,
+                    file_path=nwbfile_path,
+                )
+        except Exception as ex:  # shouldn't happen, but you never know...
+            yield InspectorMessage(
+                message=traceback.format_exc(),
+                importance=Importance.ERROR,
+                check_function_name=f"During pynwb.validate - {type(ex)}: {str(ex)}",
+                file_path=nwbfile_path,
+            )
+
+    try:
+        nwbfile = io.read()
+        for inspector_message in run_checks(nwbfile, checks=checks):
+            inspector_message.file_path = nwbfile_path
+            yield inspector_message
+    except Exception as ex:
+        yield InspectorMessage(
+            message=traceback.format_exc(),
+            importance=Importance.ERROR,
+            check_function_name=f"During io.read() - {type(ex)}: {str(ex)}",
             file_path=nwbfile_path,
         )
 

--- a/nwbinspector/nwbinspector.py
+++ b/nwbinspector/nwbinspector.py
@@ -468,9 +468,6 @@ def inspect_nwb(
 
     try:
         nwbfile = io.read()
-        for inspector_message in run_checks(nwbfile, checks=checks):
-            inspector_message.file_path = nwbfile_path
-            yield inspector_message
     except Exception as ex:
         yield InspectorMessage(
             message=traceback.format_exc(),
@@ -478,6 +475,10 @@ def inspect_nwb(
             check_function_name=f"During io.read() - {type(ex)}: {str(ex)}",
             file_path=nwbfile_path,
         )
+    else:
+        for inspector_message in run_checks(nwbfile=nwbfile, checks=checks):
+            inspector_message.file_path = nwbfile_path
+            yield inspector_message
     io.close()
 
 

--- a/nwbinspector/nwbinspector.py
+++ b/nwbinspector/nwbinspector.py
@@ -473,16 +473,12 @@ def inspect_nwb(
                 inspector_message.file_path = nwbfile_path
                 yield inspector_message
     except Exception as ex:
-        return InspectorMessage(
+        yield InspectorMessage(
             message=traceback.format_exc(),
             importance=Importance.ERROR,
             check_function_name=f"During io.read() - {type(ex)}: {str(ex)}",
             file_path=nwbfile_path,
         )
-    else:
-        for inspector_message in run_checks(nwbfile=nwbfile, checks=checks):
-            inspector_message.file_path = nwbfile_path
-            yield inspector_message
 
 
 def run_checks(nwbfile: pynwb.NWBFile, checks: list):

--- a/nwbinspector/nwbinspector.py
+++ b/nwbinspector/nwbinspector.py
@@ -454,31 +454,15 @@ def inspect_nwb(
     nwbfile_path = str(nwbfile_path)
     filterwarnings(action="ignore", message="No cached namespaces found in .*")
     filterwarnings(action="ignore", message="Ignoring cached namespace .*")
-    try:
-        io = pynwb.NWBHDF5IO(path=nwbfile_path, mode="r", load_namespaces=True, driver=driver)
-    except Exception as ex:
-        yield InspectorMessage(
-            message=traceback.format_exc(),
-            importance=Importance.ERROR,
-            check_function_name=f"During io=NWBHDF5IO(...) - {type(ex)}: {str(ex)}",
-            file_path=nwbfile_path,
-        )
+    io = pynwb.NWBHDF5IO(path=nwbfile_path, mode="r", load_namespaces=True, driver=driver)
     if not skip_validate:
-        try:
-            validation_errors = pynwb.validate(io=io)
-            for validation_error in validation_errors:
-                yield InspectorMessage(
-                    message=validation_error.reason,
-                    importance=Importance.PYNWB_VALIDATION,
-                    check_function_name=validation_error.name,
-                    location=validation_error.location,
-                    file_path=nwbfile_path,
-                )
-        except Exception as ex:  # shouldn't happen, but you never know...
+        validation_errors = pynwb.validate(io=io)
+        for validation_error in validation_errors:
             yield InspectorMessage(
-                message=traceback.format_exc(),
-                importance=Importance.ERROR,
-                check_function_name=f"During pynwb.validate - {type(ex)}: {str(ex)}",
+                message=validation_error.reason,
+                importance=Importance.PYNWB_VALIDATION,
+                check_function_name=validation_error.name,
+                location=validation_error.location,
                 file_path=nwbfile_path,
             )
 
@@ -494,6 +478,7 @@ def inspect_nwb(
             check_function_name=f"During io.read() - {type(ex)}: {str(ex)}",
             file_path=nwbfile_path,
         )
+    io.close()
 
 
 def run_checks(nwbfile: pynwb.NWBFile, checks: list):

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -86,10 +86,39 @@ def add_simple_table(nwbfile: NWBFile):
 class TestInspector(TestCase):
     maxDiff = None
 
-    @classmethod
-    def setUpClass(cls):
-        cls.tempdir = Path(mkdtemp())
-        cls.checks = [
+    # @classmethod
+    # def setUpClass(cls):
+    #     cls.tempdir = Path(mkdtemp())
+    #     cls.checks = [
+    #         check_small_dataset_compression,
+    #         check_regular_timestamps,
+    #         check_data_orientation,
+    #         check_timestamps_match_first_dimension,
+    #     ]
+    #     num_nwbfiles = 3
+    #     nwbfiles = list()
+    #     for j in range(num_nwbfiles):
+    #         nwbfiles.append(make_minimal_nwbfile())
+    #     add_big_dataset_no_compression(nwbfiles[0])
+    #     add_regular_timestamps(nwbfiles[0])
+    #     add_flipped_data_orientation_to_processing(nwbfiles[0])
+    #     add_non_matching_timestamps_dimension(nwbfiles[0])
+    #     add_simple_table(nwbfiles[0])
+    #     add_regular_timestamps(nwbfiles[1])
+    #     # Last file to be left without violations
+
+    #     cls.nwbfile_paths = [str(cls.tempdir / f"testing{j}.nwb") for j in range(num_nwbfiles)]
+    #     for nwbfile_path, nwbfile in zip(cls.nwbfile_paths, nwbfiles):
+    #         with NWBHDF5IO(path=nwbfile_path, mode="w") as io:
+    #             io.write(nwbfile)
+
+    # @classmethod
+    # def tearDownClass(cls):
+    #     rmtree(cls.tempdir)
+
+    def setUp(self):
+        self.tempdir = Path(mkdtemp())
+        self.checks = [
             check_small_dataset_compression,
             check_regular_timestamps,
             check_data_orientation,
@@ -107,14 +136,13 @@ class TestInspector(TestCase):
         add_regular_timestamps(nwbfiles[1])
         # Last file to be left without violations
 
-        cls.nwbfile_paths = [str(cls.tempdir / f"testing{j}.nwb") for j in range(num_nwbfiles)]
-        for nwbfile_path, nwbfile in zip(cls.nwbfile_paths, nwbfiles):
+        self.nwbfile_paths = [str(self.tempdir / f"testing{j}.nwb") for j in range(num_nwbfiles)]
+        for nwbfile_path, nwbfile in zip(self.nwbfile_paths, nwbfiles):
             with NWBHDF5IO(path=nwbfile_path, mode="w") as io:
                 io.write(nwbfile)
 
-    @classmethod
-    def tearDownClass(cls):
-        rmtree(cls.tempdir)
+    def tearDown(self):
+        rmtree(self.tempdir)
 
     def assertFileExists(self, path: FilePathType):
         path = Path(path)
@@ -424,32 +452,32 @@ class TestInspector(TestCase):
             skip_first_newlines=True,
         )
 
-    # def test_iterable_check_function(self):
-    #     @register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=DynamicTable)
-    #     def iterable_check_function(table: DynamicTable):
-    #         for col in table.columns:
-    #             yield InspectorMessage(message=f"Column: {col.name}")
+    def test_iterable_check_function(self):
+        @register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=DynamicTable)
+        def iterable_check_function(table: DynamicTable):
+            for col in table.columns:
+                yield InspectorMessage(message=f"Column: {col.name}")
 
-    #     test_results = list(inspect_nwb(nwbfile_path=self.nwbfile_paths[0], select=["iterable_check_function"]))
-    #     true_results = [
-    #         InspectorMessage(
-    #             message="Column: start_time",
-    #             importance=Importance.BEST_PRACTICE_VIOLATION,
-    #             check_function_name="iterable_check_function",
-    #             object_type="TimeIntervals",
-    #             object_name="test_table",
-    #             file_path=self.nwbfile_paths[0],
-    #         ),
-    #         InspectorMessage(
-    #             message="Column: stop_time",
-    #             importance=Importance.BEST_PRACTICE_VIOLATION,
-    #             check_function_name="iterable_check_function",
-    #             object_type="TimeIntervals",
-    #             object_name="test_table",
-    #             file_path=self.nwbfile_paths[0],
-    #         ),
-    #     ]
-    #     self.assertCountEqual(first=test_results, second=true_results)
+        test_results = list(inspect_nwb(nwbfile_path=self.nwbfile_paths[0], select=["iterable_check_function"]))
+        true_results = [
+            InspectorMessage(
+                message="Column: start_time",
+                importance=Importance.BEST_PRACTICE_VIOLATION,
+                check_function_name="iterable_check_function",
+                object_type="TimeIntervals",
+                object_name="test_table",
+                file_path=self.nwbfile_paths[0],
+            ),
+            InspectorMessage(
+                message="Column: stop_time",
+                importance=Importance.BEST_PRACTICE_VIOLATION,
+                check_function_name="iterable_check_function",
+                object_type="TimeIntervals",
+                object_name="test_table",
+                file_path=self.nwbfile_paths[0],
+            ),
+        ]
+        self.assertCountEqual(first=test_results, second=true_results)
 
     def test_inspect_nwb_manual_iteration(self):
         generator = inspect_nwb(nwbfile_path=self.nwbfile_paths[0], checks=self.checks)

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -86,39 +86,10 @@ def add_simple_table(nwbfile: NWBFile):
 class TestInspector(TestCase):
     maxDiff = None
 
-    # @classmethod
-    # def setUpClass(cls):
-    #     cls.tempdir = Path(mkdtemp())
-    #     cls.checks = [
-    #         check_small_dataset_compression,
-    #         check_regular_timestamps,
-    #         check_data_orientation,
-    #         check_timestamps_match_first_dimension,
-    #     ]
-    #     num_nwbfiles = 3
-    #     nwbfiles = list()
-    #     for j in range(num_nwbfiles):
-    #         nwbfiles.append(make_minimal_nwbfile())
-    #     add_big_dataset_no_compression(nwbfiles[0])
-    #     add_regular_timestamps(nwbfiles[0])
-    #     add_flipped_data_orientation_to_processing(nwbfiles[0])
-    #     add_non_matching_timestamps_dimension(nwbfiles[0])
-    #     add_simple_table(nwbfiles[0])
-    #     add_regular_timestamps(nwbfiles[1])
-    #     # Last file to be left without violations
-
-    #     cls.nwbfile_paths = [str(cls.tempdir / f"testing{j}.nwb") for j in range(num_nwbfiles)]
-    #     for nwbfile_path, nwbfile in zip(cls.nwbfile_paths, nwbfiles):
-    #         with NWBHDF5IO(path=nwbfile_path, mode="w") as io:
-    #             io.write(nwbfile)
-
-    # @classmethod
-    # def tearDownClass(cls):
-    #     rmtree(cls.tempdir)
-
-    def setUp(self):
-        self.tempdir = Path(mkdtemp())
-        self.checks = [
+    @classmethod
+    def setUpClass(cls):
+        cls.tempdir = Path(mkdtemp())
+        cls.checks = [
             check_small_dataset_compression,
             check_regular_timestamps,
             check_data_orientation,
@@ -136,13 +107,14 @@ class TestInspector(TestCase):
         add_regular_timestamps(nwbfiles[1])
         # Last file to be left without violations
 
-        self.nwbfile_paths = [str(self.tempdir / f"testing{j}.nwb") for j in range(num_nwbfiles)]
-        for nwbfile_path, nwbfile in zip(self.nwbfile_paths, nwbfiles):
+        cls.nwbfile_paths = [str(cls.tempdir / f"testing{j}.nwb") for j in range(num_nwbfiles)]
+        for nwbfile_path, nwbfile in zip(cls.nwbfile_paths, nwbfiles):
             with NWBHDF5IO(path=nwbfile_path, mode="w") as io:
                 io.write(nwbfile)
 
-    def tearDown(self):
-        rmtree(self.tempdir)
+    @classmethod
+    def tearDownClass(cls):
+        rmtree(cls.tempdir)
 
     def assertFileExists(self, path: FilePathType):
         path = Path(path)

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -424,32 +424,32 @@ class TestInspector(TestCase):
             skip_first_newlines=True,
         )
 
-    def test_iterable_check_function(self):
-        @register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=DynamicTable)
-        def iterable_check_function(table: DynamicTable):
-            for col in table.columns:
-                yield InspectorMessage(message=f"Column: {col.name}")
+    # def test_iterable_check_function(self):
+    #     @register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=DynamicTable)
+    #     def iterable_check_function(table: DynamicTable):
+    #         for col in table.columns:
+    #             yield InspectorMessage(message=f"Column: {col.name}")
 
-        test_results = list(inspect_nwb(nwbfile_path=self.nwbfile_paths[0], select=["iterable_check_function"]))
-        true_results = [
-            InspectorMessage(
-                message="Column: start_time",
-                importance=Importance.BEST_PRACTICE_VIOLATION,
-                check_function_name="iterable_check_function",
-                object_type="TimeIntervals",
-                object_name="test_table",
-                file_path=self.nwbfile_paths[0],
-            ),
-            InspectorMessage(
-                message="Column: stop_time",
-                importance=Importance.BEST_PRACTICE_VIOLATION,
-                check_function_name="iterable_check_function",
-                object_type="TimeIntervals",
-                object_name="test_table",
-                file_path=self.nwbfile_paths[0],
-            ),
-        ]
-        self.assertCountEqual(first=test_results, second=true_results)
+    #     test_results = list(inspect_nwb(nwbfile_path=self.nwbfile_paths[0], select=["iterable_check_function"]))
+    #     true_results = [
+    #         InspectorMessage(
+    #             message="Column: start_time",
+    #             importance=Importance.BEST_PRACTICE_VIOLATION,
+    #             check_function_name="iterable_check_function",
+    #             object_type="TimeIntervals",
+    #             object_name="test_table",
+    #             file_path=self.nwbfile_paths[0],
+    #         ),
+    #         InspectorMessage(
+    #             message="Column: stop_time",
+    #             importance=Importance.BEST_PRACTICE_VIOLATION,
+    #             check_function_name="iterable_check_function",
+    #             object_type="TimeIntervals",
+    #             object_name="test_table",
+    #             file_path=self.nwbfile_paths[0],
+    #         ),
+    #     ]
+    #     self.assertCountEqual(first=test_results, second=true_results)
 
     def test_inspect_nwb_manual_iteration(self):
         generator = inspect_nwb(nwbfile_path=self.nwbfile_paths[0], checks=self.checks)


### PR DESCRIPTION
Small issue came up recently when running NWBInspector on a file that was not able to be opened through PyNWB due to a `ConstructionError`.

We previously had this try/except wrapped around all our calls to `nwbfile = io.read()`, however, this particular instance of the error did not occur during those try/except clauses, it occurred during the `pynwb.validation` step (which acts directly on the open `io`, but can still cause actual `Errors` instead of just returning messages of those errors.

Unable to write CI tests for this since I can't really 'create' a simple unreadable NWBFile like that (also, the file it was triggered on is not openly shared yet). Open to suggestions on this.