### PR TITLE
Add retry for curl requests

### DIFF
--- a/nwbinspector/nwbinspector.py
+++ b/nwbinspector/nwbinspector.py
@@ -493,7 +493,7 @@ def inspect_nwb(
                 )
 
     if driver != "ros3":
-        yield _collect_all_messages(
+        return _collect_all_messages(
             nwbfile_path=nwbfile_path, checks=checks, driver=driver, skip_validate=skip_validate
         )
     else:
@@ -502,7 +502,7 @@ def inspect_nwb(
         while retries < max_retries:
             try:
                 retries += 1
-                yield _collect_all_messages(
+                return _collect_all_messages(
                     nwbfile_path=nwbfile_path, checks=checks, driver=driver, skip_validate=skip_validate
                 )
             except OSError:  # Cannot curl request

--- a/nwbinspector/nwbinspector.py
+++ b/nwbinspector/nwbinspector.py
@@ -154,7 +154,10 @@ def configure_checks(
 @click.argument("path")
 @click.option("--modules", help="Modules to import prior to reading the file(s).")
 @click.option(
-    "--report-file-path", default=None, help="Save path for the report file.", type=click.Path(writable=True),
+    "--report-file-path",
+    default=None,
+    help="Save path for the report file.",
+    type=click.Path(writable=True),
 )
 @click.option("--overwrite", help="Overwrite an existing report file at the location.", is_flag=True)
 @click.option("--levels", help="Comma-separated names of InspectorMessage attributes to organize by.")
@@ -459,7 +462,9 @@ def inspect_nwb(
     filterwarnings(action="ignore", message="No cached namespaces found in .*")
     filterwarnings(action="ignore", message="Ignoring cached namespace .*")
 
-    def _collect_all_messages(nwbfile_path: FilePathType, checks: list, driver: Optional[str] = None, skip_validate: bool = False):
+    def _collect_all_messages(
+        nwbfile_path: FilePathType, checks: list, driver: Optional[str] = None, skip_validate: bool = False
+    ):
         with pynwb.NWBHDF5IO(path=nwbfile_path, mode="r", load_namespaces=True, driver=driver) as io:
             if not skip_validate:
                 validation_errors = pynwb.validate(io=io)
@@ -488,16 +493,20 @@ def inspect_nwb(
                 )
 
     if driver != "ros3":
-        yield _collect_all_messages(nwbfile_path=nwbfile_path, checks=checks, driver=driver, skip_validate=skip_validate)
+        yield _collect_all_messages(
+            nwbfile_path=nwbfile_path, checks=checks, driver=driver, skip_validate=skip_validate
+        )
     else:
         retries = 0
 
         while retries < max_retries:
             try:
                 retries += 1
-                yield _collect_all_messages(nwbfile_path=nwbfile_path, checks=checks, driver=driver, skip_validate=skip_validate)
+                yield _collect_all_messages(
+                    nwbfile_path=nwbfile_path, checks=checks, driver=driver, skip_validate=skip_validate
+                )
             except OSError:  # Cannot curl request
-                sleep(0.1 * 2 ** retries)
+                sleep(0.1 * 2**retries)
 
 
 def run_checks(nwbfile: pynwb.NWBFile, checks: list):

--- a/tests/unit_tests/test_tables.py
+++ b/tests/unit_tests/test_tables.py
@@ -1,6 +1,7 @@
 import platform
 import json
 from unittest import TestCase
+from packaging import version
 
 import numpy as np
 from hdmf.common import DynamicTable, DynamicTableRegion
@@ -17,6 +18,7 @@ from nwbinspector import (
     check_single_row,
     check_table_values_for_dict,
 )
+from nwbinspector.utils import get_package_version
 
 
 class TestCheckDynamicTableRegion(TestCase):
@@ -237,16 +239,27 @@ def test_check_single_row_ignore_electrodes():
     table = ElectrodeTable(
         name="electrodes",  # default name when building through nwbfile
     )
-    table.add_row(
-        x=np.nan,
-        y=np.nan,
-        z=np.nan,
-        imp=np.nan,
-        location="unknown",
-        filtering="unknown",
-        group=ElectrodeGroup(name="test_group", description="", device=Device(name="test_device"), location="unknown"),
-        group_name="test_group",
-    )
+    if get_package_version(name="pynwb") >= version.Version("2.1.0"):
+        table.add_row(
+            location="unknown",
+            group=ElectrodeGroup(
+                name="test_group", description="", device=Device(name="test_device"), location="unknown"
+            ),
+            group_name="test_group",
+        )
+    else:
+        table.add_row(
+            x=np.nan,
+            y=np.nan,
+            z=np.nan,
+            imp=np.nan,
+            location="unknown",
+            filtering="unknown",
+            group=ElectrodeGroup(
+                name="test_group", description="", device=Device(name="test_device"), location="unknown"
+            ),
+            group_name="test_group",
+        )
     assert check_single_row(table=table) is None
 
 


### PR DESCRIPTION
fix #197 

Attempting to resolve curl requests errors to S3 paths, up to `max_retries` using the suggested exponential back-off