### PR TITLE
[Bug] Fix currently broken S3 test

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,5 +1,9 @@
 name: Testing
-on: pull_request
+on:
+  schedule:
+    - cron: "0 0 * * *"  # daily
+  pull_request:
+
 jobs:
   build-and-test:
     name: Testing using ${{ matrix.os }} with ${{ matrix.python-version }}

--- a/nwbinspector/inspector_tools.py
+++ b/nwbinspector/inspector_tools.py
@@ -77,7 +77,7 @@ class FormatterOptions:
     """Class structure for defining all free attributes for the design of a report format."""
 
     def __init__(
-        self, indent_size: int = 2, indent: Optional[str] = None, section_headers: List[str] = ["=", "-", "~"],
+        self, indent_size: int = 2, indent: Optional[str] = None, section_headers: List[str] = ["=", "-", "~"]
     ):
         # TODO
         # Future custom options could include section break sizes, section-specific indents, etc.
@@ -208,7 +208,6 @@ class MessageFormatter:
                     increment = self._get_message_increment(level_counter=this_level_counter)
                     message_header = self._get_message_header(message=message)
                     num_same = len(same_messages)
-                    print(num_same)
                     file_or_files = "s" if num_same > 2 else ""
                     additional_file_str = f" and {num_same-1} other file{file_or_files}" if num_same > 1 else ""
                     self.formatted_messages.append(

--- a/nwbinspector/inspector_tools.py
+++ b/nwbinspector/inspector_tools.py
@@ -13,21 +13,16 @@ from natsort import natsorted
 import numpy as np
 
 from .register_checks import InspectorMessage, Importance
-from .utils import FilePathType
-
-try:
-    from importlib.metadata import version
-
-    inspector_version = version("nwbinspector")
-except ModuleNotFoundError:  # Remove the except clause when minimal supported version becomes 3.8
-    from pkg_resources import get_distribution
-
-    inspector_version = get_distribution("nwbinspector").version
+from .utils import FilePathType, get_package_version
 
 
 def get_report_header():
     """Grab basic information from system at time of report generation."""
-    return dict(Timestamp=str(datetime.now().astimezone()), Platform=platform(), NWBInspector_version=inspector_version)
+    return dict(
+        Timestamp=str(datetime.now().astimezone()),
+        Platform=platform(),
+        NWBInspector_version=get_package_version("nwbinspector"),
+    )
 
 
 def _sort_unique_values(unique_values: list, reverse: bool = False):
@@ -82,10 +77,7 @@ class FormatterOptions:
     """Class structure for defining all free attributes for the design of a report format."""
 
     def __init__(
-        self,
-        indent_size: int = 2,
-        indent: Optional[str] = None,
-        section_headers: List[str] = ["=", "-", "~"],
+        self, indent_size: int = 2, indent: Optional[str] = None, section_headers: List[str] = ["=", "-", "~"],
     ):
         # TODO
         # Future custom options could include section break sizes, section-specific indents, etc.
@@ -216,6 +208,7 @@ class MessageFormatter:
                     increment = self._get_message_increment(level_counter=this_level_counter)
                     message_header = self._get_message_header(message=message)
                     num_same = len(same_messages)
+                    print(num_same)
                     file_or_files = "s" if num_same > 2 else ""
                     additional_file_str = f" and {num_same-1} other file{file_or_files}" if num_same > 1 else ""
                     self.formatted_messages.append(

--- a/nwbinspector/utils.py
+++ b/nwbinspector/utils.py
@@ -5,6 +5,7 @@ import numpy as np
 from typing import TypeVar, Optional, List
 from pathlib import Path
 from importlib import import_module
+from packaging import version
 
 PathType = TypeVar("PathType", str, Path)  # For types that can be either files or folders
 FilePathType = TypeVar("FilePathType", str, Path)
@@ -87,3 +88,28 @@ def is_module_installed(module_name: str):
         return True
     except ModuleNotFoundError:
         return False
+
+
+def get_package_version(name: str) -> version.Version:
+    """
+    Retrieve the version of a package regardless of if it has a __version__ attribute set.
+
+    Parameters
+    ----------
+    name : str
+        Name of package.
+
+    Returns
+    -------
+    version : Version
+        The package version as an object from packaging.version.Version, which allows comparison to other versions.
+    """
+    try:
+        from importlib.metadata import version as importlib_version
+
+        package_version = importlib_version(name)
+    except ModuleNotFoundError:  # Remove the except clause when minimal supported version becomes 3.8
+        from pkg_resources import get_distribution
+
+        package_version = get_distribution(name).version
+    return version.parse(package_version)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,9 @@
+from packaging import version
+
 from hdmf.testing import TestCase
 
 from nwbinspector import Importance
-from nwbinspector.utils import format_byte_size, check_regular_series, is_dict_in_string
+from nwbinspector.utils import format_byte_size, check_regular_series, is_dict_in_string, get_package_version
 
 
 def test_format_byte_size():
@@ -94,3 +96,11 @@ def test_is_dict_in_string_true_7():
     """
     string = "example, {this is not a dict: but it sure looks like one}!"
     assert is_dict_in_string(string=string) is True
+
+
+def test_get_package_version_type():
+    assert isinstance(get_package_version("hdmf"), version.Version)
+
+
+def test_get_package_version_value():
+    assert get_package_version("hdmf") >= version.parse("3.1.1")  # minimum supported PyNWB version

--- a/tests/unit_tests/test_time_series.py
+++ b/tests/unit_tests/test_time_series.py
@@ -33,7 +33,10 @@ except ValueError:  # ValueError: h5py was built without ROS3 support, can't use
 def test_check_regular_timestamps():
     assert check_regular_timestamps(
         time_series=pynwb.TimeSeries(
-            name="test_time_series", unit="test_units", data=np.zeros(shape=3), timestamps=[1.2, 3.2, 5.2],
+            name="test_time_series",
+            unit="test_units",
+            data=np.zeros(shape=3),
+            timestamps=[1.2, 3.2, 5.2],
         )
     ) == InspectorMessage(
         message=(
@@ -53,7 +56,10 @@ def test_pass_check_regular_timestamps():
     assert (
         check_regular_timestamps(
             time_series=pynwb.TimeSeries(
-                name="test_time_series", unit="test_units", data=[0, 0], timestamps=[1.2, 3.2],
+                name="test_time_series",
+                unit="test_units",
+                data=[0, 0],
+                timestamps=[1.2, 3.2],
             )
         )
         is None
@@ -63,7 +69,10 @@ def test_pass_check_regular_timestamps():
 def test_check_data_orientation():
     assert check_data_orientation(
         time_series=pynwb.TimeSeries(
-            name="test_time_series", unit="test_units", data=np.zeros(shape=(2, 100)), rate=1.0,
+            name="test_time_series",
+            unit="test_units",
+            data=np.zeros(shape=(2, 100)),
+            rate=1.0,
         )
     ) == InspectorMessage(
         message=(
@@ -82,7 +91,10 @@ def test_check_data_orientation():
 def test_check_timestamps():
     assert check_timestamps_match_first_dimension(
         time_series=pynwb.TimeSeries(
-            name="test_time_series", unit="test_units", data=np.zeros(shape=4), timestamps=[1.0, 2.0, 3.0],
+            name="test_time_series",
+            unit="test_units",
+            data=np.zeros(shape=4),
+            timestamps=[1.0, 2.0, 3.0],
         )
     ) == InspectorMessage(
         message="The length of the first dimension of data does not match the length of timestamps.",


### PR DESCRIPTION
After some hair pulling I finally found the source of the issue in the tests of https://github.com/NeurodataWithoutBorders/nwbinspector/pull/212.

To summarize, the file that was causing us problems before (only file for 'Kibbles' of DANDISet 65), which we debugged and added a test for previously, became unreadable with the newest release of `HDMF==3.3.1`.

As such, we now skip the running of this test. When PyNWB updates it's lower bound supported version of HDMF to this, we can completely remove the test.

Along the way I also just made a quick simple `util` for generalizing the package version retrieval, which could be convenient elsewhere.

I'm also setting the tests to run on a schedule so I'm alerted the moment this kind of thing happens.