### PR TITLE
Update subject sub-species Best Practice

### DIFF
--- a/docs/best_practices/nwbfile_metadata.rst
+++ b/docs/best_practices/nwbfile_metadata.rst
@@ -202,10 +202,16 @@ Species
 ~~~~~~~
 
 The ``species`` of a :nwb-schema:ref:`sec-Subject` should be set to the proper
-:wikipedia:`Latin binomial <Binomial_nomenclature>`. *E.g.*, a rat would be "Rattus norvegicus". Specific subspecies
-may be further specified by a dash, *e.g.*, "Rattus norvegicus - Long Evans".
+:wikipedia:`Latin binomial <Binomial_nomenclature>`. *E.g.*, a rat would be "Rattus norvegicus".
 
 Check function: :py:meth:`~nwbinspector.checks.nwbfile_metadata.check_subject_species`
+
+
+
+Strain
+~~~~~~~
+
+The ``strain`` of a :nwb-schema:ref:`sec-Subject` should be set to further indicate subspecies or breed. *E.g.*, common strains for species "Rattus norvegicus" include "Long Evans", "Sprague-Dawley", "Wistar", or "C57BL/6" is a common mouse strain. If no specific strain is used, simply indicate "Wild Type".
 
 
 

--- a/docs/best_practices/nwbfile_metadata.rst
+++ b/docs/best_practices/nwbfile_metadata.rst
@@ -211,7 +211,7 @@ Check function: :py:meth:`~nwbinspector.checks.nwbfile_metadata.check_subject_sp
 Strain
 ~~~~~~~
 
-The ``strain`` of a :nwb-schema:ref:`sec-Subject` should be set to further indicate subspecies or breed. *E.g.*, common strains for species "Rattus norvegicus" include "Long Evans", "Sprague-Dawley", "Wistar", or "C57BL/6" is a common mouse strain. If no specific strain is used, simply indicate "Wild Type".
+The ``strain`` of a :nwb-schema:ref:`sec-Subject` should be set to further indicate the subspecies or breed or common genetic modification. *E.g.*, common strains for species "Rattus norvegicus" might include "Long Evans", "Sprague-Dawley", "Wistar", or "C57BL/6". If no specific strain is used, then simply indicate "Wild Type".
 
 
 


### PR DESCRIPTION
fix #194 

Current documentation asks to append the strain or sub-species to the subject species with dash separation. It should instead indicate the usage of the `strain` field for specifying this information.