### PR TITLE
Add coding style and pre-commit section to Dev guide

### DIFF
--- a/docs/conf_extlinks.py
+++ b/docs/conf_extlinks.py
@@ -20,6 +20,7 @@ extlinks = {
     "orcid": ("https://orcid.org/%s", "%s"),
     "pre-commit-bot": ("https://results.pre-commit.ci/%s", None),
     "neuroconv-coding-style": ("https://neuroconv.readthedocs.io/en/main/developer_guide/style_guide.html#style-guide-and-general-conventions%s", None),
+    "black-coding-style": ("https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html%s", None),
 }
 
 # Use this for mapping for links to commonly used documentation

--- a/docs/conf_extlinks.py
+++ b/docs/conf_extlinks.py
@@ -18,6 +18,8 @@ extlinks = {
     "allen-brain-map": ("https://%s.brain-map.org/", "%s"),
     "uuid": ("https://docs.python.org/3/library/uuid.html%s", None),
     "orcid": ("https://orcid.org/%s", "%s"),
+    "pre-commit-bot": ("https://results.pre-commit.ci/%s", None),
+    "neuroconv-coding-style": ("https://neuroconv.readthedocs.io/en/main/developer_guide/style_guide.html#style-guide-and-general-conventions%s", None),
 }
 
 # Use this for mapping for links to commonly used documentation

--- a/docs/developer_guide.rst
+++ b/docs/developer_guide.rst
@@ -16,7 +16,7 @@ Otherwise feel free to raise a bug report, documentation mistake, or general fea
 Coding Style and pre-commit
 ---------------------------
 
-We use the black coding style with parameters defined in the ``pyproject.toml`` configuration file. We use an automated pre-commit bot to enforce these on the main repo, but contributions from external forks would either have to grant bot permissions on their own fork (via :pre-commit-bot:`the pre-commit bot website <>`) or run pre-commit manually. For instructions to install pre-commit, as well as some other minor coding styles we follow, refer to the :neuroconv-coding-style:`NeuroConv style guide <>`.
+We use the :black-coding-style:`black coding style <>` with parameters defined in the ``pyproject.toml`` configuration file. We use an automated pre-commit bot to enforce these on the main repo, but contributions from external forks would either have to grant bot permissions on their own fork (via :pre-commit-bot:`the pre-commit bot website <>`) or run pre-commit manually. For instructions to install pre-commit, as well as some other minor coding styles we follow, refer to the :neuroconv-coding-style:`NeuroConv style guide <>`.
 
 
 

--- a/docs/developer_guide.rst
+++ b/docs/developer_guide.rst
@@ -13,6 +13,12 @@ build a new data interface and a graphical overview of the object structure can 
 Otherwise feel free to raise a bug report, documentation mistake, or general feature request for our maintainers to address!
 
 
+Coding Style and pre-commit
+---------------------------
+
+We use the black coding style with parameters defined in the ``pyproject.toml`` configuration file. We use an automated pre-commit bot to enforce these on the main repo, but contributions from external forks would either have to grant bot permissions on their own fork (via :pre-commit-bot:`the pre-commit bot website <>`) or run pre-commit manually. For instructions to install pre-commit, as well as some other minor coding styles we follow, refer to the :neuroconv-coding-style:`NeuroConv style guide <>`.
+
+
 
 .. _adding_custom_checks:
 


### PR DESCRIPTION
Came up in meeting with @weiglszonja, adding a developer section for coding style and pre-commit stuff.