### PR TITLE
Add direct parameter linkage for keyword arguments

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,6 +18,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.extlinks",
     "sphinx_copybutton",
+    "sphinx_paramlinks",
 ]
 templates_path = ["_templates"]
 master_doc = "index"
@@ -60,6 +61,9 @@ autodoc_default_options = {
     "toctree": True,
 }
 add_module_names = False
+
+# Parameter links
+paramlinks_hyperlink_param = "name"
 
 
 def add_refs_to_docstrings(app, what, name, obj, options, lines):

--- a/docs/user_guide/advanced_usage.rst
+++ b/docs/user_guide/advanced_usage.rst
@@ -55,8 +55,7 @@ useful when the underlying dataset is quite large and thus impractical to downlo
 TB scale!
 
 The general tutorial for using the :code:`ros3` driver can be found :ros3-tutorial:`here <>`. This driver can be passed
-directly into our core inspection functions, and the ``path`` or ``nwbfile_path`` arguments in this case become the
-S3 path on the DANDI archive. Resolution of these paths can be performed via the following code
+directly into our core inspection functions, and the :paramref:`~nwbinspector.nwbinspector.inspect_all.path` or :paramref:`~nwbinspector.nwbinspector.inspect_nwb.nwbfile_path` arguments in this case become the S3 path on the DANDI archive. Resolution of these paths can be performed via the following code
 
 .. code-block:: python
 
@@ -87,6 +86,4 @@ Reports aggregate messages into a readable form.
 
     print("\n".join(format_messages(messages, levels=["importance", "file_path"])))
 
-The `levels` argument can be altered to change the nesting structure of the report. Any combination and order
-of :py:class:`~nwbinspector.register_checks.InspectorMessage` attributes can be utilized to produce a more easily
-readable structure.
+The :paramref:`~nwbinspector.inspector_tools.format_messages.levels` argument can be altered to change the nesting structure of the report. Any combination and order of :py:class:`~nwbinspector.register_checks.InspectorMessage` attributes can be utilized to produce a more easily readable structure.

--- a/docs/user_guide/command_line_usage.rst
+++ b/docs/user_guide/command_line_usage.rst
@@ -25,12 +25,11 @@ the most useful of these options.
 Formatting the Report
 ---------------------
 
-The basic report layout organizes by :py:attr:`~nwbinspector.register_check.InspectorMessage.importance` first and
-:py:attr:`~nwbinspector.register_check.InspectorMessage.file_path` last.
+The basic report layout organizes by :paramref:`~nwbinspector.register_check.InspectorMessage.importance` first and
+:paramref:`~nwbinspector.register_check.InspectorMessage.file_path` last.
 
 However, the NWBInspector supports more general organization as defined by the `--levels` flag. To use this flag,
-you must pass a series a comma-separated words that correspond to any attributes of the
-:py:class:`~nwbinspector.register_check.InspectorMessage` in any order.
+you must pass a series a comma-separated words that correspond to any attributes of the :py:class:`~nwbinspector.register_checks.InspectorMessage` in any order.
 
 For example,
 

--- a/docs/user_guide/library_usage.rst
+++ b/docs/user_guide/library_usage.rst
@@ -12,8 +12,7 @@ InspectorMesssage objects
 In order to understand the output of the core functions, we must first explain the most important data structure in our
 library, the :py:class:`~nwbinspector.register_checks.InspectorMessage`. This is a standalone data class that contains
 all values that could be useful or related to a detected Best Practice issue. These values include the text-based
-:paramref:`~nwbinspector.register_checks.InspectorMessage.message` displayed in the report, the ``importance`` of the check (how crucial it is to fix), the ``object_name``
-and ``object_type`` that triggered the issue, the ``location`` of that object within the NWBFile, and the ``file_path``
+:paramref:`~nwbinspector.register_checks.InspectorMessage.message` displayed in the report, the :paramref:`~nwbinspector.register_checks.InspectorMessage.importance` of the check (how crucial it is to fix), the :paramref:`~nwbinspector.register_checks.InspectorMessage.object_name` and :paramref:`~nwbinspector.register_checks.InspectorMessage.object_type` that triggered the issue, the :paramref:`~nwbinspector.register_checks.InspectorMessage.location` of that object within the NWBFile, and the :paramref:`~nwbinspector.register_checks.InspectorMessage.file_path`
 of the NWBFile relative to the directory the inspection function was called from.
 
 

