### PR TITLE
Enhance Subject.age support

### DIFF
--- a/nwbinspector/checks/nwbfile_metadata.py
+++ b/nwbinspector/checks/nwbfile_metadata.py
@@ -136,8 +136,8 @@ def check_subject_age(subject: Subject):
         message=(
             f"Subject age, '{subject.age}', does not follow ISO 8601 duration format, e.g. 'P2Y' for 2 years "
             "or 'P23W' for 23 weeks. You may also specify a range using a '/' separator, e.g., 'P1D/P3D' for an "
-            "age range somewhere from 1 to 3 days. If you cannot specify the upper bound of the range due to HIPAA "
-            "requirements, use '**' to leave it unspecified, e.g., 'P70Y/**' to mean an age greater than 70 years."
+            "age range somewhere from 1 to 3 days. If you cannot specify the upper bound of the range, "
+            "you may leave the right side blank, e.g., 'P90Y/' means 90 years old or older."
         )
     )
 

--- a/nwbinspector/checks/nwbfile_metadata.py
+++ b/nwbinspector/checks/nwbfile_metadata.py
@@ -1,6 +1,6 @@
 """Check functions that examine general NWBFile metadata."""
 import re
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from pandas import Timedelta
 from pynwb import NWBFile, ProcessingModule
@@ -13,7 +13,6 @@ duration_regex = (
     r"^P(?!$)(\d+(?:\.\d+)?Y)?(\d+(?:\.\d+)?M)?(\d+(?:\.\d+)?W)?(\d+(?:\.\d+)?D)?(T(?=\d)(\d+(?:\.\d+)?H)?(\d+(?:\.\d+)"
     r"?M)?(\d+(?:\.\d+)?S)?)?$"
 )
-duration_interval_regex = rf"^{duration_regex[1:-1]}/(\*\* | {duration_regex[1:-1]})$"
 species_regex = r"[A-Z][a-z]* [a-z]+"
 
 PROCESSING_MODULE_CONFIG = ["ophys", "ecephys", "icephys", "behavior", "misc", "ogen", "retinotopy"]

--- a/nwbinspector/checks/nwbfile_metadata.py
+++ b/nwbinspector/checks/nwbfile_metadata.py
@@ -128,7 +128,7 @@ def check_subject_age(subject: Subject):
         subject_lower_age_bound, subject_upper_age_bound = subject.age.split("/")
 
         if re.fullmatch(pattern=duration_regex, string=subject_lower_age_bound) and (
-            re.fullmatch(pattern=duration_regex, string=subject_upper_age_bound) or subject_upper_age_bound == "**"
+            re.fullmatch(pattern=duration_regex, string=subject_upper_age_bound) or subject_upper_age_bound == ""
         ):
             return
 

