### PR TITLE
Add numpy >= 1.20 requirement

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,6 +21,8 @@ jobs:
           conda-channels: conda-forge
       - uses: actions/checkout@v2
       - run: git fetch --prune --unshallow --tags
+      - name: Install latest pip
+        run: pip install -U pip
       - name: Install pytest
         run: |
           pip install pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ packaging
 natsort
 click
 tqdm
+numpy >= 1.20


### PR DESCRIPTION
`nwbinspector/utils.py` imports `numpy.typing`, which was only introduced in numpy 1.20, yet the numpy version bounds in nwbinspector's dependencies permit installing earlier versions of numpy.  nwbinspector thus needs to declare a dependency on numpy >= 1.20 in order to ensure that a compatible version of numpy is present wherever nwbinspector is installed.