### PR TITLE
Add negative job slicing

### DIFF
--- a/nwbinspector/nwbinspector.py
+++ b/nwbinspector/nwbinspector.py
@@ -153,10 +153,7 @@ def configure_checks(
 @click.argument("path")
 @click.option("--modules", help="Modules to import prior to reading the file(s).")
 @click.option(
-    "--report-file-path",
-    default=None,
-    help="Save path for the report file.",
-    type=click.Path(writable=True),
+    "--report-file-path", default=None, help="Save path for the report file.", type=click.Path(writable=True),
 )
 @click.option("--overwrite", help="Overwrite an existing report file at the location.", is_flag=True)
 @click.option("--levels", help="Comma-separated names of InspectorMessage attributes to organize by.")
@@ -317,6 +314,8 @@ def inspect_all(
         The default is the lowest level, BEST_PRACTICE_SUGGESTION.
     n_jobs : int
         Number of jobs to use in parallel. Set to -1 to use all available resources.
+        This may also be a negative integer x from -2 to -(number_of_cpus - 1) which acts like negative slicing by using
+        all available CPUs minus x.
         Set to 1 (also the default) to disable.
     skip_validate : bool, optional
         Skip the PyNWB validation step. This may be desired for older NWBFiles (< schema version v2.10).

--- a/nwbinspector/nwbinspector.py
+++ b/nwbinspector/nwbinspector.py
@@ -28,7 +28,7 @@ from .inspector_tools import (
 )
 from .register_checks import InspectorMessage, Importance
 from .tools import get_s3_urls_and_dandi_paths
-from .utils import FilePathType, PathType, OptionalListOfStrings
+from .utils import FilePathType, PathType, OptionalListOfStrings, calculate_number_of_cpu
 
 INTERNAL_CONFIGS = dict(dandi=Path(__file__).parent / "internal_configs" / "dandi.inspector_config.yaml")
 
@@ -153,7 +153,10 @@ def configure_checks(
 @click.argument("path")
 @click.option("--modules", help="Modules to import prior to reading the file(s).")
 @click.option(
-    "--report-file-path", default=None, help="Save path for the report file.", type=click.Path(writable=True),
+    "--report-file-path",
+    default=None,
+    help="Save path for the report file.",
+    type=click.Path(writable=True),
 )
 @click.option("--overwrite", help="Overwrite an existing report file at the location.", is_flag=True)
 @click.option("--levels", help="Comma-separated names of InspectorMessage attributes to organize by.")
@@ -336,6 +339,7 @@ def inspect_all(
         Defaults to the most recent published version, or if not published then the most recent draft version.
     """
     modules = modules or []
+    n_jobs = calculate_number_of_cpu(requested_cpu=n_jobs)
     if progress_bar_options is None:
         progress_bar_options = dict(position=0, leave=False)
         if stream:

--- a/nwbinspector/tools.py
+++ b/nwbinspector/tools.py
@@ -7,7 +7,7 @@ from concurrent.futures import ProcessPoolExecutor, as_completed
 
 from pynwb import NWBFile
 
-from .utils import is_module_installed
+from .utils import is_module_installed, calculate_number_of_cpu
 
 
 def make_minimal_nwbfile():
@@ -43,6 +43,7 @@ def get_s3_urls_and_dandi_paths(dandiset_id: str, version_id: Optional[str] = No
     ), "The specified 'path' is not a proper DANDISet ID. It should be a six-digit numeric identifier."
 
     s3_urls_to_dandi_paths = dict()
+    n_jobs = calculate_number_of_cpu(requested_cpu=n_jobs)
     if n_jobs != 1:
         with DandiAPIClient() as client:
             dandiset = client.get_dandiset(dandiset_id=dandiset_id, version_id=version_id)

--- a/nwbinspector/utils.py
+++ b/nwbinspector/utils.py
@@ -1,4 +1,5 @@
 """Commonly reused logic for evaluating conditions; must not have external dependencies."""
+import os
 import re
 import json
 import numpy as np
@@ -113,3 +114,19 @@ def get_package_version(name: str) -> version.Version:
 
         package_version = get_distribution(name).version
     return version.parse(package_version)
+
+
+def calculate_number_of_cpus(requested_cpu: int = 1) -> int:
+    """
+    Calculate the number CPUs to use with respect to negative slicing and check against maximal available resources.
+
+    Parameters
+    ----------
+    requested_cpu : int, optional
+        The desired number of CPUs to use.
+        
+        The default is 1.
+    """
+    total_cpu = os.cpu_count()
+    assert requested_cpu <= total_cpu, "Requested more CPUs ({requested_cpu}) than are available ({total_cpu})!"
+    assert requested_cpu >= -(total_cpu - 1)

--- a/nwbinspector/utils.py
+++ b/nwbinspector/utils.py
@@ -135,4 +135,4 @@ def calculate_number_of_cpu(requested_cpu: int = 1) -> int:
     if requested_cpu > 0:
         return requested_cpu
     else:
-        return requested_cpu % total_cpu
+        return total_cpu + requested_cpu

--- a/nwbinspector/utils.py
+++ b/nwbinspector/utils.py
@@ -128,6 +128,8 @@ def calculate_number_of_cpu(requested_cpu: int = 1) -> int:
         The default is 1.
     """
     total_cpu = os.cpu_count()
-    assert requested_cpu <= total_cpu, "Requested more CPUs ({requested_cpu}) than are available ({total_cpu})!"
-    assert requested_cpu >= -(total_cpu - 1), "Requested fewer CPUs ({requested_cpu}) than are available ({total_cpu})!"
+    assert requested_cpu <= total_cpu, f"Requested more CPUs ({requested_cpu}) than are available ({total_cpu})!"
+    assert requested_cpu >= -(
+        total_cpu - 1
+    ), f"Requested fewer CPUs ({requested_cpu}) than are available ({total_cpu})!"
     return requested_cpu % total_cpu

--- a/nwbinspector/utils.py
+++ b/nwbinspector/utils.py
@@ -116,7 +116,7 @@ def get_package_version(name: str) -> version.Version:
     return version.parse(package_version)
 
 
-def calculate_number_of_cpus(requested_cpu: int = 1) -> int:
+def calculate_number_of_cpu(requested_cpu: int = 1) -> int:
     """
     Calculate the number CPUs to use with respect to negative slicing and check against maximal available resources.
 
@@ -124,9 +124,10 @@ def calculate_number_of_cpus(requested_cpu: int = 1) -> int:
     ----------
     requested_cpu : int, optional
         The desired number of CPUs to use.
-        
+
         The default is 1.
     """
     total_cpu = os.cpu_count()
     assert requested_cpu <= total_cpu, "Requested more CPUs ({requested_cpu}) than are available ({total_cpu})!"
-    assert requested_cpu >= -(total_cpu - 1)
+    assert requested_cpu >= -(total_cpu - 1), "Requested fewer CPUs ({requested_cpu}) than are available ({total_cpu})!"
+    return requested_cpu % total_cpu

--- a/nwbinspector/utils.py
+++ b/nwbinspector/utils.py
@@ -132,4 +132,7 @@ def calculate_number_of_cpu(requested_cpu: int = 1) -> int:
     assert requested_cpu >= -(
         total_cpu - 1
     ), f"Requested fewer CPUs ({requested_cpu}) than are available ({total_cpu})!"
-    return requested_cpu % total_cpu
+    if requested_cpu > 0:
+        return requested_cpu
+    else:
+        return requested_cpu % total_cpu

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -133,5 +133,5 @@ class TestCalulcateNumberOfCPU(TestCase):
             calculate_number_of_cpu(requested_cpu=requested_cpu)
 
     def test_calculate_number_of_cpu_negative_value(self):
-        requested_cpu = -2
+        requested_cpu = -1  # CI only has 2 jobs available
         assert calculate_number_of_cpu(requested_cpu=requested_cpu) == requested_cpu % self.total_cpu

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -134,4 +134,4 @@ class TestCalulcateNumberOfCPU(TestCase):
 
     def test_calculate_number_of_cpu_negative_value(self):
         requested_cpu = -2
-        assert calculate_number_of_cpu(requested_cpu=requested_cpu) == requested_cpu % self.total_cpu()
+        assert calculate_number_of_cpu(requested_cpu=requested_cpu) == requested_cpu % self.total_cpu

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,16 @@
+import os
 from packaging import version
 
 from hdmf.testing import TestCase
 
 from nwbinspector import Importance
-from nwbinspector.utils import format_byte_size, check_regular_series, is_dict_in_string, get_package_version
+from nwbinspector.utils import (
+    format_byte_size,
+    check_regular_series,
+    is_dict_in_string,
+    get_package_version,
+    calculate_number_of_cpu,
+)
 
 
 def test_format_byte_size():
@@ -104,3 +111,27 @@ def test_get_package_version_type():
 
 def test_get_package_version_value():
     assert get_package_version("hdmf") >= version.parse("3.1.1")  # minimum supported PyNWB version
+
+
+class TestCalulcateNumberOfCPU(TestCase):
+    total_cpu = os.cpu_count()
+
+    def test_request_more_than_available_assert(self):
+        requested_cpu = 2500
+        with self.assertRaisesWith(
+            exc_type=AssertionError,
+            exc_msg=f"Requested more CPUs ({requested_cpu}) than are available ({self.total_cpu})!",
+        ):
+            calculate_number_of_cpu(requested_cpu=requested_cpu)
+
+    def test_request_fewer_than_available_assert(self):
+        requested_cpu = -2500
+        with self.assertRaisesWith(
+            exc_type=AssertionError,
+            exc_msg=f"Requested fewer CPUs ({requested_cpu}) than are available ({self.total_cpu})!",
+        ):
+            calculate_number_of_cpu(requested_cpu=requested_cpu)
+
+    def test_calculate_number_of_cpu_negative_value(self):
+        requested_cpu = -2
+        assert calculate_number_of_cpu(requested_cpu=requested_cpu) == requested_cpu % self.total_cpu()

--- a/tests/unit_tests/test_tables.py
+++ b/tests/unit_tests/test_tables.py
@@ -1,6 +1,7 @@
 import platform
 import json
 from unittest import TestCase
+from packaging import version
 
 import numpy as np
 from hdmf.common import DynamicTable, DynamicTableRegion
@@ -17,6 +18,7 @@ from nwbinspector import (
     check_single_row,
     check_table_values_for_dict,
 )
+from nwbinspector.utils import get_package_version
 
 
 class TestCheckDynamicTableRegion(TestCase):
@@ -237,16 +239,27 @@ def test_check_single_row_ignore_electrodes():
     table = ElectrodeTable(
         name="electrodes",  # default name when building through nwbfile
     )
-    table.add_row(
-        x=np.nan,
-        y=np.nan,
-        z=np.nan,
-        imp=np.nan,
-        location="unknown",
-        filtering="unknown",
-        group=ElectrodeGroup(name="test_group", description="", device=Device(name="test_device"), location="unknown"),
-        group_name="test_group",
-    )
+    if get_package_version(name="pynwb") >= version.Version("2.1.0"):
+        table.add_row(
+            location="unknown",
+            group=ElectrodeGroup(
+                name="test_group", description="", device=Device(name="test_device"), location="unknown"
+            ),
+            group_name="test_group",
+        )
+    else:
+        table.add_row(
+            x=np.nan,
+            y=np.nan,
+            z=np.nan,
+            imp=np.nan,
+            location="unknown",
+            filtering="unknown",
+            group=ElectrodeGroup(
+                name="test_group", description="", device=Device(name="test_device"), location="unknown"
+            ),
+            group_name="test_group",
+        )
     assert check_single_row(table=table) is None
 
 


### PR DESCRIPTION
fix #184 

Adds capability for specifying negative values for the number of jobs, taking on the meaning of 'use all available CPUs, except for that number'.

Primarily useful on the DANDIHub when you may have forgotten how large of an instance you initially spawned, or if autoscaling decided to allocate some other amount of resources.