### PR TITLE
Make Image checks and tests safe

### DIFF
--- a/nwbinspector/checks/images.py
+++ b/nwbinspector/checks/images.py
@@ -4,21 +4,28 @@ from pynwb.base import Images
 
 from ..register_checks import register_check, Importance, InspectorMessage
 
-
-@register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=Images)
-def check_order_of_images_unique(images: Images):
-    if images.order_of_images is None:
-        return
-    if not len(set(images.order_of_images)) == len(images.order_of_images):
-        return InspectorMessage(message="order_of_images should have unique values.")
+try:
+    from pynwb.base import Images
+    HAVE_IMAGES = True
+except ImportError:
+    HAVE_IMAGES = False
 
 
-@register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=Images)
-def check_order_of_images_len(images: Images):
-    if images.order_of_images is None:
-        return
-    if not len(images.order_of_images) == len(images.images):
-        return InspectorMessage(
-            message=f"Length of order_of_images ({len(images.order_of_images)}) does not match the number of images ("
-            f"{len(images.images)})."
-        )
+if HAVE_IMAGES:
+    @register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=Images)
+    def check_order_of_images_unique(images: Images):
+        if images.order_of_images is None:
+            return
+        if not len(set(images.order_of_images)) == len(images.order_of_images):
+            return InspectorMessage(message="order_of_images should have unique values.")
+
+
+    @register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=Images)
+    def check_order_of_images_len(images: Images):
+        if images.order_of_images is None:
+            return
+        if not len(images.order_of_images) == len(images.images):
+            return InspectorMessage(
+                message=f"Length of order_of_images ({len(images.order_of_images)}) does not match the number of images ("
+                f"{len(images.images)})."
+            )

--- a/nwbinspector/checks/images.py
+++ b/nwbinspector/checks/images.py
@@ -6,19 +6,20 @@ from ..register_checks import register_check, Importance, InspectorMessage
 
 try:
     from pynwb.base import Images
+
     HAVE_IMAGES = True
 except ImportError:
     HAVE_IMAGES = False
 
 
 if HAVE_IMAGES:
+
     @register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=Images)
     def check_order_of_images_unique(images: Images):
         if images.order_of_images is None:
             return
         if not len(set(images.order_of_images)) == len(images.order_of_images):
             return InspectorMessage(message="order_of_images should have unique values.")
-
 
     @register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=Images)
     def check_order_of_images_len(images: Images):

--- a/tests/unit_tests/test_images.py
+++ b/tests/unit_tests/test_images.py
@@ -7,14 +7,14 @@ from nwbinspector import InspectorMessage, Importance
 from nwbinspector.checks.images import check_order_of_images_unique, check_order_of_images_len
 
 try:
-    from pynwb.base import Images, ImageReferences
-    NOT_HAVE_PYNWB_GR_2_1_0 = True
-except:
-    NOT_HAVE_PYNWB_GR_2_1_0 = False
+    from pynwb.base import Images
+    HAVE_IMAGES = True
+except ImportError:
+    HAVE_IMAGES = False
 skip_reason = "You must have PyNWB>=v2.1.0 to run these tests!"
 
 
-@pytest.mark.skipif(NOT_HAVE_PYNWB_GR_2_1_0, reason=skip_reason)
+@pytest.mark.skipif(not HAVE_IMAGES, reason=skip_reason)
 def test_check_order_of_images_unique():
 
     imgs = [GrayscaleImage(name=f"image{i}", data=np.random.randn(10, 10)) for i in range(5)]
@@ -31,7 +31,7 @@ def test_check_order_of_images_unique():
     )
 
 
-@pytest.mark.skipif(NOT_HAVE_PYNWB_GR_2_1_0, reason=skip_reason)
+@pytest.mark.skipif(not HAVE_IMAGES, reason=skip_reason)
 def test_pass_check_order_of_images_unique():
 
     imgs = [GrayscaleImage(name=f"image{i}", data=np.random.randn(10, 10)) for i in range(5)]
@@ -41,7 +41,7 @@ def test_pass_check_order_of_images_unique():
     assert check_order_of_images_unique(images) is None
 
 
-@pytest.mark.skipif(NOT_HAVE_PYNWB_GR_2_1_0, reason=skip_reason)
+@pytest.mark.skipif(not HAVE_IMAGES, reason=skip_reason)
 def test_check_order_of_images_len():
 
     imgs = [GrayscaleImage(name=f"image{i}", data=np.random.randn(10, 10)) for i in range(5)]
