### PR TITLE
Add caching for repeated table data calls

### DIFF
--- a/nwbinspector/checks/tables.py
+++ b/nwbinspector/checks/tables.py
@@ -153,7 +153,9 @@ def check_column_binary_capability(table: DynamicTable, nelems: int = 200):
 
 @register_check(importance=Importance.BEST_PRACTICE_SUGGESTION, neurodata_type=DynamicTable)
 def check_single_row(
-    table: DynamicTable, exclude_types: Optional[list] = (Units,), exclude_names: Optional[List[str]] = ("electrodes",),
+    table: DynamicTable,
+    exclude_types: Optional[list] = (Units,),
+    exclude_names: Optional[List[str]] = ("electrodes",),
 ):
     """
     Check if DynamicTable has only a single row; may be better represented by another data type.

--- a/nwbinspector/checks/tables.py
+++ b/nwbinspector/checks/tables.py
@@ -111,7 +111,7 @@ def check_column_binary_capability(table: DynamicTable, nelems: int = 200):
             if np.asarray(column.data[0]).itemsize == 1:
                 continue  # already boolean, int8, or uint8
             try:
-                unique_values = np.unique(_subsample_data(data=column.data, nelems=nelems))
+                unique_values = np.unique(_subsample_data(data=column, nelems=nelems))
             except TypeError:  # some contained objects are unhashable or have no comparison defined
                 continue
             if unique_values.size != 2:
@@ -153,9 +153,7 @@ def check_column_binary_capability(table: DynamicTable, nelems: int = 200):
 
 @register_check(importance=Importance.BEST_PRACTICE_SUGGESTION, neurodata_type=DynamicTable)
 def check_single_row(
-    table: DynamicTable,
-    exclude_types: Optional[list] = (Units,),
-    exclude_names: Optional[List[str]] = ("electrodes",),
+    table: DynamicTable, exclude_types: Optional[list] = (Units,), exclude_names: Optional[List[str]] = ("electrodes",),
 ):
     """
     Check if DynamicTable has only a single row; may be better represented by another data type.
@@ -179,7 +177,7 @@ def check_table_values_for_dict(table: DynamicTable, nelems: int = 200):
     for column in table.columns:
         if not hasattr(column, "data") or isinstance(column, VectorIndex) or not isinstance(column.data[0], str):
             continue
