### PR TITLE
[Dependencies] Make dandi a lazy import

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -19,6 +19,7 @@ jobs:
       - run: git fetch --prune --unshallow --tags
       - name: Install pytest
         run: |
+          pip install dandi
           pip install pytest
           pip install pytest-cov
       - name: Install package

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -19,11 +19,12 @@ jobs:
       - run: git fetch --prune --unshallow --tags
       - name: Install pytest
         run: |
-          pip install dandi
           pip install pytest
           pip install pytest-cov
       - name: Install package
-        run: pip install -e .
+        run: |
+          pip install -e .
+          pip install dandi
       - name: Uninstall h5py
         run: pip uninstall -y h5py
       - name: Install ROS3

--- a/nwbinspector/tools.py
+++ b/nwbinspector/tools.py
@@ -6,7 +6,8 @@ from typing import Optional, Dict
 from concurrent.futures import ProcessPoolExecutor, as_completed
 
 from pynwb import NWBFile
-from dandi.dandiapi import DandiAPIClient
+
+from .utils import is_module_installed
 
 
 def make_minimal_nwbfile():
@@ -34,6 +35,13 @@ def get_s3_urls_and_dandi_paths(dandiset_id: str, version_id: Optional[str] = No
 
     Returns dictionary that maps each S3 url to the displayed file path on the DANDI archive content page.
     """
+    assert is_module_installed(module_name="dandi"), "You must install DANDI to get S3 paths (pip install dandi)."
+    from dandi.dandiapi import DandiAPIClient
+
+    def _get_content_url_and_path(asset, follow_redirects: int = 1, strip_query: bool = True) -> Dict[str, str]:
+        """Private helper function for parallelization in 'get_s3_urls_and_dandi_paths'."""
+        return {asset.get_content_url(follow_redirects=1, strip_query=True): asset.path}
+
     assert re.fullmatch(
         pattern="^[0-9]{6}$", string=dandiset_id
     ), "The specified 'path' is not a proper DANDISet ID. It should be a six-digit numeric identifier."
@@ -61,8 +69,3 @@ def get_s3_urls_and_dandi_paths(dandiset_id: str, version_id: Optional[str] = No
                 if asset.path.split(".")[-1] == "nwb":
                     s3_urls_to_dandi_paths.update(_get_content_url_and_path(asset=asset))
     return s3_urls_to_dandi_paths
-
-
-def _get_content_url_and_path(asset, follow_redirects: int = 1, strip_query: bool = True) -> Dict[str, str]:
-    """Private helper function for parallelization in 'get_s3_urls_and_dandi_paths'."""
-    return {asset.get_content_url(follow_redirects=1, strip_query=True): asset.path}

--- a/nwbinspector/tools.py
+++ b/nwbinspector/tools.py
@@ -38,10 +38,6 @@ def get_s3_urls_and_dandi_paths(dandiset_id: str, version_id: Optional[str] = No
     assert is_module_installed(module_name="dandi"), "You must install DANDI to get S3 paths (pip install dandi)."
     from dandi.dandiapi import DandiAPIClient
 
-    def _get_content_url_and_path(asset, follow_redirects: int = 1, strip_query: bool = True) -> Dict[str, str]:
-        """Private helper function for parallelization in 'get_s3_urls_and_dandi_paths'."""
-        return {asset.get_content_url(follow_redirects=1, strip_query=True): asset.path}
-
     assert re.fullmatch(
         pattern="^[0-9]{6}$", string=dandiset_id
     ), "The specified 'path' is not a proper DANDISet ID. It should be a six-digit numeric identifier."
@@ -69,3 +65,12 @@ def get_s3_urls_and_dandi_paths(dandiset_id: str, version_id: Optional[str] = No
                 if asset.path.split(".")[-1] == "nwb":
                     s3_urls_to_dandi_paths.update(_get_content_url_and_path(asset=asset))
     return s3_urls_to_dandi_paths
+
+
+def _get_content_url_and_path(asset, follow_redirects: int = 1, strip_query: bool = True) -> Dict[str, str]:
+    """
+    Private helper function for parallelization in 'get_s3_urls_and_dandi_paths'.
+
+    Must be globally defined (not as a part of get_s3_urls..) in order to be pickled.
+    """
+    return {asset.get_content_url(follow_redirects=1, strip_query=True): asset.path}

--- a/nwbinspector/utils.py
+++ b/nwbinspector/utils.py
@@ -83,7 +83,7 @@ def is_module_installed(module_name: str):
     Used for lazy imports.
     """
     try:
-        import_module(name="testing123")
+        import_module(name=module_name)
         return True
     except ModuleNotFoundError:
         return False

--- a/nwbinspector/utils.py
+++ b/nwbinspector/utils.py
@@ -4,6 +4,7 @@ import json
 import numpy as np
 from typing import TypeVar, Optional, List
 from pathlib import Path
+from importlib import import_module
 
 PathType = TypeVar("PathType", str, Path)  # For types that can be either files or folders
 FilePathType = TypeVar("FilePathType", str, Path)
@@ -72,4 +73,17 @@ def is_string_json_loadable(string: str):
         json.loads(string)
         return True
     except json.JSONDecodeError:
+        return False
+
+
+def is_module_installed(module_name: str):
+    """
+    Check if the given module is installed on the system.
+
+    Used for lazy imports.
+    """
+    try:
+        import_module(name="testing123")
+        return True
+    except ModuleNotFoundError:
         return False

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     include_package_data=True,
     url="https://github.com/NeurodataWithoutBorders/nwbinspector",
     install_requires=["pynwb", "natsort", "click", "PyYAML", "jsonschema", "tqdm"],
+    extras_require=dict(dandi=["dandi>=0.39.2"]),
     entry_points={"console_scripts": ["nwbinspector=nwbinspector.nwbinspector:inspect_all_cli"]},
     license="BSD-3-Clause",
 )

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     url="https://github.com/NeurodataWithoutBorders/nwbinspector",
-    install_requires=["pynwb", "natsort", "click", "PyYAML", "jsonschema", "dandi>=0.39.2", "tqdm"],
+    install_requires=["pynwb", "natsort", "click", "PyYAML", "jsonschema", "tqdm"],
     entry_points={"console_scripts": ["nwbinspector=nwbinspector.nwbinspector:inspect_all_cli"]},
     license="BSD-3-Clause",
 )


### PR DESCRIPTION
DANDI team is complaining that the circular dependency caused by the S3 helper function might cause a problem for them in the future. Making it a lazy import so it's not a strict dependency.