@@ -58,7 +58,7 @@ def test_check_order_of_images_len():
     )
 
 
-@pytest.mark.skipif(NOT_HAVE_PYNWB_GR_2_1_0, reason=skip_reason)
+@pytest.mark.skipif(not HAVE_IMAGES, reason=skip_reason)
 def test_pass_check_order_of_images_len():
 
     imgs = [GrayscaleImage(name=f"image{i}", data=np.random.randn(10, 10)) for i in range(5)]

--- a/tests/unit_tests/test_images.py
+++ b/tests/unit_tests/test_images.py
@@ -7,7 +7,7 @@ from nwbinspector import InspectorMessage, Importance
 from nwbinspector.checks.images import check_order_of_images_unique, check_order_of_images_len
 
 try:
-    from pynwb.base import Images
+    from pynwb.base import Images, ImageReferences
 
     HAVE_IMAGES = True
 except ImportError:

--- a/tests/unit_tests/test_images.py
+++ b/tests/unit_tests/test_images.py
@@ -1,12 +1,20 @@
-import numpy as np
+import pytest
 
-from pynwb.base import Images, ImageReferences
+import numpy as np
 from pynwb.image import GrayscaleImage
 
 from nwbinspector import InspectorMessage, Importance
 from nwbinspector.checks.images import check_order_of_images_unique, check_order_of_images_len
 
+try:
+    from pynwb.base import Images, ImageReferences
+    NOT_HAVE_PYNWB_GR_2_1_0 = True
+except:
+    NOT_HAVE_PYNWB_GR_2_1_0 = False
+skip_reason = "You must have PyNWB>=v2.1.0 to run these tests!"
 
+
+@pytest.mark.skipif(NOT_HAVE_PYNWB_GR_2_1_0, reason=skip_reason)
 def test_check_order_of_images_unique():
 
     imgs = [GrayscaleImage(name=f"image{i}", data=np.random.randn(10, 10)) for i in range(5)]
@@ -23,6 +31,7 @@ def test_check_order_of_images_unique():
     )
 
 
+@pytest.mark.skipif(NOT_HAVE_PYNWB_GR_2_1_0, reason=skip_reason)
 def test_pass_check_order_of_images_unique():
 
     imgs = [GrayscaleImage(name=f"image{i}", data=np.random.randn(10, 10)) for i in range(5)]
@@ -32,6 +41,7 @@ def test_pass_check_order_of_images_unique():
     assert check_order_of_images_unique(images) is None
 
 
+@pytest.mark.skipif(NOT_HAVE_PYNWB_GR_2_1_0, reason=skip_reason)
 def test_check_order_of_images_len():
 
     imgs = [GrayscaleImage(name=f"image{i}", data=np.random.randn(10, 10)) for i in range(5)]
@@ -48,6 +58,7 @@ def test_check_order_of_images_len():
     )
 
 
+@pytest.mark.skipif(NOT_HAVE_PYNWB_GR_2_1_0, reason=skip_reason)
 def test_pass_check_order_of_images_len():
 
     imgs = [GrayscaleImage(name=f"image{i}", data=np.random.randn(10, 10)) for i in range(5)]

--- a/tests/unit_tests/test_images.py
+++ b/tests/unit_tests/test_images.py
@@ -8,6 +8,7 @@ from nwbinspector.checks.images import check_order_of_images_unique, check_order
 
 try:
     from pynwb.base import Images
+
     HAVE_IMAGES = True
 except ImportError:
     HAVE_IMAGES = False


### PR DESCRIPTION
## Motivation

Conda-forge testing compares against dependencies that are also installed from conda-forge. PyNWB 2.1.0 does not yet have a conda-forge release so it tests NWB Inspector against versions that don't have the new Images objects.

This makes loading of those checks safe for past PyNWB versions and disables those tests as well.

## Checklist

- [X] Have you ensured the PR description clearly describes the problem and solutions?
- [X] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/neurodatawithoutborders/nwbinspector/pulls) for the same change?
- [X] Is your code contribution compliant with `black` format? If not, simply `pip install black` and run `black .` inside your fork.
- [X] If this PR fixes an issue, is the first line of the PR description `fix #XX` where `XX` is the issue number?
