### PR TITLE
[New Check]: Add experimenter form check using DANDI regex

### DIFF
--- a/nwbinspector/checks/nwbfile_metadata.py
+++ b/nwbinspector/checks/nwbfile_metadata.py
@@ -1,7 +1,6 @@
 """Check functions that examine general NWBFile metadata."""
 import re
 from datetime import datetime
-from warnings import warn
 
 from pynwb import NWBFile, ProcessingModule
 from pynwb.file import Subject

--- a/nwbinspector/checks/nwbfile_metadata.py
+++ b/nwbinspector/checks/nwbfile_metadata.py
@@ -52,7 +52,7 @@ def check_experimenter_form(nwbfile: NWBFile):
     if is_module_installed(module_name="dandi"):
         from dandischema.models import NAME_PATTERN  # for most up to date version of the regex
     else:
-        NAME_PATTERN = r"^([\w\s\-\.']+),\s+([\w\s\-\.']+)$"
+        NAME_PATTERN = r"^([\w\s\-\.']+),\s+([\w\s\-\.']+)$"  # copied on 7/12/22
 
     for experimenter in nwbfile.experimenter:
         experimenter = experimenter.decode() if isinstance(experimenter, bytes) else experimenter

--- a/nwbinspector/checks/nwbfile_metadata.py
+++ b/nwbinspector/checks/nwbfile_metadata.py
@@ -48,7 +48,7 @@ def check_experimenter_exists(nwbfile: NWBFile):
 
 @register_check(importance=Importance.BEST_PRACTICE_SUGGESTION, neurodata_type=NWBFile)
 def check_experimenter_form(nwbfile: NWBFile):
