### PR TITLE
add checks and tests for bounds of radians and degrees

### DIFF
--- a/nwbinspector/checks/behavior.py
+++ b/nwbinspector/checks/behavior.py
@@ -1,4 +1,5 @@
 """Checks for types belonging to the pynwb.behavior module."""
+import numpy as np
 from pynwb.behavior import SpatialSeries, CompassDirection
 
 from ..register_checks import register_check, Importance, InspectorMessage
@@ -20,4 +21,24 @@ def check_compass_direction_unit(compass_direction: CompassDirection):
             yield InspectorMessage(
                 message=f"SpatialSeries objects inside a CompassDirection object should be angular and should have a "
                 f"unit of 'degrees' or 'radians', but '{spatial_series.name}' has units '{spatial_series.unit}'."
+            )
+
+
+@register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=SpatialSeries)
+def check_spatial_series_radians_magnitude(spatial_series: SpatialSeries, nelems: int = 200):
+    if spatial_series.unit in ("radian", "radians"):
+        data = spatial_series.data[:nelems]
+        if np.any(data > (2 * np.pi)) or np.any(data < (-2 * np.pi)):
+            return InspectorMessage(
+                message="SpatialSeries with units of radians must have values between -2pi and 2pi."
+            )
+
+
+@register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=SpatialSeries)
+def check_spatial_series_degrees_magnitude(spatial_series: SpatialSeries, nelems: int = 200):
+    if spatial_series.unit in ("degree", "degrees"):
+        data = spatial_series.data[:nelems]
+        if np.any(data > 360) or np.any(data < -360):
+            return InspectorMessage(
+                message="SpatialSeries with units of degrees must have values between -360 and 360."
             )

--- a/tests/unit_tests/test_behavior.py
+++ b/tests/unit_tests/test_behavior.py
@@ -113,9 +113,13 @@ def test_check_spatial_series_degrees_magnitude():
         unit="degrees",
     )
 
-    assert (
-        check_spatial_series_degrees_magnitude(spatial_series).message
-        == "SpatialSeries with units of degrees must have values between -360 and 360."
+    assert check_spatial_series_degrees_magnitude(spatial_series) == InspectorMessage(
+        check_function_name="check_spatial_series_degrees_magnitude",
+        message="SpatialSeries with units of degrees must have values between -360 and 360.",
+        importance=Importance.BEST_PRACTICE_VIOLATION,
+        object_name="SpatialSeries",
+        location="/",
+        object_type="SpatialSeries",
     )
 
 
@@ -144,7 +148,11 @@ def test_check_spatial_series_radians_magnitude():
         unit="radians",
     )
 
-    assert (
-        check_spatial_series_radians_magnitude(spatial_series).message == "SpatialSeries with units of radians "
-        "must have values between -2pi and 2pi."
+    assert check_spatial_series_radians_magnitude(spatial_series) == InspectorMessage(
+        check_function_name="check_spatial_series_radians_magnitude",
+        message="SpatialSeries with units of radians must have values between -2pi and 2pi.",
+        importance=Importance.BEST_PRACTICE_VIOLATION,
+        object_name="SpatialSeries",
+        location="/",
+        object_type="SpatialSeries",
     )

--- a/tests/unit_tests/test_behavior.py
+++ b/tests/unit_tests/test_behavior.py
@@ -2,7 +2,12 @@ from pynwb.behavior import SpatialSeries, CompassDirection
 import numpy as np
 
 from nwbinspector import InspectorMessage, Importance
-from nwbinspector.checks.behavior import check_compass_direction_unit, check_spatial_series_dims
+from nwbinspector.checks.behavior import (
+    check_compass_direction_unit,
+    check_spatial_series_dims,
+    check_spatial_series_degrees_magnitude,
+    check_spatial_series_radians_magnitude,
+)
 
 
 def test_check_spatial_series_dims():
@@ -81,3 +86,65 @@ def test_pass_check_compass_direction_unit():
         )
 
         assert check_compass_direction_unit(obj) is None
+
+
+def test_pass_check_spatial_series_degrees_magnitude():
+
+    spatial_series = SpatialSeries(
+        name="SpatialSeries",
+        description="description",
+        data=np.ones((10,)),
+        rate=3.0,
+        reference_frame="reference_frame",
+        unit="degrees",
+    )
+
+    assert check_spatial_series_degrees_magnitude(spatial_series) is None
+
+
+def test_check_spatial_series_degrees_magnitude():
+
+    spatial_series = SpatialSeries(
+        name="SpatialSeries",
+        description="description",
+        data=np.ones((10,)) * 400,
+        rate=3.0,
+        reference_frame="reference_frame",
+        unit="degrees",
+    )
+
+    assert (
+        check_spatial_series_degrees_magnitude(spatial_series).message
+        == "SpatialSeries with units of degrees must have values between -360 and 360."
+    )
+
+
+def test_pass_check_spatial_series_radians_magnitude():
+
+    spatial_series = SpatialSeries(
+        name="SpatialSeries",
+        description="description",
+        data=np.ones((10,)),
+        rate=3.0,
+        reference_frame="reference_frame",
+        unit="radians",
+    )
+
+    assert check_spatial_series_radians_magnitude(spatial_series) is None
+
+
+def test_check_spatial_series_radians_magnitude():
+
+    spatial_series = SpatialSeries(
+        name="SpatialSeries",
+        description="description",
+        data=np.ones((10,)) * 400,
+        rate=3.0,
+        reference_frame="reference_frame",
+        unit="radians",
+    )
+
+    assert (
+        check_spatial_series_radians_magnitude(spatial_series).message == "SpatialSeries with units of radians "
+        "must have values between -2pi and 2pi."
+    )


### PR DESCRIPTION
## Motivation

New check to ensure the range of values in any SpatialSeries with units radians or degrees correspond to the strict interior bounds of that unit (-2pi to 2pi for radians, -360 to 360 for degrees).


## Checklist

- [x] Have you ensured the PR description clearly describes the problem and solutions?
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/nwbinspector/pulls) for the same change?
- [x] Is your code contribution compliant with `black` format? If not, simply `pip install black` and run `black .` inside your fork.
- [x] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?
