### PR TITLE
[New Check] Entire column of a table is not NaN

### DIFF
--- a/nwbinspector/checks/tables.py
+++ b/nwbinspector/checks/tables.py
@@ -189,7 +189,7 @@ def check_col_not_nan(table: DynamicTable, nelems: int = 200):
     for column in table.columns:
         if not hasattr(column, "data") or isinstance(column, VectorIndex) or isinstance(column.data[0], str):
             continue
-        if not all(np.isnan(column[:nelems])):
+        if not all(np.isnan(column[:nelems]).flatten()):
             continue
 
         subindex_selection = np.unique(np.round(np.linspace(start=0, stop=column.shape[0] - 1, num=nelems)).astype(int))

--- a/nwbinspector/checks/tables.py
+++ b/nwbinspector/checks/tables.py
@@ -148,9 +148,7 @@ def check_column_binary_capability(table: DynamicTable, nelems: int = 200):
 
 @register_check(importance=Importance.BEST_PRACTICE_SUGGESTION, neurodata_type=DynamicTable)
 def check_single_row(
-    table: DynamicTable,
-    exclude_types: Optional[list] = (Units,),
-    exclude_names: Optional[List[str]] = ("electrodes",),
+    table: DynamicTable, exclude_types: Optional[list] = (Units,), exclude_names: Optional[List[str]] = ("electrodes",),
 ):
     """
     Check if DynamicTable has only a single row; may be better represented by another data type.
@@ -191,6 +189,9 @@ def check_col_not_nan(table: DynamicTable, nelems: int = 200):
     for column in table.columns:
         if not hasattr(column, "data") or isinstance(column, VectorIndex) or isinstance(column.data[0], str):
             continue
+        if not all(np.isnan(column[:nelems])):
+            continue
+
         subindex_selection = np.unique(np.round(np.linspace(start=0, stop=column.shape[0] - 1, num=nelems)).astype(int))
         if all(np.isnan(column[subindex_selection])):
             yield InspectorMessage(

--- a/nwbinspector/checks/tables.py
+++ b/nwbinspector/checks/tables.py
@@ -14,7 +14,6 @@ from ..utils import (
     is_ascending_series,
     is_dict_in_string,
     is_string_json_loadable,
-    safe_uniform_selection,
 )
 
 

--- a/nwbinspector/checks/tables.py
+++ b/nwbinspector/checks/tables.py
@@ -199,7 +199,11 @@ def check_col_not_nan(table: DynamicTable, nelems: Optional[int] = 200):
         if nelems is not None and not all(np.isnan(column[:nelems]).flatten()):
             continue
 
-        if all(np.isnan(column[slice(0, None, np.ceil(length / nelems).astype(int) if nelems else None)])):
+        if all(
+            np.isnan(
+                column[slice(0, None, np.ceil(len(column.data) / nelems).astype(int) if nelems else None)]
+            ).flatten()
+        ):
             yield InspectorMessage(
                 message=f"Column {column.name} has all NaN values. Consider removing it from the table."
             )

--- a/nwbinspector/checks/tables.py
+++ b/nwbinspector/checks/tables.py
@@ -200,8 +200,7 @@ def check_col_not_nan(table: DynamicTable, nelems: Optional[int] = 200):
         if nelems is not None and not all(np.isnan(column[:nelems]).flatten()):
             continue
 
-        subindex_selection = safe_uniform_selection(length=column.shape[0], nelems=nelems)
-        if all(np.isnan(column[subindex_selection])):
+        if all(np.isnan(column[slice(0, None, np.ceil(length / nelems).astype(int) if nelems else None)])):
             yield InspectorMessage(
                 message=f"Column {column.name} has all NaN values. Consider removing it from the table."
             )

--- a/nwbinspector/checks/tables.py
+++ b/nwbinspector/checks/tables.py
@@ -148,9 +148,7 @@ def check_column_binary_capability(table: DynamicTable, nelems: int = 200):
 
 @register_check(importance=Importance.BEST_PRACTICE_SUGGESTION, neurodata_type=DynamicTable)
 def check_single_row(
-    table: DynamicTable,
-    exclude_types: Optional[list] = (Units,),
-    exclude_names: Optional[List[str]] = ("electrodes",),
+    table: DynamicTable, exclude_types: Optional[list] = (Units,), exclude_names: Optional[List[str]] = ("electrodes",),
 ):
     """
     Check if DynamicTable has only a single row; may be better represented by another data type.
@@ -183,3 +181,9 @@ def check_table_values_for_dict(table: DynamicTable, nelems: int = 200):
                 if is_string_json_loadable(string=string):
                     message += " This string is also JSON loadable, so call `json.loads(...)` on the string to unpack."
                 yield InspectorMessage(message=message)
+
+
+@register_check(importance=Importance.BEST_PRACTICE_SUGGESTION, neurodata_type=DynamicTable)
+def check_col_not_nan(table: DynamicTable, nelems: int = 200):
+    """Check if all of the values in a single column of a table are NaN."""
+    pass  # TODO