--- a/tests/unit_tests/test_nwbfile_metadata.py
+++ b/tests/unit_tests/test_nwbfile_metadata.py
@@ -383,7 +383,7 @@ def test_check_subject_proper_age_range_fail():
     subject = Subject(subject_id="001", sex="Male", age="P3D/P1D")
     assert check_subject_proper_age_range(subject) == InspectorMessage(
         message=(
-            f"The durations of the Subject age range, '{subject.age}', are not strictly increasing. "
+            "The durations of the Subject age range, 'P3D/P1D', are not strictly increasing. "
             "The upper (right) bound should be a longer duration than the lower (left) bound."
         ),
         importance=Importance.BEST_PRACTICE_SUGGESTION,

--- a/tests/unit_tests/test_nwbfile_metadata.py
+++ b/tests/unit_tests/test_nwbfile_metadata.py
@@ -317,10 +317,10 @@ def test_check_subject_age_iso8601_fail():
     subject = Subject(subject_id="001", sex="Male", age="9 months")
     assert check_subject_age(subject) == InspectorMessage(
         message=(
-            "Subject age, '9 months', does not follow ISO 8601 duration format, e.g. 'P2Y' for 2 years or 'P23W' "
-            "for 23 weeks. You may also specify a range using a '/' separator, e.g., 'P1D/P3D' for an "
-            "age range somewhere from 1 to 3 days. If you cannot specify the upper bound of the range due to HIPAA "
-            "requirements, use '**' to leave it unspecified, e.g., 'P70Y/**' to mean an age greater than 70 years."
+            "Subject age, '9 months', does not follow ISO 8601 duration format, e.g. 'P2Y' for 2 years "
+            "or 'P23W' for 23 weeks. You may also specify a range using a '/' separator, e.g., 'P1D/P3D' for an "
+            "age range somewhere from 1 to 3 days. If you cannot specify the upper bound of the range, "
+            "you may leave the right side blank, e.g., 'P90Y/' means 90 years old or older."
         ),
         importance=Importance.BEST_PRACTICE_SUGGESTION,
         check_function_name="check_subject_age",
@@ -336,7 +336,7 @@ def test_check_subject_age_iso8601_range_pass_1():
 
 
 def test_check_subject_age_iso8601_range_pass_2():
-    subject = Subject(subject_id="001", sex="Male", age="P1D/**")
+    subject = Subject(subject_id="001", sex="Male", age="P1D/")
     assert check_subject_age(subject) is None
 
 
@@ -344,10 +344,10 @@ def test_check_subject_age_iso8601_range_fail_1():
     subject = Subject(subject_id="001", sex="Male", age="9 months/12 months")
     assert check_subject_age(subject) == InspectorMessage(
         message=(
-            "Subject age, '9 months/12 months', does not follow ISO 8601 duration format, e.g. 'P2Y' for 2 years or "
-            "'P23W' for 23 weeks. You may also specify a range using a '/' separator, e.g., 'P1D/P3D' for an "
-            "age range somewhere from 1 to 3 days. If you cannot specify the upper bound of the range due to HIPAA "
-            "requirements, use '**' to leave it unspecified, e.g., 'P70Y/**' to mean an age greater than 70 years."
+            "Subject age, '9 months/12 months', does not follow ISO 8601 duration format, e.g. 'P2Y' for 2 years "
+            "or 'P23W' for 23 weeks. You may also specify a range using a '/' separator, e.g., 'P1D/P3D' for an "
+            "age range somewhere from 1 to 3 days. If you cannot specify the upper bound of the range, "
+            "you may leave the right side blank, e.g., 'P90Y/' means 90 years old or older."
         ),
         importance=Importance.BEST_PRACTICE_SUGGESTION,
         check_function_name="check_subject_age",
@@ -358,13 +358,13 @@ def test_check_subject_age_iso8601_range_fail_1():
 
 
 def test_check_subject_age_iso8601_range_fail_2():
-    subject = Subject(subject_id="001", sex="Male", age="9 months/**")
+    subject = Subject(subject_id="001", sex="Male", age="9 months/")
     assert check_subject_age(subject) == InspectorMessage(
         message=(
-            "Subject age, '9 months/**', does not follow ISO 8601 duration format, e.g. 'P2Y' for 2 years or 'P23W' "
-            "for 23 weeks. You may also specify a range using a '/' separator, e.g., 'P1D/P3D' for an "
-            "age range somewhere from 1 to 3 days. If you cannot specify the upper bound of the range due to HIPAA "
-            "requirements, use '**' to leave it unspecified, e.g., 'P70Y/**' to mean an age greater than 70 years."
+            "Subject age, '9 months/', does not follow ISO 8601 duration format, e.g. 'P2Y' for 2 years "
+            "or 'P23W' for 23 weeks. You may also specify a range using a '/' separator, e.g., 'P1D/P3D' for an "
+            "age range somewhere from 1 to 3 days. If you cannot specify the upper bound of the range, "
+            "you may leave the right side blank, e.g., 'P90Y/' means 90 years old or older."
         ),
         importance=Importance.BEST_PRACTICE_SUGGESTION,
         check_function_name="check_subject_age",

--- a/tests/unit_tests/test_nwbfile_metadata.py
+++ b/tests/unit_tests/test_nwbfile_metadata.py
@@ -292,7 +292,7 @@ def test_check_subject_sex_other_value():
 
 
 def test_pass_check_subject_age_with_dob():
-    subject = Subject(subject_id="001", sex="Male", date_of_birth=datetime.now())
+    subject = Subject(subject_id="001", sex="M", date_of_birth=datetime.now())
     assert check_subject_age(subject) is None
 
 

--- a/tests/unit_tests/test_nwbfile_metadata.py
+++ b/tests/unit_tests/test_nwbfile_metadata.py
@@ -1,5 +1,5 @@
 from uuid import uuid4
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timezone
 
 from pynwb import NWBFile, ProcessingModule
 from pynwb.file import Subject
@@ -17,6 +17,7 @@ from nwbinspector import (
     check_subject_id_exists,
     check_subject_sex,
     check_subject_age,
+    check_subject_proper_age_range,
     check_subject_species_exists,
     check_subject_species_latin_binomial,
     check_processing_module_name,
@@ -290,6 +291,11 @@ def test_check_subject_sex_other_value():
     )
 
 
+def test_pass_check_subject_age_with_dob():
+    subject = Subject(subject_id="001", sex="Male", date_of_birth=datetime.now())
+    assert check_subject_age(subject) is None
+
+
 def test_check_subject_age_missing():
     subject = Subject(subject_id="001", sex="Male")
     assert check_subject_age(subject) == InspectorMessage(
@@ -368,24 +374,24 @@ def test_check_subject_age_iso8601_range_fail_2():
     )
 
 
-def test_check_subject_age_iso8601_range_fail_3():
+def test_check_subject_proper_age_range_pass():
+    subject = Subject(subject_id="001", sex="Male", age="P1D/P3D")
+    assert check_subject_proper_age_range(subject) is None
+
+
+def test_check_subject_proper_age_range_fail():
     subject = Subject(subject_id="001", sex="Male", age="P3D/P1D")
-    assert check_subject_age(subject) == InspectorMessage(
+    assert check_subject_proper_age_range(subject) == InspectorMessage(
         message=(
             f"The durations of the Subject age range, '{subject.age}', are not strictly increasing. "
             "The upper (right) bound should be a longer duration than the lower (left) bound."
         ),
         importance=Importance.BEST_PRACTICE_SUGGESTION,
-        check_function_name="check_subject_age",
+        check_function_name="check_subject_proper_age_range",
         object_type="Subject",
         object_name="subject",
         location="/general/subject",
     )
-
-
-def test_pass_check_subject_age_with_dob():
-    subject = Subject(subject_id="001", sex="Male", date_of_birth=datetime.now())
-    assert check_subject_age(subject) is None
 
 
 def test_pass_check_subject_species_exists():

--- a/tests/unit_tests/test_nwbfile_metadata.py
+++ b/tests/unit_tests/test_nwbfile_metadata.py
@@ -344,8 +344,8 @@ def test_check_subject_age_iso8601_range_fail_1():
     subject = Subject(subject_id="001", sex="Male", age="9 months/12 months")
     assert check_subject_age(subject) == InspectorMessage(
         message=(
-            "Subject age, '9 months', does not follow ISO 8601 duration format, e.g. 'P2Y' for 2 years or 'P23W' "
-            "for 23 weeks. You may also specify a range using a '/' separator, e.g., 'P1D/P3D' for an "
+            "Subject age, '9 months/12 months', does not follow ISO 8601 duration format, e.g. 'P2Y' for 2 years or "
+            "'P23W' for 23 weeks. You may also specify a range using a '/' separator, e.g., 'P1D/P3D' for an "
             "age range somewhere from 1 to 3 days. If you cannot specify the upper bound of the range due to HIPAA "
             "requirements, use '**' to leave it unspecified, e.g., 'P70Y/**' to mean an age greater than 70 years."
         ),
@@ -361,7 +361,7 @@ def test_check_subject_age_iso8601_range_fail_2():
     subject = Subject(subject_id="001", sex="Male", age="9 months/**")
     assert check_subject_age(subject) == InspectorMessage(
         message=(
-            "Subject age, '9 months', does not follow ISO 8601 duration format, e.g. 'P2Y' for 2 years or 'P23W' "
+            "Subject age, '9 months/**', does not follow ISO 8601 duration format, e.g. 'P2Y' for 2 years or 'P23W' "
             "for 23 weeks. You may also specify a range using a '/' separator, e.g., 'P1D/P3D' for an "
             "age range somewhere from 1 to 3 days. If you cannot specify the upper bound of the range due to HIPAA "
             "requirements, use '**' to leave it unspecified, e.g., 'P70Y/**' to mean an age greater than 70 years."

--- a/tests/unit_tests/test_nwbfile_metadata.py
+++ b/tests/unit_tests/test_nwbfile_metadata.py
@@ -279,7 +279,7 @@ def test_check_subject_sex():
 
 
 def test_check_subject_sex_other_value():
-    subject = Subject(subject_id="001", sex="Male")
+    subject = Subject(subject_id="001", sex="Female")
 
     assert check_subject_sex(subject) == InspectorMessage(
         message="Subject.sex should be one of: 'M' (male), 'F' (female), 'O' (other), or 'U' (unknown).",
@@ -292,12 +292,12 @@ def test_check_subject_sex_other_value():
 
 
 def test_pass_check_subject_age_with_dob():
-    subject = Subject(subject_id="001", sex="M", date_of_birth=datetime.now())
+    subject = Subject(subject_id="001", sex="F", date_of_birth=datetime.now())
     assert check_subject_age(subject) is None
 
 
 def test_check_subject_age_missing():
-    subject = Subject(subject_id="001", sex="M")
+    subject = Subject(subject_id="001")
     assert check_subject_age(subject) == InspectorMessage(
         message="Subject is missing age and date_of_birth.",
         importance=Importance.BEST_PRACTICE_SUGGESTION,
@@ -309,12 +309,12 @@ def test_check_subject_age_missing():
 
 
 def test_check_subject_age_iso8601_pass():
-    subject = Subject(subject_id="001", sex="M", age="P1D")
+    subject = Subject(subject_id="001", age="P1D")
     assert check_subject_age(subject) is None
 
 
 def test_check_subject_age_iso8601_fail():
-    subject = Subject(subject_id="001", sex="Male", age="9 months")
+    subject = Subject(subject_id="001", age="9 months")
     assert check_subject_age(subject) == InspectorMessage(
         message=(
             "Subject age, '9 months', does not follow ISO 8601 duration format, e.g. 'P2Y' for 2 years "
@@ -331,17 +331,17 @@ def test_check_subject_age_iso8601_fail():
 
 
 def test_check_subject_age_iso8601_range_pass_1():
-    subject = Subject(subject_id="001", sex="Male", age="P1D/P3D")
+    subject = Subject(subject_id="001", age="P1D/P3D")
     assert check_subject_age(subject) is None
 
 
 def test_check_subject_age_iso8601_range_pass_2():
-    subject = Subject(subject_id="001", sex="Male", age="P1D/")
+    subject = Subject(subject_id="001", age="P1D/")
     assert check_subject_age(subject) is None
 
 
 def test_check_subject_age_iso8601_range_fail_1():
-    subject = Subject(subject_id="001", sex="Male", age="9 months/12 months")
+    subject = Subject(subject_id="001", age="9 months/12 months")
     assert check_subject_age(subject) == InspectorMessage(
         message=(
             "Subject age, '9 months/12 months', does not follow ISO 8601 duration format, e.g. 'P2Y' for 2 years "
@@ -358,7 +358,7 @@ def test_check_subject_age_iso8601_range_fail_1():
 
 
 def test_check_subject_age_iso8601_range_fail_2():
-    subject = Subject(subject_id="001", sex="Male", age="9 months/")
+    subject = Subject(subject_id="001", age="9 months/")
     assert check_subject_age(subject) == InspectorMessage(
         message=(
             "Subject age, '9 months/', does not follow ISO 8601 duration format, e.g. 'P2Y' for 2 years "
@@ -375,12 +375,12 @@ def test_check_subject_age_iso8601_range_fail_2():
 
 
 def test_check_subject_proper_age_range_pass():
-    subject = Subject(subject_id="001", sex="Male", age="P1D/P3D")
+    subject = Subject(subject_id="001", age="P1D/P3D")
     assert check_subject_proper_age_range(subject) is None
 
 
 def test_check_subject_proper_age_range_fail():
-    subject = Subject(subject_id="001", sex="Male", age="P3D/P1D")
+    subject = Subject(subject_id="001", age="P3D/P1D")
     assert check_subject_proper_age_range(subject) == InspectorMessage(
         message=(
             "The durations of the Subject age range, 'P3D/P1D', are not strictly increasing. "
@@ -430,7 +430,7 @@ def test_check_subject_species_not_binomial():
 
 
 def test_pass_check_subject_age():
-    subject = Subject(subject_id="001", sex="Male", age="P9M")
+    subject = Subject(subject_id="001", age="P9M")
     assert check_subject_age(subject) is None
 
 
@@ -447,12 +447,12 @@ def test_check_subject_exists():
 
 def test_pass_check_subject_exists():
     nwbfile = NWBFile(session_description="", identifier=str(uuid4()), session_start_time=datetime.now().astimezone())
-    nwbfile.subject = Subject(subject_id="001", sex="Male")
+    nwbfile.subject = Subject(subject_id="001")
     assert check_subject_exists(nwbfile) is None
 
 
 def test_check_subject_id_exists():
-    subject = Subject(sex="Male")
+    subject = Subject(sex="F")
     assert check_subject_id_exists(subject) == InspectorMessage(
         message="subject_id is missing.",
         importance=Importance.BEST_PRACTICE_SUGGESTION,

--- a/tests/unit_tests/test_nwbfile_metadata.py
+++ b/tests/unit_tests/test_nwbfile_metadata.py
@@ -297,7 +297,7 @@ def test_pass_check_subject_age_with_dob():
 
 
 def test_check_subject_age_missing():
-    subject = Subject(subject_id="001", sex="Male")
+    subject = Subject(subject_id="001", sex="M")
     assert check_subject_age(subject) == InspectorMessage(
         message="Subject is missing age and date_of_birth.",
         importance=Importance.BEST_PRACTICE_SUGGESTION,

--- a/tests/unit_tests/test_nwbfile_metadata.py
+++ b/tests/unit_tests/test_nwbfile_metadata.py
@@ -309,7 +309,7 @@ def test_check_subject_age_missing():
 
 
 def test_check_subject_age_iso8601_pass():
-    subject = Subject(subject_id="001", sex="Male", age="P1D")
+    subject = Subject(subject_id="001", sex="M", age="P1D")
     assert check_subject_age(subject) is None
 
 


### PR DESCRIPTION
WIP for the upcoming meeting

Adds greater support for the `subject.age` field, including a range specified with a `/` separator and wildcard `**` for the optional upper bound.

Added a bunch of tests for these cases, too.