### PR TITLE
More general curl fix

### DIFF
--- a/nwbinspector/utils.py
+++ b/nwbinspector/utils.py
@@ -126,10 +126,11 @@ def robust_s3_read(
     for retry in range(max_retries):
         try:
             return command(*command_args, **command_kwargs)
-        except OSError:  # cannot curl request
-            sleep(0.1 * 2**retry)
         except Exception as exc:
-            raise exc
+            if "curl" in str(exc):  # 'cannot curl request' can show up in potentially many different return error types
+                sleep(0.1 * 2**retry)
+            else:
+                raise exc
     raise TimeoutError(f"Unable to complete the command ({command.__name__}) after {max_retries} attempts!")
 
 


### PR DESCRIPTION
After PR #223 was merged, a new type of curl error was discovered randomly by the CI: https://github.com/NeurodataWithoutBorders/nwbinspector/runs/7290188091?check_suite_focus=true

This PR generalizes the `robust_s3_read` catching method - every instance observed of these curling issues results in an error message that includes at the very least the word 'curl', but apparently it can take on many different error types depending on the operation that triggered the connection issue.