--- a/nwbinspector/checks/tables.py
+++ b/nwbinspector/checks/tables.py
@@ -190,9 +190,7 @@ def check_col_not_nan(table: DynamicTable, nelems: int = 200):
         if not hasattr(column, "data") or isinstance(column, VectorIndex) or isinstance(column.data[0], str):
             continue
         subindex_selection = np.unique(np.round(np.linspace(start=0, stop=column.shape[0] - 1, num=nelems)).astype(int))
-        if np.any(~np.isnan(column[subindex_selection])):
-            continue
-        else:
+        if all(np.isnan(column[subindex_selection])):
             yield InspectorMessage(
                 message=f"Column {column.name} has all NaN values. Consider removing it from the table."
             )

--- a/nwbinspector/checks/tables.py
+++ b/nwbinspector/checks/tables.py
@@ -13,7 +13,7 @@ from ..utils import (
     is_ascending_series,
     is_dict_in_string,
     is_string_json_loadable,
-    get_uniform_indexes,
+    safe_uniform_selection,
 )
 
 
@@ -195,7 +195,7 @@ def check_col_not_nan(table: DynamicTable, nelems: Optional[int] = 200):
         if nelems is not None and not all(np.isnan(column[:nelems]).flatten()):
             continue
 
-        subindex_selection = get_uniform_indexes(length=column.shape[0], nelems=nelems)
+        subindex_selection = safe_uniform_selection(length=column.shape[0], nelems=nelems)
         if all(np.isnan(column[subindex_selection])):
             yield InspectorMessage(
                 message=f"Column {column.name} has all NaN values. Consider removing it from the table."

--- a/nwbinspector/checks/tables.py
+++ b/nwbinspector/checks/tables.py
@@ -149,7 +149,9 @@ def check_column_binary_capability(table: DynamicTable, nelems: int = 200):
 
 @register_check(importance=Importance.BEST_PRACTICE_SUGGESTION, neurodata_type=DynamicTable)
 def check_single_row(
-    table: DynamicTable, exclude_types: Optional[list] = (Units,), exclude_names: Optional[List[str]] = ("electrodes",),
+    table: DynamicTable,
+    exclude_types: Optional[list] = (Units,),
+    exclude_names: Optional[List[str]] = ("electrodes",),
 ):
     """
     Check if DynamicTable has only a single row; may be better represented by another data type.

--- a/nwbinspector/checks/tables.py
+++ b/nwbinspector/checks/tables.py
@@ -186,4 +186,13 @@ def check_table_values_for_dict(table: DynamicTable, nelems: int = 200):
 @register_check(importance=Importance.BEST_PRACTICE_SUGGESTION, neurodata_type=DynamicTable)
 def check_col_not_nan(table: DynamicTable, nelems: int = 200):
     """Check if all of the values in a single column of a table are NaN."""
-    pass  # TODO
+    for column in table.columns:
+        if not hasattr(column, "data") or isinstance(column, VectorIndex) or isinstance(column.data[0], str):
+            continue
+        subindex_selection = np.unique(np.round(np.linspace(start=0, stop=column.shape[0] - 1, num=nelems)).astype(int))
+        if np.any(~np.isnan(column[subindex_selection])):
+            continue
+        else:
+            yield InspectorMessage(
+                message=f"Column {column.name} has all NaN values. Consider removing it from the table."
+            )

--- a/nwbinspector/checks/tables.py
+++ b/nwbinspector/checks/tables.py
@@ -148,7 +148,9 @@ def check_column_binary_capability(table: DynamicTable, nelems: int = 200):
 
 @register_check(importance=Importance.BEST_PRACTICE_SUGGESTION, neurodata_type=DynamicTable)
 def check_single_row(
-    table: DynamicTable, exclude_types: Optional[list] = (Units,), exclude_names: Optional[List[str]] = ("electrodes",),
+    table: DynamicTable,
+    exclude_types: Optional[list] = (Units,),
+    exclude_names: Optional[List[str]] = ("electrodes",),
 ):
     """
     Check if DynamicTable has only a single row; may be better represented by another data type.

--- a/nwbinspector/utils.py
+++ b/nwbinspector/utils.py
@@ -90,11 +90,6 @@ def is_ascending_series(series: Union[h5py.Dataset, ArrayLike], nelems=None):
         return np.all(np.diff(series[:nelems]) > 0)  # already in memory, no need to cache
 
 
-def safe_uniform_selection(length: int, nelems: Optional[int] = 200) -> slice:
-    """General purpose function for safely generating an evenly spaced slice ."""
-    return slice(0, None, np.ceil(length / nelems).astype(int) if nelems else None)
-
-
 def is_dict_in_string(string: str):
     """
     Determine if the string value contains an encoded Python dictionary.

--- a/nwbinspector/utils.py
+++ b/nwbinspector/utils.py
@@ -59,9 +59,7 @@ def is_ascending_series(series: np.ndarray, nelems=None):
 
 def safe_uniform_selection(length: int, nelems: Optional[int] = 200) -> slice:
     """General purpose function for safely generating an evenly spaced slice ."""
-    if nelems is None:
-        return slice(0, None)
-    return slice(0, length, np.ceil(length / nelems).astype(int))
+    return slice(0, None, np.ceil(length / nelems).astype(int) if nelems else None)
 
 
 def is_dict_in_string(string: str):

--- a/nwbinspector/utils.py
+++ b/nwbinspector/utils.py
@@ -57,6 +57,15 @@ def is_ascending_series(series: np.ndarray, nelems=None):
     return np.all(np.diff(series[:nelems]) > 0)
 
 
+def get_uniform_indexes(length: int, nelems: Optional[int] = 200):
+    """General purpose function for generating nelems indices from 0 to length-1 with approximately equal gaps."""
+    indexes = np.round(np.linspace(start=0, stop=length - 1, num=nelems)).astype(int)
+    if nelems is None or nelems >= length - 1:
+        return slice(0, None)
+    else:
+        return indexes
+
+
 def is_dict_in_string(string: str):
     """
     Determine if the string value contains an encoded Python dictionary.
@@ -127,7 +136,7 @@ def robust_s3_read(
         try:
             return command(*command_args, **command_kwargs)
         except OSError:  # cannot curl request
-            sleep(0.1 * 2**retry)
+            sleep(0.1 * 2 ** retry)
         except Exception as exc:
             raise exc
     raise TimeoutError(f"Unable to complete the command ({command.__name__}) after {max_retries} attempts!")

--- a/nwbinspector/utils.py
+++ b/nwbinspector/utils.py
@@ -57,13 +57,11 @@ def is_ascending_series(series: np.ndarray, nelems=None):
     return np.all(np.diff(series[:nelems]) > 0)
 
 
-def get_uniform_indexes(length: int, nelems: Optional[int] = 200):
-    """General purpose function for generating nelems indices from 0 to length-1 with approximately equal gaps."""
-    indexes = np.round(np.linspace(start=0, stop=length - 1, num=nelems)).astype(int)
-    if nelems is None or nelems >= length - 1:
+def safe_uniform_selection(length: int, nelems: Optional[int] = 200) -> slice:
+    """General purpose function for safely generating an evenly spaced slice ."""
+    if nelems is None:
         return slice(0, None)
-    else:
-        return indexes
+    return slice(0, length, np.ceil(length/nelems).astype(int))
 
 
 def is_dict_in_string(string: str):

--- a/nwbinspector/utils.py
+++ b/nwbinspector/utils.py
@@ -61,7 +61,7 @@ def safe_uniform_selection(length: int, nelems: Optional[int] = 200) -> slice:
     """General purpose function for safely generating an evenly spaced slice ."""
     if nelems is None:
         return slice(0, None)
-    return slice(0, length, np.ceil(length/nelems).astype(int))
+    return slice(0, length, np.ceil(length / nelems).astype(int))
 
 
 def is_dict_in_string(string: str):

--- a/nwbinspector/utils.py
+++ b/nwbinspector/utils.py
@@ -136,7 +136,7 @@ def robust_s3_read(
         try:
             return command(*command_args, **command_kwargs)
         except OSError:  # cannot curl request
-            sleep(0.1 * 2 ** retry)
+            sleep(0.1 * 2**retry)
         except Exception as exc:
             raise exc
     raise TimeoutError(f"Unable to complete the command ({command.__name__}) after {max_retries} attempts!")

--- a/tests/unit_tests/test_tables.py
+++ b/tests/unit_tests/test_tables.py
@@ -229,13 +229,17 @@ def test_check_single_row_pass():
 
 
 def test_check_single_row_ignore_units():
-    table = Units(name="Units",)  # default name when building through nwbfile
+    table = Units(
+        name="Units",
+    )  # default name when building through nwbfile
     table.add_unit(spike_times=[1, 2, 3])
     assert check_single_row(table=table) is None
 
 
 def test_check_single_row_ignore_electrodes():
-    table = ElectrodeTable(name="electrodes",)  # default name when building through nwbfile
+    table = ElectrodeTable(
+        name="electrodes",
+    )  # default name when building through nwbfile
     if get_package_version(name="pynwb") >= version.Version("2.1.0"):
         table.add_row(
             location="unknown",


### PR DESCRIPTION
Along with #229, finishes #155

Whenever an entire column of a table is `NaN`, informs the user that there probably isn't a need to include it. Samples the `nelems` uniformly across the length of the column since it's quite possible to have a block of consecutive entries (even `nelems` many) that are purposefully and even informatively `NaN`.

Only giving it a `SUGGESTION` level of importance since this will fail for large columns of sparse non-`NaN`, and also could be a design choice of the user.