--- a/docs/user_guide/library_usage.rst
+++ b/docs/user_guide/library_usage.rst
@@ -12,7 +12,7 @@ InspectorMesssage objects
 In order to understand the output of the core functions, we must first explain the most important data structure in our
 library, the :py:class:`~nwbinspector.register_checks.InspectorMessage`. This is a standalone data class that contains
 all values that could be useful or related to a detected Best Practice issue. These values include the text-based
-:py:attr:`nwbinspector.register_checks.InspectorMessage.message` displayed in the report, the ``importance`` of the check (how crucial it is to fix), the ``object_name``
+:paramref:`~nwbinspector.register_checks.InspectorMessage.message` displayed in the report, the ``importance`` of the check (how crucial it is to fix), the ``object_name``
 and ``object_type`` that triggered the issue, the ``location`` of that object within the NWBFile, and the ``file_path``
 of the NWBFile relative to the directory the inspection function was called from.
 

--- a/docs/user_guide/library_usage.rst
+++ b/docs/user_guide/library_usage.rst
@@ -12,7 +12,7 @@ InspectorMesssage objects
 In order to understand the output of the core functions, we must first explain the most important data structure in our
 library, the :py:class:`~nwbinspector.register_checks.InspectorMessage`. This is a standalone data class that contains
 all values that could be useful or related to a detected Best Practice issue. These values include the text-based
-``message`` displayed in the report, the ``importance`` of the check (how crucial it is to fix), the ``object_name``
+:py:attr:`nwbinspector.register_checks.InspectorMessage.message` displayed in the report, the ``importance`` of the check (how crucial it is to fix), the ``object_name``
 and ``object_type`` that triggered the issue, the ``location`` of that object within the NWBFile, and the ``file_path``
 of the NWBFile relative to the directory the inspection function was called from.
 

--- a/nwbinspector/register_checks.py
+++ b/nwbinspector/register_checks.py
@@ -42,8 +42,8 @@ class InspectorMessage:
 
     Parameters
     ----------
-    :param message: : str
-        A message that informs the user of the violation.
+    :param message: A message that informs the user of the violation.
+    :type: str
     severity : Severity, optional
         If a check of non-CRITICAL importance has some basis of comparison, such as magnitude of affected data, then
         the developer of the check may set the severity as Severity.HIGH or Severity.LOW by calling

--- a/nwbinspector/register_checks.py
+++ b/nwbinspector/register_checks.py
@@ -43,7 +43,7 @@ class InspectorMessage:
     Parameters
     ----------
     :param message: A message that informs the user of the violation.
-    :type: str
+    :type message: str
     severity : Severity, optional
         If a check of non-CRITICAL importance has some basis of comparison, such as magnitude of affected data, then
         the developer of the check may set the severity as Severity.HIGH or Severity.LOW by calling

--- a/nwbinspector/register_checks.py
+++ b/nwbinspector/register_checks.py
@@ -42,8 +42,8 @@ class InspectorMessage:
 
     Parameters
     ----------
-    :param message: A message that informs the user of the violation.
-    :type message: str
+    message : str
+        A message that informs the user of the violation.
     severity : Severity, optional
         If a check of non-CRITICAL importance has some basis of comparison, such as magnitude of affected data, then
         the developer of the check may set the severity as Severity.HIGH or Severity.LOW by calling

--- a/nwbinspector/register_checks.py
+++ b/nwbinspector/register_checks.py
@@ -42,7 +42,7 @@ class InspectorMessage:
 
     Parameters
     ----------
-    message : str
+    :param message: : str
         A message that informs the user of the violation.
     severity : Severity, optional
         If a check of non-CRITICAL importance has some basis of comparison, such as magnitude of affected data, then

--- a/requirements-rtd.txt
+++ b/requirements-rtd.txt
@@ -5,3 +5,4 @@ sphinx==5.1.1
 sphinx_rtd_theme==0.5.1
 readthedocs-sphinx-search==0.1.0rc3
 sphinx-copybutton==0.5.0
+sphinx-paramlinks==0.5.4


### PR DESCRIPTION
Testing if I can get direct linkage between `:py:attr:` and an API doc for the method that uses that keyword argument.

Demonstrated on https://nwbinspector--279.org.readthedocs.build/en/279/user_guide/library_usage.html#inspectormesssage-objects

EDIT: `:py:attr:` does not work, but the extension for param links works like a charm. The in-line command is :paramref: and will lead directly to any `Parameters` section from our NumPy formatted (and Napolean parsed) docstrings.