### PR TITLE
Finish taking stock of remaining BP links

### DIFF
--- a/docs/best_practices/todo.rst
+++ b/docs/best_practices/todo.rst
@@ -29,43 +29,46 @@ TODO
 Add small section for this.
 
 
-
-.. _best_practice_time_intervals_stop_after_start:
-
-TODO
-----
-
 .. _best_practice_table_values_for_dict:
 
 TODO
 ----
+
+This is the JSON one for table values. Need to explain.
 
 .. _best_practice_col_not_nan:
 
 TODO
 ----
 
+Small section on this. Can maybe combine with above.
+
 .. _best_practice_intracellular_electrode_cell_id_exists:
 
 TODO
 ----
 
-.. _best_practice_electrical_series_dims:
-
-TODO
-----
+No `icephys` section yet.
 
 .. _best_practice_electrical_series_reference_electrodes_table:
 
 TODO
 ----
 
+Short section about this.
+
+
 .. _best_practice_spike_times_not_in_unobserved_interval:
 
 TODO
 ----
 
+Add a short section for this.
+
+
 .. _best_practice_roi_response_series_link_to_plane_segmentation:
 
 TODO
 ----
+
+Very similar to the electrode table one.

--- a/nwbinspector/checks/tables.py
+++ b/nwbinspector/checks/tables.py
@@ -155,7 +155,9 @@ def check_column_binary_capability(table: DynamicTable, nelems: int = 200):
 
 @register_check(importance=Importance.BEST_PRACTICE_SUGGESTION, neurodata_type=DynamicTable)
 def check_single_row(
-    table: DynamicTable, exclude_types: Optional[list] = (Units,), exclude_names: Optional[List[str]] = ("electrodes",),
+    table: DynamicTable,
+    exclude_types: Optional[list] = (Units,),
+    exclude_names: Optional[List[str]] = ("electrodes",),
 ):
     """
     Check if DynamicTable has only a single row; may be better represented by another data type.

--- a/nwbinspector/checks/tables.py
+++ b/nwbinspector/checks/tables.py
@@ -72,7 +72,7 @@ def check_time_intervals_stop_after_start(time_intervals: TimeIntervals, nelems:
     """
     Check that all stop times on a TimeInterval object occur after their corresponding start times.
 
-    Best Practice: :ref:``
+    Best Practice: :ref:`best_practice_time_interval_time_columns`
 
     Parameters
     ----------
@@ -155,9 +155,7 @@ def check_column_binary_capability(table: DynamicTable, nelems: int = 200):
 
 @register_check(importance=Importance.BEST_PRACTICE_SUGGESTION, neurodata_type=DynamicTable)
 def check_single_row(
-    table: DynamicTable,
-    exclude_types: Optional[list] = (Units,),
-    exclude_names: Optional[List[str]] = ("electrodes",),
+    table: DynamicTable, exclude_types: Optional[list] = (Units,), exclude_names: Optional[List[str]] = ("electrodes",),
 ):
     """
     Check if DynamicTable has only a single row; may be better represented by another data type.


### PR DESCRIPTION
The organizational work that began in #273 is finished here - all remaining check to BP links are now established, and the ones in the temporary `todo.rst` file are those remaining - now the only item that remains is to actually write each BP section, which will be done in subsequent PRs branching from this.