### PR TITLE
[New Check] Check if identifiers are unique over a folder path

### DIFF
--- a/nwbinspector/nwbinspector.py
+++ b/nwbinspector/nwbinspector.py
@@ -155,7 +155,10 @@ def configure_checks(
 @click.argument("path")
 @click.option("--modules", help="Modules to import prior to reading the file(s).")
 @click.option(
-    "--report-file-path", default=None, help="Save path for the report file.", type=click.Path(writable=True),
+    "--report-file-path",
+    default=None,
+    help="Save path for the report file.",
+    type=click.Path(writable=True),
 )
 @click.option("--overwrite", help="Overwrite an existing report file at the location.", is_flag=True)
 @click.option("--levels", help="Comma-separated names of InspectorMessage attributes to organize by.")

--- a/nwbinspector/nwbinspector.py
+++ b/nwbinspector/nwbinspector.py
@@ -19,6 +19,7 @@ import click
 import pynwb
 import yaml
 from tqdm import tqdm
+from natsort import natsorted
 
 from . import available_checks
 from .inspector_tools import (
@@ -379,7 +380,7 @@ def inspect_all(
                 yield InspectorMessage(
                     message=(
                         f"The identifier '{identifier}' is used across the .nwb files: "
-                        f"{[str(x) for x in nwbfiles_with_identifier]}\n"
+                        f"{natsorted([x.name for x in nwbfiles_with_identifier])}. "
                         "The identifier of any NWBFile should be a completely unique value - "
                         "we recommend using uuid4 to achieve this."
                     ),
@@ -388,7 +389,7 @@ def inspect_all(
                     object_type="NWBFile",
                     object_name="root",
                     location="/",
-                    file_path=str(Path(nwbfiles_with_identifier[0]).parent),
+                    file_path=str(nwbfiles_with_identifier[0].parent),
                 )
 
     nwbfiles_iterable = nwbfiles

--- a/nwbinspector/nwbinspector.py
+++ b/nwbinspector/nwbinspector.py
@@ -392,7 +392,7 @@ def inspect_all(
                     object_type="NWBFile",
                     object_name="root",
                     location="/",
-                    file_path=str(nwbfiles_with_identifier[0].parent),
+                    file_path=str(path),
                 )
 
     nwbfiles_iterable = nwbfiles

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -4,6 +4,7 @@ from shutil import rmtree
 from tempfile import mkdtemp
 from pathlib import Path
 from unittest import TestCase
+from datetime import datetime
 
 import numpy as np
 from pynwb import NWBFile, NWBHDF5IO, TimeSeries
@@ -144,7 +145,7 @@ class TestInspector(TestCase):
                     if ".nwb" in test_line:
                         # Transform temporary testing path and formatted to hardcoded fake path
                         str_loc = test_line.find(".nwb")
-                        correction_str = test_line.replace(test_line[5 : str_loc - 8], "./")
+                        correction_str = test_line.replace(test_line[5 : str_loc - 8], "./")  # noqa E203 (black)
                         test_file_lines[line_number] = correction_str
                 self.assertEqual(first=test_file_lines[skip_first_n_lines:-1], second=true_file_lines)
 
@@ -561,3 +562,75 @@ class TestStreamingCLI(TestCase):
             f"> {console_output_file}"
         )
         self.assertFileExists(path=self.tempdir / "test_nwbinspector_streaming_report_7.txt")
+
+
+class TestCheckUniqueIdentifiersPass(TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tempdir = Path(mkdtemp())
+        num_nwbfiles = 3
+        unique_id_nwbfiles = list()
+        for j in range(num_nwbfiles):
+            unique_id_nwbfiles.append(make_minimal_nwbfile())
+
+        cls.unique_id_nwbfile_paths = [str(cls.tempdir / f"unique_id_testing{j}.nwb") for j in range(num_nwbfiles)]
+        for nwbfile_path, nwbfile in zip(cls.unique_id_nwbfile_paths, unique_id_nwbfiles):
+            with NWBHDF5IO(path=nwbfile_path, mode="w") as io:
+                io.write(nwbfile)
+
+    @classmethod
+    def tearDownClass(cls):
+        rmtree(cls.tempdir)
+
+    def test_check_unique_identifiers_pass(self):
+        assert list(inspect_all(path=self.tempdir, select=["check_data_orientation"])) == []
+
+
+class TestCheckUniqueIdentifiersFail(TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tempdir = Path(mkdtemp())
+        num_nwbfiles = 3
+        non_unique_id_nwbfiles = list()
+        for j in range(num_nwbfiles):
+            non_unique_id_nwbfiles.append(
+                NWBFile(
+                    session_description="",
+                    identifier="not a unique identifier!",
+                    session_start_time=datetime.now().astimezone(),
+                )
+            )
+
+        cls.non_unique_id_nwbfile_paths = [
+            str(cls.tempdir / f"non_unique_id_testing{j}.nwb") for j in range(num_nwbfiles)
+        ]
+        for nwbfile_path, nwbfile in zip(cls.non_unique_id_nwbfile_paths, non_unique_id_nwbfiles):
+            with NWBHDF5IO(path=nwbfile_path, mode="w") as io:
+                io.write(nwbfile)
+
+    @classmethod
+    def tearDownClass(cls):
+        rmtree(cls.tempdir)
+
+    def test_check_unique_identifiers_fail(self):
+        print(list(inspect_all(path=self.tempdir, select=["check_data_orientation"])))
+        assert list(inspect_all(path=self.tempdir, select=["check_data_orientation"])) == [
+            InspectorMessage(
+                message=(
+                    "The identifier 'not a unique identifier!' is used across the .nwb files: "
+                    f"{[str(x) for x in self.non_unique_id_nwbfile_paths]}\n"
+                    "The identifier of any NWBFile should be a completely unique value - "
+                    "we recommend using uuid4 to achieve this."
+                ),
+                importance=Importance.CRITICAL,
+                check_function_name="check_unique_identifiers",
+                object_type="NWBFile",
+                object_name="root",
+                location="/",
+                file_path=str(Path(self.non_unique_id_nwbfile_paths[0]).parent),
+            )
+        ]

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -11,6 +11,7 @@ from pynwb import NWBFile, NWBHDF5IO, TimeSeries
 from pynwb.file import TimeIntervals
 from pynwb.behavior import SpatialSeries, Position
 from hdmf.common import DynamicTable
+from natsort import natsorted
 
 from nwbinspector import (
     Importance,
@@ -617,12 +618,11 @@ class TestCheckUniqueIdentifiersFail(TestCase):
         rmtree(cls.tempdir)
 
     def test_check_unique_identifiers_fail(self):
-        print(list(inspect_all(path=self.tempdir, select=["check_data_orientation"])))
         assert list(inspect_all(path=self.tempdir, select=["check_data_orientation"])) == [
             InspectorMessage(
                 message=(
                     "The identifier 'not a unique identifier!' is used across the .nwb files: "
-                    f"{[str(x) for x in self.non_unique_id_nwbfile_paths]}\n"
+                    f"{natsorted([Path(x).name for x in self.non_unique_id_nwbfile_paths])}. "
                     "The identifier of any NWBFile should be a completely unique value - "
                     "we recommend using uuid4 to achieve this."
                 ),
@@ -631,6 +631,6 @@ class TestCheckUniqueIdentifiersFail(TestCase):
                 object_type="NWBFile",
                 object_name="root",
                 location="/",
-                file_path=str(Path(self.non_unique_id_nwbfile_paths[0]).parent),
+                file_path=str(self.tempdir),
             )
         ]


### PR DESCRIPTION
fix #157 

A very special one-of-a-kind check that isn't actually a function in the registry but rather a manual inspection triggered only when multiple files are detected from a folder path in `inspect_all` (or the analogous CLI call).

Extracts the identifiers of each file and checks to see if they are unique - if not, inform the user of which ones are in violation (iteratively over each non-unique identifier).