-        for string in _subsample_data(data=column.data, nelems=nelems):
+        for string in _subsample_data(data=column, nelems=nelems):
             if is_dict_in_string(string=string):
                 message = (
                     f"The column '{column.name}' contains a string value that contains a dictionary! Please "

--- a/nwbinspector/utils.py
+++ b/nwbinspector/utils.py
@@ -25,6 +25,7 @@ MAX_CACHE_ITEMS = 1000  # lru_cache default is 128 calls of matching input/outpu
 @lru_cache(maxsize=MAX_CACHE_ITEMS)
 def _cache_data_selection(data: h5py.Dataset, selection: Union[slice, Tuple[slice]]) -> np.array:
     """Extract the selection lazily from the data object for efficient caching (most beneficial during streaming)."""
+    data = np.asarray(data) if isinstance(data, list) else data
     return data[selection]
 
 

--- a/nwbinspector/utils.py
+++ b/nwbinspector/utils.py
@@ -23,16 +23,24 @@ MAX_CACHE_ITEMS = 1000  # lru_cache default is 128 calls of matching input/outpu
 
 
 @lru_cache(maxsize=MAX_CACHE_ITEMS)
-def _cache_data_retrieval(data: Union[h5py.Dataset, tuple], selection: Union[slice, Tuple[slice]]) -> np.ndarray:
+def _cache_data_retrieval_command(
+    data: Union[h5py.Dataset, tuple], reduced_selection: Tuple[Tuple[Optional[int], Optional[int], Optional[int]]]
+) -> np.ndarray:
     """LRU caching for _cache_data_selection cannot be applied to list inputs; this expects the tuple or Dataset."""
-    data = np.array(data) if not isinstance(data, h5py.Dataset) else data  # to support the array slicing below
+    data = np.array(data) if isinstance(data, tuple) else data  # to support the array slicing below
+    selection = [slice(*reduced_slice) for reduced_slice in reduced_selection]  # reconstitute the slices
     return data[selection]
 
 
-def _cache_data_selection(data: Union[h5py.Dataset, ArrayLike], selection: Union[slice, Tuple[slice]]) -> np.ndarray:
+def _cache_data_selection(data: Union[h5py.Dataset, list, tuple], selection: Union[slice, Tuple[slice]]) -> np.ndarray:
     """Extract the selection lazily from the data object for efficient caching (most beneficial during streaming)."""
-    data = tuple(data) if isinstance(data, ArrayLike) else data
-    return _cache_data_retrieval(data=data, selection=selection)
+    data = tuple(data) if isinstance(data, list) else data  # lists are unhashable
+    # slices also aren't hashable, but their reduced representation is
+    if isinstance(selection, slice):  # if a single slice
+        reduced_selection = tuple([selection.__reduce__()[1]])  # if a single slice
+    else:  # slices also aren't hashable, but their reduced representation is
+        reduced_selection = tuple([selection_slice.__reduce__()[1] for selection_slice in selection])
+    return _cache_data_retrieval_command(data=data, reduced_selection=reduced_selection)
 
 
 def format_byte_size(byte_size: int, units: str = "SI"):

--- a/nwbinspector/utils.py
+++ b/nwbinspector/utils.py
@@ -23,10 +23,15 @@ MAX_CACHE_ITEMS = 1000  # lru_cache default is 128 calls of matching input/outpu
 
 
 @lru_cache(maxsize=MAX_CACHE_ITEMS)
-def _cache_data_selection(data: h5py.Dataset, selection: Union[slice, Tuple[slice]]) -> np.array:
-    """Extract the selection lazily from the data object for efficient caching (most beneficial during streaming)."""
-    data = np.asarray(data) if isinstance(data, list) else data
+def _cache_data_retrieval(data: Union[h5py.Dataset, tuple], selection: Union[slice, Tuple[slice]]) -> np.ndarray:
+    """LRU caching for _cache_data_selection cannot be applied to list inputs; this expects the tuple or Dataset."""
     return data[selection]
+
+
+def _cache_data_selection(data: Union[h5py.Dataset, list, tuple], selection: Union[slice, Tuple[slice]]) -> np.ndarray:
+    """Extract the selection lazily from the data object for efficient caching (most beneficial during streaming)."""
+    data = tuple(data) if isinstance(data, list) else data
+    return _cache_data_retrieval(data=data, selection=selection)
 
 
 def format_byte_size(byte_size: int, units: str = "SI"):

--- a/nwbinspector/utils.py
+++ b/nwbinspector/utils.py
@@ -142,7 +142,7 @@ def robust_s3_read(
         try:
             return command(*command_args, **command_kwargs)
         except OSError:  # cannot curl request
-            sleep(0.1 * 2 ** retry)
+            sleep(0.1 * 2**retry)
         except Exception as exc:
             raise exc
     raise TimeoutError(f"Unable to complete the command ({command.__name__}) after {max_retries} attempts!")

--- a/nwbinspector/utils.py
+++ b/nwbinspector/utils.py
@@ -137,7 +137,7 @@ def robust_s3_read(
         try:
             return command(*command_args, **command_kwargs)
         except OSError:  # cannot curl request
-            sleep(0.1 * 2 ** retry)
+            sleep(0.1 * 2**retry)
         except Exception as exc:
             raise exc
     raise TimeoutError(f"Unable to complete the command ({command.__name__}) after {max_retries} attempts!")

--- a/nwbinspector/utils.py
+++ b/nwbinspector/utils.py
@@ -25,12 +25,13 @@ MAX_CACHE_ITEMS = 1000  # lru_cache default is 128 calls of matching input/outpu
 @lru_cache(maxsize=MAX_CACHE_ITEMS)
 def _cache_data_retrieval(data: Union[h5py.Dataset, tuple], selection: Union[slice, Tuple[slice]]) -> np.ndarray:
     """LRU caching for _cache_data_selection cannot be applied to list inputs; this expects the tuple or Dataset."""
+    data = np.array(data) if not isinstance(data, h5py.Dataset) else data  # to support the array slicing below
     return data[selection]
 
 
-def _cache_data_selection(data: Union[h5py.Dataset, list, tuple], selection: Union[slice, Tuple[slice]]) -> np.ndarray:
+def _cache_data_selection(data: Union[h5py.Dataset, ArrayLike], selection: Union[slice, Tuple[slice]]) -> np.ndarray:
     """Extract the selection lazily from the data object for efficient caching (most beneficial during streaming)."""
-    data = tuple(data) if isinstance(data, list) else data
+    data = tuple(data) if isinstance(data, ArrayLike) else data
     return _cache_data_retrieval(data=data, selection=selection)
 
 

--- a/tests/unit_tests/test_tables.py
+++ b/tests/unit_tests/test_tables.py
@@ -183,8 +183,8 @@ class TestCheckBinaryColumns(TestCase):
         assert check_column_binary_capability(table=self.table) == [
             InspectorMessage(
                 message=(
-                    "Column 'test_col' uses 'integers' but has binary values [0 1]. Consider making it boolean instead "
-                    f"and renaming the column to start with 'is_'; doing so will save {platform_saved_bytes}."
+                    "Column 'test_col' uses 'integers' but has binary values [0. 1.]. Consider making it boolean "
+                    f"instead and renaming the column to start with 'is_'; doing so will save {platform_saved_bytes}."
                 ),
                 importance=Importance.BEST_PRACTICE_SUGGESTION,
                 check_function_name="check_column_binary_capability",

--- a/tests/unit_tests/test_tables.py
+++ b/tests/unit_tests/test_tables.py
@@ -183,7 +183,7 @@ class TestCheckBinaryColumns(TestCase):
         assert check_column_binary_capability(table=self.table) == [
             InspectorMessage(
                 message=(
-                    "Column 'test_col' uses 'integers' but has binary values [0. 1.]. Consider making it boolean "
+                    "Column 'test_col' uses 'integers' but has binary values [0 1]. Consider making it boolean "
                     f"instead and renaming the column to start with 'is_'; doing so will save {platform_saved_bytes}."
                 ),
                 importance=Importance.BEST_PRACTICE_SUGGESTION,

--- a/tests/unit_tests/test_time_series.py
+++ b/tests/unit_tests/test_time_series.py
@@ -34,10 +34,7 @@ except ValueError:  # ValueError: h5py was built without ROS3 support, can't use
 def test_check_regular_timestamps():
     assert check_regular_timestamps(
         time_series=pynwb.TimeSeries(
-            name="test_time_series",
-            unit="test_units",
-            data=np.zeros(shape=3),
-            timestamps=[1.2, 3.2, 5.2],
+            name="test_time_series", unit="test_units", data=np.zeros(shape=3), timestamps=[1.2, 3.2, 5.2],
         )
     ) == InspectorMessage(
         message=(
@@ -57,10 +54,7 @@ def test_pass_check_regular_timestamps():
     assert (
         check_regular_timestamps(
             time_series=pynwb.TimeSeries(
-                name="test_time_series",
-                unit="test_units",
-                data=[0, 0],
-                timestamps=[1.2, 3.2],
+                name="test_time_series", unit="test_units", data=[0, 0], timestamps=[1.2, 3.2],
             )
         )
         is None
@@ -70,10 +64,7 @@ def test_pass_check_regular_timestamps():
 def test_check_data_orientation():
     assert check_data_orientation(
         time_series=pynwb.TimeSeries(
-            name="test_time_series",
-            unit="test_units",
-            data=np.zeros(shape=(2, 100)),
-            rate=1.0,
+            name="test_time_series", unit="test_units", data=np.zeros(shape=(2, 100)), rate=1.0,
         )
     ) == InspectorMessage(
         message=(
@@ -92,10 +83,7 @@ def test_check_data_orientation():
 def test_check_timestamps():
     assert check_timestamps_match_first_dimension(
         time_series=pynwb.TimeSeries(
-            name="test_time_series",
-            unit="test_units",
-            data=np.zeros(shape=4),
-            timestamps=[1.0, 2.0, 3.0],
+            name="test_time_series", unit="test_units", data=np.zeros(shape=4), timestamps=[1.0, 2.0, 3.0],
         )
     ) == InspectorMessage(
         message="The length of the first dimension of data does not match the length of timestamps.",
@@ -133,8 +121,23 @@ def test_check_timestamps_empty_timestamps():
     )
 
 
-def test_check_timestamps_ascending():
-    time_series = pynwb.TimeSeries(name="test_time_series", unit="test_units", data=[1, 2, 3], timestamps=[1, 3, 2])
+def test_pass_check_timestamps_ascending_pass():
+    time_series = pynwb.TimeSeries(
+        name="test_time_series",
+        unit="test_units",
+        data=[1, 2, 3],
+        timestamps=tuple([1, 2, 3]),  # must be tuple in-memory for caching
+    )
+    assert check_timestamps_ascending(time_series) is None
+
+
+def test_check_timestamps_ascending_fail():
+    time_series = pynwb.TimeSeries(
+        name="test_time_series",
+        unit="test_units",
+        data=[1, 2, 3],
+        timestamps=tuple([1, 3, 2]),  # must be tuple in-memory for caching
+    )
     assert check_timestamps_ascending(time_series) == InspectorMessage(
         message="test_time_series timestamps are not ascending.",
         importance=Importance.BEST_PRACTICE_VIOLATION,
@@ -143,11 +146,6 @@ def test_check_timestamps_ascending():
         object_name="test_time_series",
         location="/",
     )
-
-
-def test_pass_check_timestamps_ascending():
-    time_series = pynwb.TimeSeries(name="test_time_series", unit="test_units", data=[1, 2, 3], timestamps=[1, 2, 3])
-    assert check_timestamps_ascending(time_series) is None
 
 
 def test_check_missing_unit_pass():
@@ -169,7 +167,7 @@ def test_check_missing_unit_fail():
 
 def test_check_positive_resolution_pass():
     time_series = pynwb.TimeSeries(name="test", unit="test_units", data=[1, 2, 3], timestamps=[1, 2, 3], resolution=3.4)
-    assert check_timestamps_ascending(time_series) is None
+    assert check_resolution(time_series) is None
 
 
 def test_check_unknown_resolution_pass():
@@ -198,8 +196,7 @@ def test_check_none_matnwb_resolution_pass():
     ) as io:
         nwbfile = robust_s3_read(command=io.read)
         time_series = robust_s3_read(
-            "20170203_KIB_01_s1.1.h264",
-            command=nwbfile.processing["video_files"]["video"].time_series.get,
+            "20170203_KIB_01_s1.1.h264", command=nwbfile.processing["video_files"]["video"].time_series.get,
         )
     assert check_resolution(time_series) is None
 

--- a/tests/unit_tests/test_time_series.py
+++ b/tests/unit_tests/test_time_series.py
@@ -34,7 +34,10 @@ except ValueError:  # ValueError: h5py was built without ROS3 support, can't use
 def test_check_regular_timestamps():
     assert check_regular_timestamps(
         time_series=pynwb.TimeSeries(
-            name="test_time_series", unit="test_units", data=np.zeros(shape=3), timestamps=[1.2, 3.2, 5.2],
+            name="test_time_series",
+            unit="test_units",
+            data=np.zeros(shape=3),
+            timestamps=[1.2, 3.2, 5.2],
         )
     ) == InspectorMessage(
         message=(
@@ -54,7 +57,10 @@ def test_pass_check_regular_timestamps():
     assert (
         check_regular_timestamps(
             time_series=pynwb.TimeSeries(
-                name="test_time_series", unit="test_units", data=[0, 0], timestamps=[1.2, 3.2],
+                name="test_time_series",
+                unit="test_units",
+                data=[0, 0],
+                timestamps=[1.2, 3.2],
             )
         )
         is None
@@ -64,7 +70,10 @@ def test_pass_check_regular_timestamps():
 def test_check_data_orientation():
     assert check_data_orientation(
         time_series=pynwb.TimeSeries(
-            name="test_time_series", unit="test_units", data=np.zeros(shape=(2, 100)), rate=1.0,
+            name="test_time_series",
+            unit="test_units",
+            data=np.zeros(shape=(2, 100)),
+            rate=1.0,
         )
     ) == InspectorMessage(
         message=(
@@ -83,7 +92,10 @@ def test_check_data_orientation():
 def test_check_timestamps():
     assert check_timestamps_match_first_dimension(
         time_series=pynwb.TimeSeries(
-            name="test_time_series", unit="test_units", data=np.zeros(shape=4), timestamps=[1.0, 2.0, 3.0],
+            name="test_time_series",
+            unit="test_units",
+            data=np.zeros(shape=4),
+            timestamps=[1.0, 2.0, 3.0],
         )
     ) == InspectorMessage(
         message="The length of the first dimension of data does not match the length of timestamps.",
@@ -196,7 +208,8 @@ def test_check_none_matnwb_resolution_pass():
     ) as io:
         nwbfile = robust_s3_read(command=io.read)
         time_series = robust_s3_read(
-            "20170203_KIB_01_s1.1.h264", command=nwbfile.processing["video_files"]["video"].time_series.get,
+            "20170203_KIB_01_s1.1.h264",
+            command=nwbfile.processing["video_files"]["video"].time_series.get,
         )
     assert check_resolution(time_series) is None
 

--- a/tests/unit_tests/test_time_series.py
+++ b/tests/unit_tests/test_time_series.py
@@ -122,22 +122,12 @@ def test_check_timestamps_empty_timestamps():
 
 
 def test_pass_check_timestamps_ascending_pass():
-    time_series = pynwb.TimeSeries(
-        name="test_time_series",
-        unit="test_units",
-        data=[1, 2, 3],
-        timestamps=tuple([1, 2, 3]),  # must be tuple in-memory for caching
-    )
+    time_series = pynwb.TimeSeries(name="test_time_series", unit="test_units", data=[1, 2, 3], timestamps=[1, 2, 3])
     assert check_timestamps_ascending(time_series) is None
 
 
 def test_check_timestamps_ascending_fail():
-    time_series = pynwb.TimeSeries(
-        name="test_time_series",
-        unit="test_units",
-        data=[1, 2, 3],
-        timestamps=tuple([1, 3, 2]),  # must be tuple in-memory for caching
-    )
+    time_series = pynwb.TimeSeries(name="test_time_series", unit="test_units", data=[1, 2, 3], timestamps=[1, 3, 2])
     assert check_timestamps_ascending(time_series) == InspectorMessage(
         message="test_time_series timestamps are not ascending.",
         importance=Importance.BEST_PRACTICE_VIOLATION,


### PR DESCRIPTION
fix #177 

Many of the checks we have for tables rely on extracting a specifiable amount of data (`nelems`) from the columns to enact some logic upon. This results in the same pattern of data extraction being applied to the same table column potentially multiple times.

This PR adds caching for the input/output of these calls to allow instant retrieval. The default cache 'size' is `128` function items (pairs of input/output values), which I've bumped to `1000` to get some benefit for larger tables or files with many tables. Each of these pairs should be approximately 1.6 KB in size (assuming `float64` values) for a 1.6 MB cache when fully used.