### PR TITLE
Add isort to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,5 @@
 repos:
+exclude: ^docs/
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0
     hooks:
@@ -9,9 +10,8 @@ repos:
     rev: 22.8.0
     hooks:
     -   id: black
-        exclude: ^docs/*$
 -   repo: https://github.com/PyCQA/isort
     rev: 5.8.0
     hooks:
     -   id: isort
-        exclude: ^(docs/*|nwbinspector/__init__\.py)$
+        exclude: ^nwbinspector/__init__\.py$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,4 +14,4 @@ repos:
     rev: 5.8.0
     hooks:
     -   id: isort
-        exclude: ^docs/*$
+        exclude: ^(docs/*|nwbinspector/__init__\.py)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,4 +9,9 @@ repos:
     rev: 22.8.0
     hooks:
     -   id: black
-        exclude: ^docs/
+        exclude: ^docs/*$
+-   repo: https://github.com/PyCQA/isort
+    rev: 5.8.0
+    hooks:
+    -   id: isort
+        exclude: ^docs/*$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,4 @@
 repos:
-exclude: ^docs/
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0
     hooks:
@@ -10,8 +9,13 @@ exclude: ^docs/
     rev: 22.8.0
     hooks:
     -   id: black
+        exclude: ^docs/
 -   repo: https://github.com/PyCQA/isort
     rev: 5.8.0
     hooks:
     -   id: isort
-        exclude: nwbinspector/__init__.py
+        exclude: |
+            (?x)^(
+                docs/|
+                nwbinspector/__init__.py
+            )$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,4 +14,4 @@ exclude: ^docs/
     rev: 5.8.0
     hooks:
     -   id: isort
-        exclude: ^nwbinspector/__init__\.py$
+        exclude: nwbinspector/__init__.py

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,5 @@
-from pathlib import Path
 import sys
+from pathlib import Path
 
 sys.path.append(str(Path(__file__).parent))
 from conf_extlinks import extlinks, intersphinx_mapping

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,5 @@
-import sys
 from pathlib import Path
+import sys
 
 sys.path.append(str(Path(__file__).parent))
 from conf_extlinks import extlinks, intersphinx_mapping

--- a/nwbinspector/__init__.py
+++ b/nwbinspector/__init__.py
@@ -1,3 +1,5 @@
+from .version import __version__
+
 from .register_checks import available_checks
 
 from .checks.behavior import *
@@ -14,4 +16,3 @@ from .checks.tables import *
 from .checks.time_series import *
 from .nwbinspector import inspect_all, inspect_nwb, load_config
 from .register_checks import Importance
-from .version import __version__

--- a/nwbinspector/__init__.py
+++ b/nwbinspector/__init__.py
@@ -1,9 +1,7 @@
-from .version import __version__
-from .register_checks import available_checks, Importance
-from .nwbinspector import inspect_nwb, inspect_all, load_config
 from .checks.behavior import *
 from .checks.ecephys import *
 from .checks.general import *
+from .checks.icephys import *
 from .checks.image_series import *
 from .checks.images import *
 from .checks.nwb_containers import *
@@ -12,4 +10,6 @@ from .checks.ogen import *
 from .checks.ophys import *
 from .checks.tables import *
 from .checks.time_series import *
-from .checks.icephys import *
+from .nwbinspector import inspect_all, inspect_nwb, load_config
+from .register_checks import Importance, available_checks
+from .version import __version__

--- a/nwbinspector/__init__.py
+++ b/nwbinspector/__init__.py
@@ -1,3 +1,5 @@
+from .register_checks import available_checks
+
 from .checks.behavior import *
 from .checks.ecephys import *
 from .checks.general import *
@@ -11,5 +13,5 @@ from .checks.ophys import *
 from .checks.tables import *
 from .checks.time_series import *
 from .nwbinspector import inspect_all, inspect_nwb, load_config
-from .register_checks import Importance, available_checks
+from .register_checks import Importance
 from .version import __version__

--- a/nwbinspector/checks/behavior.py
+++ b/nwbinspector/checks/behavior.py
@@ -1,8 +1,8 @@
 """Checks for types belonging to the pynwb.behavior module."""
 import numpy as np
-from pynwb.behavior import SpatialSeries, CompassDirection
+from pynwb.behavior import CompassDirection, SpatialSeries
 
-from ..register_checks import register_check, Importance, InspectorMessage
+from ..register_checks import Importance, InspectorMessage, register_check
 
 
 @register_check(importance=Importance.CRITICAL, neurodata_type=SpatialSeries)

--- a/nwbinspector/checks/ecephys.py
+++ b/nwbinspector/checks/ecephys.py
@@ -1,6 +1,6 @@
 """Check functions specific to extracellular electrophysiology neurodata types."""
-from hdmf.utils import get_data_shape
 import numpy as np
+from hdmf.utils import get_data_shape
 from pynwb.ecephys import ElectricalSeries
 from pynwb.misc import Units
 

--- a/nwbinspector/checks/ecephys.py
+++ b/nwbinspector/checks/ecephys.py
@@ -1,6 +1,6 @@
 """Check functions specific to extracellular electrophysiology neurodata types."""
-import numpy as np
 from hdmf.utils import get_data_shape
+import numpy as np
 from pynwb.ecephys import ElectricalSeries
 from pynwb.misc import Units
 

--- a/nwbinspector/checks/ecephys.py
+++ b/nwbinspector/checks/ecephys.py
@@ -1,12 +1,10 @@
 """Check functions specific to extracellular electrophysiology neurodata types."""
 import numpy as np
-
-from pynwb.misc import Units
-from pynwb.ecephys import ElectricalSeries
-
 from hdmf.utils import get_data_shape
+from pynwb.ecephys import ElectricalSeries
+from pynwb.misc import Units
 
-from ..register_checks import register_check, Importance, InspectorMessage
+from ..register_checks import Importance, InspectorMessage, register_check
 
 
 @register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=Units)

--- a/nwbinspector/checks/general.py
+++ b/nwbinspector/checks/general.py
@@ -1,5 +1,5 @@
 """Check functions that examine any general neurodata_type with the available attributes."""
-from ..register_checks import register_check, InspectorMessage, Importance
+from ..register_checks import Importance, InspectorMessage, register_check
 
 COMMON_DESCRIPTION_PLACEHOLDERS = ["no description", "no desc", "none", "placeholder"]
 

--- a/nwbinspector/checks/icephys.py
+++ b/nwbinspector/checks/icephys.py
@@ -1,6 +1,6 @@
 from pynwb.icephys import IntracellularElectrode
 
-from ..register_checks import register_check, Importance, InspectorMessage
+from ..register_checks import Importance, InspectorMessage, register_check
 
 
 @register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=IntracellularElectrode)

--- a/nwbinspector/checks/image_series.py
+++ b/nwbinspector/checks/image_series.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from pynwb.image import ImageSeries
 
-from ..register_checks import register_check, Importance, InspectorMessage
+from ..register_checks import Importance, InspectorMessage, register_check
 from ..tools import get_nwbfile_path_from_internal_object
 
 

--- a/nwbinspector/checks/images.py
+++ b/nwbinspector/checks/images.py
@@ -1,8 +1,7 @@
 from hdmf.utils import get_data_shape
-
 from pynwb.base import Images
 
-from ..register_checks import register_check, Importance, InspectorMessage
+from ..register_checks import Importance, InspectorMessage, register_check
 
 try:
     from pynwb.base import Images

--- a/nwbinspector/checks/nwb_containers.py
+++ b/nwbinspector/checks/nwb_containers.py
@@ -4,8 +4,8 @@ import os
 import h5py
 from pynwb import NWBContainer
 
-
-from ..register_checks import register_check, Importance, InspectorMessage, Severity
+from ..register_checks import (Importance, InspectorMessage, Severity,
+                               register_check)
 
 
 @register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=NWBContainer)

--- a/nwbinspector/checks/nwb_containers.py
+++ b/nwbinspector/checks/nwb_containers.py
@@ -4,8 +4,7 @@ import os
 import h5py
 from pynwb import NWBContainer
 
-from ..register_checks import (Importance, InspectorMessage, Severity,
-                               register_check)
+from ..register_checks import Importance, InspectorMessage, Severity, register_check
 
 
 @register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=NWBContainer)

--- a/nwbinspector/checks/nwbfile_metadata.py
+++ b/nwbinspector/checks/nwbfile_metadata.py
@@ -6,7 +6,7 @@ from pandas import Timedelta
 from pynwb import NWBFile, ProcessingModule
 from pynwb.file import Subject
 
-from ..register_checks import register_check, InspectorMessage, Importance
+from ..register_checks import Importance, InspectorMessage, register_check
 from ..utils import is_module_installed
 
 duration_regex = (
@@ -60,7 +60,8 @@ def check_experimenter_form(nwbfile: NWBFile):
     if nwbfile.experimenter is None:
         return
     if is_module_installed(module_name="dandi"):
-        from dandischema.models import NAME_PATTERN  # for most up to date version of the regex
+        from dandischema.models import \
+            NAME_PATTERN  # for most up to date version of the regex
     else:
         NAME_PATTERN = r"^([\w\s\-\.']+),\s+([\w\s\-\.']+)$"  # copied on 7/12/22
 

--- a/nwbinspector/checks/nwbfile_metadata.py
+++ b/nwbinspector/checks/nwbfile_metadata.py
@@ -1,6 +1,6 @@
 """Check functions that examine general NWBFile metadata."""
-import re
 from datetime import datetime
+import re
 
 from pandas import Timedelta
 from pynwb import NWBFile, ProcessingModule
@@ -60,8 +60,9 @@ def check_experimenter_form(nwbfile: NWBFile):
     if nwbfile.experimenter is None:
         return
     if is_module_installed(module_name="dandi"):
-        from dandischema.models import \
-            NAME_PATTERN  # for most up to date version of the regex
+        from dandischema.models import (
+            NAME_PATTERN,  # for most up to date version of the regex
+        )
     else:
         NAME_PATTERN = r"^([\w\s\-\.']+),\s+([\w\s\-\.']+)$"  # copied on 7/12/22
 

--- a/nwbinspector/checks/nwbfile_metadata.py
+++ b/nwbinspector/checks/nwbfile_metadata.py
@@ -1,6 +1,6 @@
 """Check functions that examine general NWBFile metadata."""
-from datetime import datetime
 import re
+from datetime import datetime
 
 from pandas import Timedelta
 from pynwb import NWBFile, ProcessingModule

--- a/nwbinspector/checks/ogen.py
+++ b/nwbinspector/checks/ogen.py
@@ -1,6 +1,6 @@
 from pynwb.ogen import OptogeneticSeries, OptogeneticStimulusSite
 
-from ..register_checks import register_check, Importance, InspectorMessage
+from ..register_checks import Importance, InspectorMessage, register_check
 
 
 @register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=OptogeneticStimulusSite)

--- a/nwbinspector/checks/ophys.py
+++ b/nwbinspector/checks/ophys.py
@@ -1,14 +1,9 @@
 """Check functions specific to optical electrophysiology neurodata types."""
-from pynwb.ophys import (
-    RoiResponseSeries,
-    PlaneSegmentation,
-    OpticalChannel,
-    ImagingPlane,
-)
-
 from hdmf.utils import get_data_shape
+from pynwb.ophys import (ImagingPlane, OpticalChannel, PlaneSegmentation,
+                         RoiResponseSeries)
 
-from ..register_checks import register_check, Importance, InspectorMessage
+from ..register_checks import Importance, InspectorMessage, register_check
 
 MIN_LAMBDA = 10.0  # trigger warnings for wavelength values less than this value
 

--- a/nwbinspector/checks/ophys.py
+++ b/nwbinspector/checks/ophys.py
@@ -1,7 +1,11 @@
 """Check functions specific to optical electrophysiology neurodata types."""
 from hdmf.utils import get_data_shape
-from pynwb.ophys import (ImagingPlane, OpticalChannel, PlaneSegmentation,
-                         RoiResponseSeries)
+from pynwb.ophys import (
+    ImagingPlane,
+    OpticalChannel,
+    PlaneSegmentation,
+    RoiResponseSeries,
+)
 
 from ..register_checks import Importance, InspectorMessage, register_check
 

--- a/nwbinspector/checks/tables.py
+++ b/nwbinspector/checks/tables.py
@@ -2,9 +2,9 @@
 from numbers import Real
 from typing import List, Optional
 
+import numpy as np
 from hdmf.common import DynamicTable, DynamicTableRegion, VectorIndex
 from hdmf.utils import get_data_shape
-import numpy as np
 from pynwb.file import TimeIntervals, Units
 
 from ..register_checks import Importance, InspectorMessage, register_check

--- a/nwbinspector/checks/tables.py
+++ b/nwbinspector/checks/tables.py
@@ -7,14 +7,10 @@ from hdmf.common import DynamicTable, DynamicTableRegion, VectorIndex
 from hdmf.utils import get_data_shape
 from pynwb.file import TimeIntervals, Units
 
-from ..register_checks import register_check, InspectorMessage, Importance
-from ..utils import (
-    _cache_data_selection,
-    format_byte_size,
-    is_ascending_series,
-    is_dict_in_string,
-    is_string_json_loadable,
-)
+from ..register_checks import Importance, InspectorMessage, register_check
+from ..utils import (_cache_data_selection, format_byte_size,
+                     is_ascending_series, is_dict_in_string,
+                     is_string_json_loadable)
 
 
 @register_check(importance=Importance.CRITICAL, neurodata_type=DynamicTableRegion)

--- a/nwbinspector/checks/tables.py
+++ b/nwbinspector/checks/tables.py
@@ -2,15 +2,19 @@
 from numbers import Real
 from typing import List, Optional
 
-import numpy as np
 from hdmf.common import DynamicTable, DynamicTableRegion, VectorIndex
 from hdmf.utils import get_data_shape
+import numpy as np
 from pynwb.file import TimeIntervals, Units
 
 from ..register_checks import Importance, InspectorMessage, register_check
-from ..utils import (_cache_data_selection, format_byte_size,
-                     is_ascending_series, is_dict_in_string,
-                     is_string_json_loadable)
+from ..utils import (
+    _cache_data_selection,
+    format_byte_size,
+    is_ascending_series,
+    is_dict_in_string,
+    is_string_json_loadable,
+)
 
 
 @register_check(importance=Importance.CRITICAL, neurodata_type=DynamicTableRegion)

--- a/nwbinspector/checks/time_series.py
+++ b/nwbinspector/checks/time_series.py
@@ -1,11 +1,11 @@
 """Check functions that can apply to any descendant of TimeSeries."""
 import numpy as np
-
 from pynwb import TimeSeries
 
 # from ..tools import all_of_type
-from ..register_checks import register_check, Importance, Severity, InspectorMessage
-from ..utils import is_regular_series, is_ascending_series
+from ..register_checks import (Importance, InspectorMessage, Severity,
+                               register_check)
+from ..utils import is_ascending_series, is_regular_series
 
 
 @register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=TimeSeries)

--- a/nwbinspector/checks/time_series.py
+++ b/nwbinspector/checks/time_series.py
@@ -3,8 +3,7 @@ import numpy as np
 from pynwb import TimeSeries
 
 # from ..tools import all_of_type
-from ..register_checks import (Importance, InspectorMessage, Severity,
-                               register_check)
+from ..register_checks import Importance, InspectorMessage, Severity, register_check
 from ..utils import is_ascending_series, is_regular_series
 
 

--- a/nwbinspector/inspector_tools.py
+++ b/nwbinspector/inspector_tools.py
@@ -1,15 +1,15 @@
 """Internally used tools specifically for rendering more human-readable output from collected check results."""
-import os
-import sys
 from collections import defaultdict
 from datetime import datetime
 from enum import Enum
+import os
 from pathlib import Path
 from platform import platform
+import sys
 from typing import Dict, List, Optional, Union
 
-import numpy as np
 from natsort import natsorted
+import numpy as np
 
 from .register_checks import Importance, InspectorMessage
 from .utils import FilePathType, get_package_version

--- a/nwbinspector/inspector_tools.py
+++ b/nwbinspector/inspector_tools.py
@@ -1,18 +1,17 @@
 """Internally used tools specifically for rendering more human-readable output from collected check results."""
 import os
 import sys
-from typing import Dict, List, Optional, Union
-from pathlib import Path
-from enum import Enum
-from datetime import datetime
-from platform import platform
 from collections import defaultdict
-
-from natsort import natsorted
+from datetime import datetime
+from enum import Enum
+from pathlib import Path
+from platform import platform
+from typing import Dict, List, Optional, Union
 
 import numpy as np
+from natsort import natsorted
 
-from .register_checks import InspectorMessage, Importance
+from .register_checks import Importance, InspectorMessage
 from .utils import FilePathType, get_package_version
 
 

--- a/nwbinspector/inspector_tools.py
+++ b/nwbinspector/inspector_tools.py
@@ -1,15 +1,15 @@
 """Internally used tools specifically for rendering more human-readable output from collected check results."""
+import os
+import sys
 from collections import defaultdict
 from datetime import datetime
 from enum import Enum
-import os
 from pathlib import Path
 from platform import platform
-import sys
 from typing import Dict, List, Optional, Union
 
-from natsort import natsorted
 import numpy as np
+from natsort import natsorted
 
 from .register_checks import Importance, InspectorMessage
 from .utils import FilePathType, get_package_version

--- a/nwbinspector/nwbinspector.py
+++ b/nwbinspector/nwbinspector.py
@@ -1,25 +1,25 @@
 """Primary functions for inspecting NWBFiles."""
+import importlib
+import json
+import os
+import re
+import traceback
 from collections import defaultdict
 from collections.abc import Iterable
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from distutils.util import strtobool
 from enum import Enum
-import importlib
-import json
-import os
 from pathlib import Path
-import re
-import traceback
 from types import FunctionType
 from typing import List, Optional, Union
 from warnings import filterwarnings, warn
 
 import click
 import jsonschema
-from natsort import natsorted
 import pynwb
-from tqdm import tqdm
 import yaml
+from natsort import natsorted
+from tqdm import tqdm
 
 from . import available_checks
 from .inspector_tools import (

--- a/nwbinspector/nwbinspector.py
+++ b/nwbinspector/nwbinspector.py
@@ -1,36 +1,33 @@
 """Primary functions for inspecting NWBFiles."""
+import importlib
+import json
 import os
 import re
-import importlib
 import traceback
-import json
-import jsonschema
-from pathlib import Path
-from collections.abc import Iterable
-from enum import Enum
-from typing import Union, Optional, List
-from concurrent.futures import ProcessPoolExecutor, as_completed
-from types import FunctionType
-from warnings import filterwarnings, warn
-from distutils.util import strtobool
 from collections import defaultdict
+from collections.abc import Iterable
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from distutils.util import strtobool
+from enum import Enum
+from pathlib import Path
+from types import FunctionType
+from typing import List, Optional, Union
+from warnings import filterwarnings, warn
 
 import click
+import jsonschema
 import pynwb
 import yaml
-from tqdm import tqdm
 from natsort import natsorted
+from tqdm import tqdm
 
 from . import available_checks
-from .inspector_tools import (
-    get_report_header,
-    format_messages,
-    print_to_console,
-    save_report,
-)
-from .register_checks import InspectorMessage, Importance
+from .inspector_tools import (format_messages, get_report_header,
+                              print_to_console, save_report)
+from .register_checks import Importance, InspectorMessage
 from .tools import get_s3_urls_and_dandi_paths
-from .utils import FilePathType, PathType, OptionalListOfStrings, robust_s3_read, calculate_number_of_cpu
+from .utils import (FilePathType, OptionalListOfStrings, PathType,
+                    calculate_number_of_cpu, robust_s3_read)
 
 INTERNAL_CONFIGS = dict(dandi=Path(__file__).parent / "internal_configs" / "dandi.inspector_config.yaml")
 

--- a/nwbinspector/nwbinspector.py
+++ b/nwbinspector/nwbinspector.py
@@ -1,33 +1,42 @@
 """Primary functions for inspecting NWBFiles."""
-import importlib
-import json
-import os
-import re
-import traceback
 from collections import defaultdict
 from collections.abc import Iterable
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from distutils.util import strtobool
 from enum import Enum
+import importlib
+import json
+import os
 from pathlib import Path
+import re
+import traceback
 from types import FunctionType
 from typing import List, Optional, Union
 from warnings import filterwarnings, warn
 
 import click
 import jsonschema
-import pynwb
-import yaml
 from natsort import natsorted
+import pynwb
 from tqdm import tqdm
+import yaml
 
 from . import available_checks
-from .inspector_tools import (format_messages, get_report_header,
-                              print_to_console, save_report)
+from .inspector_tools import (
+    format_messages,
+    get_report_header,
+    print_to_console,
+    save_report,
+)
 from .register_checks import Importance, InspectorMessage
 from .tools import get_s3_urls_and_dandi_paths
-from .utils import (FilePathType, OptionalListOfStrings, PathType,
-                    calculate_number_of_cpu, robust_s3_read)
+from .utils import (
+    FilePathType,
+    OptionalListOfStrings,
+    PathType,
+    calculate_number_of_cpu,
+    robust_s3_read,
+)
 
 INTERNAL_CONFIGS = dict(dandi=Path(__file__).parent / "internal_configs" / "dandi.inspector_config.yaml")
 

--- a/nwbinspector/register_checks.py
+++ b/nwbinspector/register_checks.py
@@ -1,14 +1,14 @@
 """Primary decorator used on a check function to add it to the registry and automatically parse its output."""
 from collections.abc import Iterable
-from functools import wraps
-from enum import Enum
 from dataclasses import dataclass
+from enum import Enum
+from functools import wraps
 from typing import Optional
 
 import h5py
 from pynwb import NWBFile
-from pynwb.file import Subject
 from pynwb.ecephys import Device, ElectrodeGroup
+from pynwb.file import Subject
 
 
 class Importance(Enum):

--- a/nwbinspector/testing.py
+++ b/nwbinspector/testing.py
@@ -1,7 +1,7 @@
 """Helper functions for internal use across the testing suite."""
 import os
 from distutils.util import strtobool
-from typing import Tuple, Optional
+from typing import Optional, Tuple
 
 from .tools import check_streaming_enabled
 from .utils import is_module_installed

--- a/nwbinspector/testing.py
+++ b/nwbinspector/testing.py
@@ -1,6 +1,6 @@
 """Helper functions for internal use across the testing suite."""
-from distutils.util import strtobool
 import os
+from distutils.util import strtobool
 from typing import Optional, Tuple
 
 from .tools import check_streaming_enabled

--- a/nwbinspector/testing.py
+++ b/nwbinspector/testing.py
@@ -1,6 +1,6 @@
 """Helper functions for internal use across the testing suite."""
-import os
 from distutils.util import strtobool
+import os
 from typing import Optional, Tuple
 
 from .tools import check_streaming_enabled

--- a/nwbinspector/tools.py
+++ b/nwbinspector/tools.py
@@ -1,7 +1,7 @@
 """Helper functions for internal use that rely on external dependencies (i.e., pynwb)."""
+import re
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from datetime import datetime
-import re
 from typing import Dict, Optional, Tuple
 from urllib import request
 from uuid import uuid4

--- a/nwbinspector/tools.py
+++ b/nwbinspector/tools.py
@@ -1,7 +1,7 @@
 """Helper functions for internal use that rely on external dependencies (i.e., pynwb)."""
-import re
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from datetime import datetime
+import re
 from typing import Dict, Optional, Tuple
 from urllib import request
 from uuid import uuid4

--- a/nwbinspector/tools.py
+++ b/nwbinspector/tools.py
@@ -1,16 +1,16 @@
 """Helper functions for internal use that rely on external dependencies (i.e., pynwb)."""
 import re
-from uuid import uuid4
-from datetime import datetime
-from typing import Optional, Dict, Tuple
 from concurrent.futures import ProcessPoolExecutor, as_completed
+from datetime import datetime
+from typing import Dict, Optional, Tuple
 from urllib import request
+from uuid import uuid4
 from warnings import warn
 
 import h5py
 from pynwb import NWBFile
 
-from .utils import is_module_installed, calculate_number_of_cpu
+from .utils import calculate_number_of_cpu, is_module_installed
 
 
 def make_minimal_nwbfile():

--- a/nwbinspector/utils.py
+++ b/nwbinspector/utils.py
@@ -1,18 +1,17 @@
 """Commonly reused logic for evaluating conditions; must not have external dependencies."""
+import json
 import os
 import re
-import json
-from typing import TypeVar, Union, Optional, List, Dict, Callable, Tuple
-from pathlib import Path
-from importlib import import_module
-from packaging import version
-from time import sleep
 from functools import lru_cache
+from importlib import import_module
+from pathlib import Path
+from time import sleep
+from typing import Callable, Dict, List, Optional, Tuple, TypeVar, Union
 
 import h5py
 import numpy as np
 from numpy.typing import ArrayLike
-
+from packaging import version
 
 PathType = TypeVar("PathType", str, Path)  # For types that can be either files or folders
 FilePathType = TypeVar("FilePathType", str, Path)

--- a/nwbinspector/utils.py
+++ b/nwbinspector/utils.py
@@ -1,10 +1,10 @@
 """Commonly reused logic for evaluating conditions; must not have external dependencies."""
-import json
-import os
-import re
 from functools import lru_cache
 from importlib import import_module
+import json
+import os
 from pathlib import Path
+import re
 from time import sleep
 from typing import Callable, Dict, List, Optional, Tuple, TypeVar, Union
 

--- a/nwbinspector/utils.py
+++ b/nwbinspector/utils.py
@@ -1,10 +1,10 @@
 """Commonly reused logic for evaluating conditions; must not have external dependencies."""
-from functools import lru_cache
-from importlib import import_module
 import json
 import os
-from pathlib import Path
 import re
+from functools import lru_cache
+from importlib import import_module
+from pathlib import Path
 from time import sleep
 from typing import Callable, Dict, List, Optional, Tuple, TypeVar, Union
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,5 @@ force-exclude = '''
 
 [tool.isort]
 profile = "black"
-force_sort_within_sections = true
 reverse_relative = true
-sort_relative_in_force_sorted_sections = true
 known_first_party = ["nwbinspector"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,3 +25,10 @@ force-exclude = '''
    /docs/*
 )\
 '''
+
+[tool.isort]
+profile = "black"
+force_sort_within_sections = true
+reverse_relative = true
+sort_relative_in_force_sorted_sections = true
+known_first_party = ["nwbinspector"]

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
-from setuptools import setup, find_packages
 from pathlib import Path
+
+from setuptools import find_packages, setup
 
 root = Path(__file__).parent
 with open(root / "README.md", "r") as f:

--- a/tests/test_check_configuration.py
+++ b/tests/test_check_configuration.py
@@ -2,12 +2,20 @@ from unittest import TestCase
 
 from jsonschema import ValidationError
 
-from nwbinspector import (Importance, available_checks, check_data_orientation,
-                          check_regular_timestamps,
-                          check_small_dataset_compression,
-                          check_timestamps_match_first_dimension)
-from nwbinspector.nwbinspector import (_copy_function, configure_checks,
-                                       load_config, validate_config)
+from nwbinspector import (
+    Importance,
+    available_checks,
+    check_data_orientation,
+    check_regular_timestamps,
+    check_small_dataset_compression,
+    check_timestamps_match_first_dimension,
+)
+from nwbinspector.nwbinspector import (
+    _copy_function,
+    configure_checks,
+    load_config,
+    validate_config,
+)
 
 
 class TestCheckConfiguration(TestCase):

--- a/tests/test_check_configuration.py
+++ b/tests/test_check_configuration.py
@@ -1,15 +1,13 @@
-from jsonschema import ValidationError
 from unittest import TestCase
 
-from nwbinspector import (
-    Importance,
-    check_small_dataset_compression,
-    check_regular_timestamps,
-    check_data_orientation,
-    check_timestamps_match_first_dimension,
-    available_checks,
-)
-from nwbinspector.nwbinspector import validate_config, configure_checks, _copy_function, load_config
+from jsonschema import ValidationError
+
+from nwbinspector import (Importance, available_checks, check_data_orientation,
+                          check_regular_timestamps,
+                          check_small_dataset_compression,
+                          check_timestamps_match_first_dimension)
+from nwbinspector.nwbinspector import (_copy_function, configure_checks,
+                                       load_config, validate_config)
 
 
 class TestCheckConfiguration(TestCase):

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -1,17 +1,17 @@
-from datetime import datetime
 import os
+from datetime import datetime
 from pathlib import Path
 from shutil import rmtree
 from tempfile import mkdtemp
 from unittest import TestCase
 
+import numpy as np
+import pytest
 from hdmf.common import DynamicTable
 from natsort import natsorted
-import numpy as np
 from pynwb import NWBHDF5IO, NWBFile, TimeSeries
 from pynwb.behavior import Position, SpatialSeries
 from pynwb.file import TimeIntervals
-import pytest
 
 from nwbinspector import (
     Importance,

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -1,29 +1,26 @@
 import os
-import pytest
+from datetime import datetime
+from pathlib import Path
 from shutil import rmtree
 from tempfile import mkdtemp
-from pathlib import Path
 from unittest import TestCase
-from datetime import datetime
 
 import numpy as np
-from pynwb import NWBFile, NWBHDF5IO, TimeSeries
-from pynwb.file import TimeIntervals
-from pynwb.behavior import SpatialSeries, Position
+import pytest
 from hdmf.common import DynamicTable
 from natsort import natsorted
+from pynwb import NWBHDF5IO, NWBFile, TimeSeries
+from pynwb.behavior import Position, SpatialSeries
+from pynwb.file import TimeIntervals
 
-from nwbinspector import (
-    Importance,
-    check_small_dataset_compression,
-    check_regular_timestamps,
-    check_data_orientation,
-    check_timestamps_match_first_dimension,
-    check_subject_exists,
-    load_config,
-)
-from nwbinspector import inspect_all, inspect_nwb
-from nwbinspector.register_checks import Severity, InspectorMessage, register_check
+from nwbinspector import (Importance, check_data_orientation,
+                          check_regular_timestamps,
+                          check_small_dataset_compression,
+                          check_subject_exists,
+                          check_timestamps_match_first_dimension, inspect_all,
+                          inspect_nwb, load_config)
+from nwbinspector.register_checks import (InspectorMessage, Severity,
+                                          register_check)
 from nwbinspector.testing import check_streaming_tests_enabled
 from nwbinspector.tools import make_minimal_nwbfile
 from nwbinspector.utils import FilePathType

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -1,26 +1,30 @@
-import os
 from datetime import datetime
+import os
 from pathlib import Path
 from shutil import rmtree
 from tempfile import mkdtemp
 from unittest import TestCase
 
-import numpy as np
-import pytest
 from hdmf.common import DynamicTable
 from natsort import natsorted
+import numpy as np
 from pynwb import NWBHDF5IO, NWBFile, TimeSeries
 from pynwb.behavior import Position, SpatialSeries
 from pynwb.file import TimeIntervals
+import pytest
 
-from nwbinspector import (Importance, check_data_orientation,
-                          check_regular_timestamps,
-                          check_small_dataset_compression,
-                          check_subject_exists,
-                          check_timestamps_match_first_dimension, inspect_all,
-                          inspect_nwb, load_config)
-from nwbinspector.register_checks import (InspectorMessage, Severity,
-                                          register_check)
+from nwbinspector import (
+    Importance,
+    check_data_orientation,
+    check_regular_timestamps,
+    check_small_dataset_compression,
+    check_subject_exists,
+    check_timestamps_match_first_dimension,
+    inspect_all,
+    inspect_nwb,
+    load_config,
+)
+from nwbinspector.register_checks import InspectorMessage, Severity, register_check
 from nwbinspector.testing import check_streaming_tests_enabled
 from nwbinspector.tools import make_minimal_nwbfile
 from nwbinspector.utils import FilePathType

--- a/tests/test_register_check.py
+++ b/tests/test_register_check.py
@@ -4,7 +4,8 @@ from hdmf.common import DynamicTable
 from hdmf.testing import TestCase
 from pynwb import TimeSeries
 
-from nwbinspector.register_checks import register_check, Importance, Severity, InspectorMessage
+from nwbinspector.register_checks import (Importance, InspectorMessage,
+                                          Severity, register_check)
 
 
 class TestRegisterClass(TestCase):

--- a/tests/test_register_check.py
+++ b/tests/test_register_check.py
@@ -4,8 +4,12 @@ from hdmf.common import DynamicTable
 from hdmf.testing import TestCase
 from pynwb import TimeSeries
 
-from nwbinspector.register_checks import (Importance, InspectorMessage,
-                                          Severity, register_check)
+from nwbinspector.register_checks import (
+    Importance,
+    InspectorMessage,
+    Severity,
+    register_check,
+)
 
 
 class TestRegisterClass(TestCase):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,9 +1,9 @@
 from datetime import datetime
 from uuid import uuid4
 
-from hdmf.testing import TestCase
 import numpy as np
 import pynwb
+from hdmf.testing import TestCase
 
 from nwbinspector.inspector_tools import organize_messages
 from nwbinspector.register_checks import Importance, InspectorMessage, Severity

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,9 +1,9 @@
 from datetime import datetime
 from uuid import uuid4
 
+from hdmf.testing import TestCase
 import numpy as np
 import pynwb
-from hdmf.testing import TestCase
 
 from nwbinspector.inspector_tools import organize_messages
 from nwbinspector.register_checks import Importance, InspectorMessage, Severity

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,13 +1,13 @@
-import numpy as np
-from uuid import uuid4
 from datetime import datetime
+from uuid import uuid4
 
+import numpy as np
 import pynwb
 from hdmf.testing import TestCase
 
-from nwbinspector.tools import all_of_type
 from nwbinspector.inspector_tools import organize_messages
-from nwbinspector.register_checks import InspectorMessage, Importance, Severity
+from nwbinspector.register_checks import Importance, InspectorMessage, Severity
+from nwbinspector.tools import all_of_type
 
 
 def test_all_of_type():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,9 +4,13 @@ from hdmf.testing import TestCase
 from packaging import version
 
 from nwbinspector import Importance
-from nwbinspector.utils import (calculate_number_of_cpu, format_byte_size,
-                                get_package_version, is_dict_in_string,
-                                is_regular_series)
+from nwbinspector.utils import (
+    calculate_number_of_cpu,
+    format_byte_size,
+    get_package_version,
+    is_dict_in_string,
+    is_regular_series,
+)
 
 
 def test_format_byte_size():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,16 +1,12 @@
 import os
-from packaging import version
 
 from hdmf.testing import TestCase
+from packaging import version
 
 from nwbinspector import Importance
-from nwbinspector.utils import (
-    format_byte_size,
-    is_regular_series,
-    is_dict_in_string,
-    get_package_version,
-    calculate_number_of_cpu,
-)
+from nwbinspector.utils import (calculate_number_of_cpu, format_byte_size,
+                                get_package_version, is_dict_in_string,
+                                is_regular_series)
 
 
 def test_format_byte_size():

--- a/tests/unit_tests/test_behavior.py
+++ b/tests/unit_tests/test_behavior.py
@@ -1,13 +1,10 @@
-from pynwb.behavior import SpatialSeries, CompassDirection
 import numpy as np
+from pynwb.behavior import CompassDirection, SpatialSeries
 
-from nwbinspector import InspectorMessage, Importance
+from nwbinspector import Importance, InspectorMessage
 from nwbinspector.checks.behavior import (
-    check_compass_direction_unit,
-    check_spatial_series_dims,
-    check_spatial_series_degrees_magnitude,
-    check_spatial_series_radians_magnitude,
-)
+    check_compass_direction_unit, check_spatial_series_degrees_magnitude,
+    check_spatial_series_dims, check_spatial_series_radians_magnitude)
 
 
 def test_check_spatial_series_dims():

--- a/tests/unit_tests/test_behavior.py
+++ b/tests/unit_tests/test_behavior.py
@@ -3,8 +3,11 @@ from pynwb.behavior import CompassDirection, SpatialSeries
 
 from nwbinspector import Importance, InspectorMessage
 from nwbinspector.checks.behavior import (
-    check_compass_direction_unit, check_spatial_series_degrees_magnitude,
-    check_spatial_series_dims, check_spatial_series_radians_magnitude)
+    check_compass_direction_unit,
+    check_spatial_series_degrees_magnitude,
+    check_spatial_series_dims,
+    check_spatial_series_radians_magnitude,
+)
 
 
 def test_check_spatial_series_dims():

--- a/tests/unit_tests/test_containers.py
+++ b/tests/unit_tests/test_containers.py
@@ -1,20 +1,17 @@
-from pathlib import Path
-from tempfile import mkdtemp
-from shutil import rmtree
-from unittest import TestCase
 from datetime import datetime
+from pathlib import Path
+from shutil import rmtree
+from tempfile import mkdtemp
+from unittest import TestCase
 
 import h5py
 import numpy as np
 from pynwb import NWBContainer, NWBFile
 
-from nwbinspector import (
-    InspectorMessage,
-    Importance,
-    check_small_dataset_compression,
-    check_large_dataset_compression,
-    check_empty_string_for_optional_attribute,
-)
+from nwbinspector import (Importance, InspectorMessage,
+                          check_empty_string_for_optional_attribute,
+                          check_large_dataset_compression,
+                          check_small_dataset_compression)
 from nwbinspector.register_checks import Severity
 
 

--- a/tests/unit_tests/test_containers.py
+++ b/tests/unit_tests/test_containers.py
@@ -8,10 +8,13 @@ import h5py
 import numpy as np
 from pynwb import NWBContainer, NWBFile
 
-from nwbinspector import (Importance, InspectorMessage,
-                          check_empty_string_for_optional_attribute,
-                          check_large_dataset_compression,
-                          check_small_dataset_compression)
+from nwbinspector import (
+    Importance,
+    InspectorMessage,
+    check_empty_string_for_optional_attribute,
+    check_large_dataset_compression,
+    check_small_dataset_compression,
+)
 from nwbinspector.register_checks import Severity
 
 

--- a/tests/unit_tests/test_ecephys.py
+++ b/tests/unit_tests/test_ecephys.py
@@ -3,19 +3,16 @@ from unittest import TestCase
 from uuid import uuid4
 
 import numpy as np
+from hdmf.common.table import DynamicTable, DynamicTableRegion
 from pynwb import NWBFile
 from pynwb.ecephys import ElectricalSeries
 from pynwb.misc import Units
-from hdmf.common.table import DynamicTableRegion, DynamicTable
 
-from nwbinspector import (
-    InspectorMessage,
-    Importance,
-    check_negative_spike_times,
-    check_electrical_series_dims,
-    check_electrical_series_reference_electrodes_table,
-    check_spike_times_not_in_unobserved_interval,
-)
+from nwbinspector import (Importance, InspectorMessage,
+                          check_electrical_series_dims,
+                          check_electrical_series_reference_electrodes_table,
+                          check_negative_spike_times,
+                          check_spike_times_not_in_unobserved_interval)
 
 
 def test_check_negative_spike_times_all_positive():

--- a/tests/unit_tests/test_ecephys.py
+++ b/tests/unit_tests/test_ecephys.py
@@ -2,8 +2,8 @@ from datetime import datetime
 from unittest import TestCase
 from uuid import uuid4
 
-from hdmf.common.table import DynamicTable, DynamicTableRegion
 import numpy as np
+from hdmf.common.table import DynamicTable, DynamicTableRegion
 from pynwb import NWBFile
 from pynwb.ecephys import ElectricalSeries
 from pynwb.misc import Units

--- a/tests/unit_tests/test_ecephys.py
+++ b/tests/unit_tests/test_ecephys.py
@@ -2,17 +2,20 @@ from datetime import datetime
 from unittest import TestCase
 from uuid import uuid4
 
-import numpy as np
 from hdmf.common.table import DynamicTable, DynamicTableRegion
+import numpy as np
 from pynwb import NWBFile
 from pynwb.ecephys import ElectricalSeries
 from pynwb.misc import Units
 
-from nwbinspector import (Importance, InspectorMessage,
-                          check_electrical_series_dims,
-                          check_electrical_series_reference_electrodes_table,
-                          check_negative_spike_times,
-                          check_spike_times_not_in_unobserved_interval)
+from nwbinspector import (
+    Importance,
+    InspectorMessage,
+    check_electrical_series_dims,
+    check_electrical_series_reference_electrodes_table,
+    check_negative_spike_times,
+    check_spike_times_not_in_unobserved_interval,
+)
 
 
 def test_check_negative_spike_times_all_positive():

--- a/tests/unit_tests/test_general.py
+++ b/tests/unit_tests/test_general.py
@@ -1,7 +1,11 @@
 from hdmf.common import DynamicTable
 
-from nwbinspector import (Importance, InspectorMessage, check_description,
-                          check_name_slashes)
+from nwbinspector import (
+    Importance,
+    InspectorMessage,
+    check_description,
+    check_name_slashes,
+)
 
 
 def test_check_name_slashes_pass():

--- a/tests/unit_tests/test_general.py
+++ b/tests/unit_tests/test_general.py
@@ -1,6 +1,7 @@
 from hdmf.common import DynamicTable
 
-from nwbinspector import InspectorMessage, Importance, check_name_slashes, check_description
+from nwbinspector import (Importance, InspectorMessage, check_description,
+                          check_name_slashes)
 
 
 def test_check_name_slashes_pass():

--- a/tests/unit_tests/test_icephys.py
+++ b/tests/unit_tests/test_icephys.py
@@ -1,7 +1,7 @@
+import pytest
 from packaging.version import Version
 from pynwb.device import Device
 from pynwb.icephys import IntracellularElectrode
-import pytest
 
 from nwbinspector import (
     Importance,

--- a/tests/unit_tests/test_icephys.py
+++ b/tests/unit_tests/test_icephys.py
@@ -1,9 +1,10 @@
 import pytest
 from packaging.version import Version
-from pynwb.icephys import IntracellularElectrode
 from pynwb.device import Device
+from pynwb.icephys import IntracellularElectrode
 
-from nwbinspector import InspectorMessage, Importance, check_intracellular_electrode_cell_id_exists
+from nwbinspector import (Importance, InspectorMessage,
+                          check_intracellular_electrode_cell_id_exists)
 from nwbinspector.utils import get_package_version
 
 PYNWB_VERSION_LOWER_2_1_0 = get_package_version(name="pynwb") < Version("2.1.0")

--- a/tests/unit_tests/test_icephys.py
+++ b/tests/unit_tests/test_icephys.py
@@ -1,10 +1,13 @@
-import pytest
 from packaging.version import Version
 from pynwb.device import Device
 from pynwb.icephys import IntracellularElectrode
+import pytest
 
-from nwbinspector import (Importance, InspectorMessage,
-                          check_intracellular_electrode_cell_id_exists)
+from nwbinspector import (
+    Importance,
+    InspectorMessage,
+    check_intracellular_electrode_cell_id_exists,
+)
 from nwbinspector.utils import get_package_version
 
 PYNWB_VERSION_LOWER_2_1_0 = get_package_version(name="pynwb") < Version("2.1.0")

--- a/tests/unit_tests/test_image_series.py
+++ b/tests/unit_tests/test_image_series.py
@@ -7,10 +7,13 @@ import numpy as np
 from pynwb import NWBHDF5IO
 from pynwb.image import ImageSeries
 
-from nwbinspector import (Importance, InspectorMessage,
-                          check_image_series_data_size,
-                          check_image_series_external_file_relative,
-                          check_image_series_external_file_valid)
+from nwbinspector import (
+    Importance,
+    InspectorMessage,
+    check_image_series_data_size,
+    check_image_series_external_file_relative,
+    check_image_series_external_file_valid,
+)
 from nwbinspector.tools import make_minimal_nwbfile
 
 

--- a/tests/unit_tests/test_image_series.py
+++ b/tests/unit_tests/test_image_series.py
@@ -1,19 +1,16 @@
-from unittest import TestCase
-from tempfile import mkdtemp
-from shutil import rmtree
 from pathlib import Path
+from shutil import rmtree
+from tempfile import mkdtemp
+from unittest import TestCase
 
 import numpy as np
 from pynwb import NWBHDF5IO
 from pynwb.image import ImageSeries
 
-from nwbinspector import (
-    InspectorMessage,
-    Importance,
-    check_image_series_external_file_valid,
-    check_image_series_external_file_relative,
-    check_image_series_data_size,
-)
+from nwbinspector import (Importance, InspectorMessage,
+                          check_image_series_data_size,
+                          check_image_series_external_file_relative,
+                          check_image_series_external_file_valid)
 from nwbinspector.tools import make_minimal_nwbfile
 
 

--- a/tests/unit_tests/test_images.py
+++ b/tests/unit_tests/test_images.py
@@ -1,6 +1,6 @@
 import numpy as np
-from pynwb.image import GrayscaleImage
 import pytest
+from pynwb.image import GrayscaleImage
 
 from nwbinspector import Importance, InspectorMessage
 from nwbinspector.checks.images import (

--- a/tests/unit_tests/test_images.py
+++ b/tests/unit_tests/test_images.py
@@ -1,13 +1,13 @@
-import pytest
-
 import numpy as np
+import pytest
 from pynwb.image import GrayscaleImage
 
-from nwbinspector import InspectorMessage, Importance
-from nwbinspector.checks.images import check_order_of_images_unique, check_order_of_images_len
+from nwbinspector import Importance, InspectorMessage
+from nwbinspector.checks.images import (check_order_of_images_len,
+                                        check_order_of_images_unique)
 
 try:
-    from pynwb.base import Images, ImageReferences
+    from pynwb.base import ImageReferences, Images
 
     HAVE_IMAGES = True
 except ImportError:

--- a/tests/unit_tests/test_images.py
+++ b/tests/unit_tests/test_images.py
@@ -1,10 +1,12 @@
 import numpy as np
-import pytest
 from pynwb.image import GrayscaleImage
+import pytest
 
 from nwbinspector import Importance, InspectorMessage
-from nwbinspector.checks.images import (check_order_of_images_len,
-                                        check_order_of_images_unique)
+from nwbinspector.checks.images import (
+    check_order_of_images_len,
+    check_order_of_images_unique,
+)
 
 try:
     from pynwb.base import ImageReferences, Images

--- a/tests/unit_tests/test_nwbfile_metadata.py
+++ b/tests/unit_tests/test_nwbfile_metadata.py
@@ -1,32 +1,22 @@
-from uuid import uuid4
 from datetime import datetime, timezone
+from uuid import uuid4
 
 from pynwb import NWBFile, ProcessingModule
 from pynwb.file import Subject
 
-from nwbinspector import (
-    InspectorMessage,
-    Importance,
-    check_experimenter_exists,
-    check_experimenter_form,
-    check_experiment_description,
-    check_institution,
-    check_keywords,
-    check_doi_publications,
-    check_subject_exists,
-    check_subject_id_exists,
-    check_subject_sex,
-    check_subject_age,
-    check_subject_proper_age_range,
-    check_subject_species_exists,
-    check_subject_species_latin_binomial,
-    check_processing_module_name,
-    check_session_start_time_old_date,
-    check_session_start_time_future_date,
-    PROCESSING_MODULE_CONFIG,
-)
+from nwbinspector import (PROCESSING_MODULE_CONFIG, Importance,
+                          InspectorMessage, check_doi_publications,
+                          check_experiment_description,
+                          check_experimenter_exists, check_experimenter_form,
+                          check_institution, check_keywords,
+                          check_processing_module_name,
+                          check_session_start_time_future_date,
+                          check_session_start_time_old_date, check_subject_age,
+                          check_subject_exists, check_subject_id_exists,
+                          check_subject_proper_age_range, check_subject_sex,
+                          check_subject_species_exists,
+                          check_subject_species_latin_binomial)
 from nwbinspector.tools import make_minimal_nwbfile
-
 
 minimal_nwbfile = make_minimal_nwbfile()
 

--- a/tests/unit_tests/test_nwbfile_metadata.py
+++ b/tests/unit_tests/test_nwbfile_metadata.py
@@ -4,18 +4,27 @@ from uuid import uuid4
 from pynwb import NWBFile, ProcessingModule
 from pynwb.file import Subject
 
-from nwbinspector import (PROCESSING_MODULE_CONFIG, Importance,
-                          InspectorMessage, check_doi_publications,
-                          check_experiment_description,
-                          check_experimenter_exists, check_experimenter_form,
-                          check_institution, check_keywords,
-                          check_processing_module_name,
-                          check_session_start_time_future_date,
-                          check_session_start_time_old_date, check_subject_age,
-                          check_subject_exists, check_subject_id_exists,
-                          check_subject_proper_age_range, check_subject_sex,
-                          check_subject_species_exists,
-                          check_subject_species_latin_binomial)
+from nwbinspector import (
+    PROCESSING_MODULE_CONFIG,
+    Importance,
+    InspectorMessage,
+    check_doi_publications,
+    check_experiment_description,
+    check_experimenter_exists,
+    check_experimenter_form,
+    check_institution,
+    check_keywords,
+    check_processing_module_name,
+    check_session_start_time_future_date,
+    check_session_start_time_old_date,
+    check_subject_age,
+    check_subject_exists,
+    check_subject_id_exists,
+    check_subject_proper_age_range,
+    check_subject_sex,
+    check_subject_species_exists,
+    check_subject_species_latin_binomial,
+)
 from nwbinspector.tools import make_minimal_nwbfile
 
 minimal_nwbfile = make_minimal_nwbfile()

--- a/tests/unit_tests/test_ogen.py
+++ b/tests/unit_tests/test_ogen.py
@@ -1,9 +1,9 @@
-from unittest import TestCase
 from datetime import datetime
+from unittest import TestCase
 
-from pynwb.ogen import OptogeneticSeries
 from pynwb.device import Device
 from pynwb.file import NWBFile
+from pynwb.ogen import OptogeneticSeries
 
 from nwbinspector import check_optogenetic_stimulus_site_has_optogenetic_series
 

--- a/tests/unit_tests/test_ophys.py
+++ b/tests/unit_tests/test_ophys.py
@@ -3,27 +3,18 @@ from unittest import TestCase
 from uuid import uuid4
 
 import numpy as np
+from hdmf.common.table import DynamicTable, DynamicTableRegion
 from pynwb import NWBFile
 from pynwb.device import Device
-from pynwb.ophys import (
-    OpticalChannel,
-    ImageSegmentation,
-    RoiResponseSeries,
-    ImagingPlane,
-    PlaneSegmentation,
-    TwoPhotonSeries,
-)
-from hdmf.common.table import DynamicTableRegion, DynamicTable
+from pynwb.ophys import (ImageSegmentation, ImagingPlane, OpticalChannel,
+                         PlaneSegmentation, RoiResponseSeries, TwoPhotonSeries)
 
 from nwbinspector import (
-    InspectorMessage,
-    Importance,
-    check_roi_response_series_dims,
-    check_roi_response_series_link_to_plane_segmentation,
+    Importance, InspectorMessage, check_emission_lambda_in_nm,
     check_excitation_lambda_in_nm,
-    check_emission_lambda_in_nm,
     check_plane_segmentation_image_mask_shape_against_ref_images,
-)
+    check_roi_response_series_dims,
+    check_roi_response_series_link_to_plane_segmentation)
 
 
 class TestCheckRoiResponseSeries(TestCase):

--- a/tests/unit_tests/test_ophys.py
+++ b/tests/unit_tests/test_ophys.py
@@ -2,8 +2,8 @@ from datetime import datetime
 from unittest import TestCase
 from uuid import uuid4
 
-from hdmf.common.table import DynamicTable, DynamicTableRegion
 import numpy as np
+from hdmf.common.table import DynamicTable, DynamicTableRegion
 from pynwb import NWBFile
 from pynwb.device import Device
 from pynwb.ophys import (

--- a/tests/unit_tests/test_ophys.py
+++ b/tests/unit_tests/test_ophys.py
@@ -2,19 +2,28 @@ from datetime import datetime
 from unittest import TestCase
 from uuid import uuid4
 
-import numpy as np
 from hdmf.common.table import DynamicTable, DynamicTableRegion
+import numpy as np
 from pynwb import NWBFile
 from pynwb.device import Device
-from pynwb.ophys import (ImageSegmentation, ImagingPlane, OpticalChannel,
-                         PlaneSegmentation, RoiResponseSeries, TwoPhotonSeries)
+from pynwb.ophys import (
+    ImageSegmentation,
+    ImagingPlane,
+    OpticalChannel,
+    PlaneSegmentation,
+    RoiResponseSeries,
+    TwoPhotonSeries,
+)
 
 from nwbinspector import (
-    Importance, InspectorMessage, check_emission_lambda_in_nm,
+    Importance,
+    InspectorMessage,
+    check_emission_lambda_in_nm,
     check_excitation_lambda_in_nm,
     check_plane_segmentation_image_mask_shape_against_ref_images,
     check_roi_response_series_dims,
-    check_roi_response_series_link_to_plane_segmentation)
+    check_roi_response_series_link_to_plane_segmentation,
+)
 
 
 class TestCheckRoiResponseSeries(TestCase):

--- a/tests/unit_tests/test_tables.py
+++ b/tests/unit_tests/test_tables.py
@@ -2,19 +2,23 @@ import json
 import platform
 from unittest import TestCase
 
-import numpy as np
 from hdmf.common import DynamicTable, DynamicTableRegion
+import numpy as np
 from packaging import version
-from pynwb.file import (Device, ElectrodeGroup, ElectrodeTable, TimeIntervals,
-                        Units)
+from pynwb.file import Device, ElectrodeGroup, ElectrodeTable, TimeIntervals, Units
 
-from nwbinspector import (Importance, InspectorMessage, check_col_not_nan,
-                          check_column_binary_capability,
-                          check_dynamic_table_region_data_validity,
-                          check_empty_table, check_single_row,
-                          check_table_values_for_dict,
-                          check_time_interval_time_columns,
-                          check_time_intervals_stop_after_start)
+from nwbinspector import (
+    Importance,
+    InspectorMessage,
+    check_col_not_nan,
+    check_column_binary_capability,
+    check_dynamic_table_region_data_validity,
+    check_empty_table,
+    check_single_row,
+    check_table_values_for_dict,
+    check_time_interval_time_columns,
+    check_time_intervals_stop_after_start,
+)
 from nwbinspector.utils import get_package_version
 
 

--- a/tests/unit_tests/test_tables.py
+++ b/tests/unit_tests/test_tables.py
@@ -2,8 +2,8 @@ import json
 import platform
 from unittest import TestCase
 
-from hdmf.common import DynamicTable, DynamicTableRegion
 import numpy as np
+from hdmf.common import DynamicTable, DynamicTableRegion
 from packaging import version
 from pynwb.file import Device, ElectrodeGroup, ElectrodeTable, TimeIntervals, Units
 

--- a/tests/unit_tests/test_tables.py
+++ b/tests/unit_tests/test_tables.py
@@ -1,24 +1,20 @@
-import platform
 import json
+import platform
 from unittest import TestCase
-from packaging import version
 
 import numpy as np
 from hdmf.common import DynamicTable, DynamicTableRegion
-from pynwb.file import TimeIntervals, Units, ElectrodeTable, ElectrodeGroup, Device
+from packaging import version
+from pynwb.file import (Device, ElectrodeGroup, ElectrodeTable, TimeIntervals,
+                        Units)
 
-from nwbinspector import (
-    InspectorMessage,
-    Importance,
-    check_empty_table,
-    check_time_interval_time_columns,
-    check_time_intervals_stop_after_start,
-    check_dynamic_table_region_data_validity,
-    check_column_binary_capability,
-    check_single_row,
-    check_table_values_for_dict,
-    check_col_not_nan,
-)
+from nwbinspector import (Importance, InspectorMessage, check_col_not_nan,
+                          check_column_binary_capability,
+                          check_dynamic_table_region_data_validity,
+                          check_empty_table, check_single_row,
+                          check_table_values_for_dict,
+                          check_time_interval_time_columns,
+                          check_time_intervals_stop_after_start)
 from nwbinspector.utils import get_package_version
 
 

--- a/tests/unit_tests/test_time_series.py
+++ b/tests/unit_tests/test_time_series.py
@@ -1,7 +1,7 @@
 import numpy as np
-from packaging import version
 import pynwb
 import pytest
+from packaging import version
 
 from nwbinspector import (
     Importance,

--- a/tests/unit_tests/test_time_series.py
+++ b/tests/unit_tests/test_time_series.py
@@ -3,16 +3,10 @@ import pynwb
 import pytest
 from packaging import version
 
-from nwbinspector import (
-    InspectorMessage,
-    Importance,
-    check_regular_timestamps,
-    check_data_orientation,
-    check_timestamps_match_first_dimension,
-    check_timestamps_ascending,
-    check_missing_unit,
-    check_resolution,
-)
+from nwbinspector import (Importance, InspectorMessage, check_data_orientation,
+                          check_missing_unit, check_regular_timestamps,
+                          check_resolution, check_timestamps_ascending,
+                          check_timestamps_match_first_dimension)
 from nwbinspector.testing import check_streaming_tests_enabled
 from nwbinspector.utils import get_package_version, robust_s3_read
 

--- a/tests/unit_tests/test_time_series.py
+++ b/tests/unit_tests/test_time_series.py
@@ -1,12 +1,18 @@
 import numpy as np
+from packaging import version
 import pynwb
 import pytest
-from packaging import version
 
-from nwbinspector import (Importance, InspectorMessage, check_data_orientation,
-                          check_missing_unit, check_regular_timestamps,
-                          check_resolution, check_timestamps_ascending,
-                          check_timestamps_match_first_dimension)
+from nwbinspector import (
+    Importance,
+    InspectorMessage,
+    check_data_orientation,
+    check_missing_unit,
+    check_regular_timestamps,
+    check_resolution,
+    check_timestamps_ascending,
+    check_timestamps_match_first_dimension,
+)
 from nwbinspector.testing import check_streaming_tests_enabled
 from nwbinspector.utils import get_package_version, robust_s3_read
 


### PR DESCRIPTION
Trying out an extension of the pre-commit bot to handle automated import ordering

EDIT: working pretty well IMO. One less thing to have have to worry about since automation will handle it for us. Minor detail, the check registry in the main `__init__.py` has to be skipped since the order of that one global import matters.