-    """Check if an experimenter has been added for the session."""
+    """Check the text form of each experimenter to see if it matches the DANDI regex pattern."""
     if not is_module_installed(module_name="dandi"):
         warn(
             "It is strongly recommended to download DANDI alongside the NWB Inspector \n\n"

--- a/nwbinspector/checks/nwbfile_metadata.py
+++ b/nwbinspector/checks/nwbfile_metadata.py
@@ -49,14 +49,10 @@ def check_experimenter_exists(nwbfile: NWBFile):
 @register_check(importance=Importance.BEST_PRACTICE_SUGGESTION, neurodata_type=NWBFile)
 def check_experimenter_form(nwbfile: NWBFile):
     """Check the text form of each experimenter to see if it matches the DANDI regex pattern."""
-    if not is_module_installed(module_name="dandi"):
-        warn(
-            "It is strongly recommended to download DANDI alongside the NWB Inspector \n\n"
-            "\tpip install dandi\n\nor\n\n\tpip install nwbinspector.[dandi]\n"
-        )
-        return
-
-    from dandischema.models import NAME_PATTERN
+    if is_module_installed(module_name="dandi"):
+        from dandischema.models import NAME_PATTERN  # for most up to date version of the regex
+    else:
+        NAME_PATTERN = r"^([\w\s\-\.']+),\s+([\w\s\-\.']+)$"
 
     for experimenter in nwbfile.experimenter:
         experimenter = experimenter.decode() if isinstance(experimenter, bytes) else experimenter

--- a/tests/unit_tests/test_nwbfile_metadata.py
+++ b/tests/unit_tests/test_nwbfile_metadata.py
@@ -7,7 +7,8 @@ from pynwb.file import Subject
 from nwbinspector import (
     InspectorMessage,
     Importance,
-    check_experimenter,
+    check_experimenter_exists,
+    check_experimenter_form,
     check_experiment_description,
     check_institution,
     check_keywords,
@@ -70,35 +71,77 @@ def test_check_session_start_time_future_date_fail():
     )
 
 
-def test_check_experimenter_pass():
+def test_check_experimenter_exists_pass():
     nwbfile = NWBFile(
         session_description="",
         identifier=str(uuid4()),
         session_start_time=datetime.now().astimezone(),
         experimenter=["Last, First"],
     )
-    assert check_experimenter(nwbfile) is None
+    assert check_experimenter_exists(nwbfile) is None
 
 
-def test_check_experimenter_bytestring_pass():
+def test_check_experimenter_exists_bytestring_pass():
     nwbfile = NWBFile(
         session_description="",
         identifier=str(uuid4()),
         session_start_time=datetime.now().astimezone(),
         experimenter=[b"Last, First"],
     )
-    assert check_experimenter(nwbfile) is None
+    assert check_experimenter_exists(nwbfile) is None
 
 
-def test_check_experimenter_fail():
-    assert check_experimenter(minimal_nwbfile) == InspectorMessage(
+def test_check_experimenter_exists_fail():
+    assert check_experimenter_exists(minimal_nwbfile) == InspectorMessage(
         message="Experimenter is missing.",
         importance=Importance.BEST_PRACTICE_SUGGESTION,
-        check_function_name="check_experimenter",
+        check_function_name="check_experimenter_exists",
         object_type="NWBFile",
         object_name="root",
         location="/",
     )
+
+
+def test_check_experimenter_form_pass():
+    nwbfile = NWBFile(
+        session_description="",
+        identifier=str(uuid4()),
+        session_start_time=datetime.now().astimezone(),
+        experimenter=["Last, First"],
+    )
+    assert check_experimenter_form(nwbfile=nwbfile) is None
+
+
+def test_check_experimenter_form_bytestring_pass():
+    nwbfile = NWBFile(
+        session_description="",
+        identifier=str(uuid4()),
+        session_start_time=datetime.now().astimezone(),
+        experimenter=[b"Last, First"],
+    )
+    assert check_experimenter_form(nwbfile=nwbfile) is None
+
+
+def test_check_experimenter_form_fail():
+    nwbfile = NWBFile(
+        session_description="",
+        identifier=str(uuid4()),
+        session_start_time=datetime.now().astimezone(),
+        experimenter=["First Middle Last"],
+    )
+    assert check_experimenter_form(nwbfile=nwbfile) == [
+        InspectorMessage(
+            message=(
+                "The name of experimenter 'First Middle Last' does not match the DANDI form "
+                "(Last, First Middle or Last, First M.)."
+            ),
+            importance=Importance.BEST_PRACTICE_SUGGESTION,
+            check_function_name="check_experimenter_form",
+            object_type="NWBFile",
+            object_name="root",
+            location="/",
+        )
+    ]
 
 
 def test_check_experiment_description():

--- a/tests/unit_tests/test_tables.py
+++ b/tests/unit_tests/test_tables.py
@@ -1,6 +1,7 @@
 import platform
 import json
 from unittest import TestCase
+from packaging import version
 
 import numpy as np
 from hdmf.common import DynamicTable, DynamicTableRegion
@@ -17,6 +18,7 @@ from nwbinspector import (
     check_single_row,
     check_table_values_for_dict,
 )
+from nwbinspector.utils import get_package_version
 
 
 class TestCheckDynamicTableRegion(TestCase):
@@ -237,16 +239,27 @@ def test_check_single_row_ignore_electrodes():
     table = ElectrodeTable(
         name="electrodes",  # default name when building through nwbfile
     )
-    table.add_row(
-        x=np.nan,
-        y=np.nan,
-        z=np.nan,
-        imp=np.nan,
-        location="unknown",
-        filtering="unknown",
-        group=ElectrodeGroup(name="test_group", description="", device=Device(name="test_device"), location="unknown"),
-        group_name="test_group",
-    )
+    if get_package_version(name="pynwb") >= version.Version("2.1.0"):
+        table.add_row(
+            location="unknown",
+            group=ElectrodeGroup(
+                name="test_group", description="", device=Device(name="test_device"), location="unknown"
+            ),
+            group_name="test_group",
+        )
+    else:
+        table.add_row(
+            x=np.nan,
+            y=np.nan,
+            z=np.nan,
+            imp=np.nan,
+            location="unknown",
+            filtering="unknown",
+            group=ElectrodeGroup(
+                name="test_group", description="", device=Device(name="test_device"), location="unknown"
+            ),
+            group_name="test_group",
+        )
     assert check_single_row(table=table) is None
 
 


### PR DESCRIPTION
fix #33

Checks the text form of each experimenter against the DANDI regex pattern (imported directly from there in case they ever update it).

Check has early return in the event that DANDI is not installed (with informative warning message).

Also incorporates that byte-string fix we needed for publications, which has a similar kind of structure to this.