### PR TITLE
Add Best Practice for not using placeholders

### DIFF
--- a/docs/best_practices/general.rst
+++ b/docs/best_practices/general.rst
@@ -38,7 +38,7 @@ It is recommended to use :wikipedia:`CamelCase <Camel_case>` when naming instanc
 Do Not Use Slashes in Names
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Slash characters ``'/'`` and ``'\'``  should not be used in the ``name`` of an object, because they can be confusing to systems that parse HDF5 files (which NWB uses as the primary backend, see the :nwb-overview:`NWB FAQ <faq_details/why_hdf5.html#why-hdf5>` for more details). The forward slash is used in `h5py` to specify a `Groups <https://schema-language.readthedocs.io/en/latest/description.html#groups>`_ hierarchy. 
+Slash characters ``'/'`` and ``'\'``  should not be used in the ``name`` of an object, because they can be confusing to systems that parse HDF5 files (which NWB uses as the primary backend, see the :nwb-overview:`NWB FAQ <faq_details/why_hdf5.html#why-hdf5>` for more details). The forward slash is used in `h5py` to specify a `Groups <https://schema-language.readthedocs.io/en/latest/description.html#groups>`_ hierarchy.
 
 For mathematical expressions, instead of including the special character in the name, please use an English equivalent instead. *E.g.*, instead of "Df/f" use "DfOverF".
 

--- a/docs/best_practices/general.rst
+++ b/docs/best_practices/general.rst
@@ -60,7 +60,7 @@ Check function: :py:meth:`~nwbinspector.checks.general.check_description`
 
 
 
-.. _best_practice_empty_string_for_optional_attribute:
+.. _best_practice_placeholders:
 
 Empty Strings
 ~~~~~~~~~~~~~

--- a/docs/best_practices/general.rst
+++ b/docs/best_practices/general.rst
@@ -3,8 +3,8 @@ General
 
 
 
-Metadata
---------
+Neurodata Types
+---------------
 
 
 

--- a/docs/best_practices/general.rst
+++ b/docs/best_practices/general.rst
@@ -3,8 +3,8 @@ General
 
 
 
-Neurodata Types
----------------
+Metadata
+--------
 
 
 
@@ -35,11 +35,12 @@ It is recommended to use :wikipedia:`CamelCase <Camel_case>` when naming instanc
 
 .. _best_practice_name_slashes:
 
-Do Not Use Slashes
-~~~~~~~~~~~~~~~~~~
+Do Not Use Slashes in Names
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-'/' is not allowed in Group or Dataset names, as this can confuse h5py and lead to the creation of an additional group.
-Instead of including a forward slash in the name, please use "Over" like in DfOverF.
+Slash characters ``'/'`` and ``'\'``  should not be used in the ``name`` of an object, because they can be confusing to systems that parse HDF5 files (which NWB uses as the primary backend, see the :nwb-overview:`NWB FAQ <faq_details/why_hdf5.html#why-hdf5>` for more details). The forward slash is used in `h5py` to specify a `Groups <https://schema-language.readthedocs.io/en/latest/description.html#groups>`_ hierarchy. 
+
+For mathematical expressions, instead of including the special character in the name, please use an English equivalent instead. *E.g.*, instead of "Df/f" use "DfOverF".
 
 Check function: :py:meth:`~nwbinspector.checks.general.check_name_slashes`
 
@@ -47,24 +48,23 @@ Check function: :py:meth:`~nwbinspector.checks.general.check_name_slashes`
 
 .. _best_practice_description:
 
-Metadata and Descriptions
-~~~~~~~~~~~~~~~~~~~~~~~~~
+Descriptions
+~~~~~~~~~~~~
 
-The ``name`` of an object is for identifying that object within the file; it is not for storing metadata. Instead, the
-``description`` field for most objects can be used to include any important distinguishing information. When writing
-metadata, be as explicit and self-contained as possible in explaining relevant details. Use
-official ontologies where appropriate.
+The :py:attr:`name` of an object is for identifying that object within the file; it is not for storing metadata. Instead, the :py:attr:`description` field for most objects can be used to include any important distinguishing information. When writing metadata, be as explicit and self-contained as possible in explaining relevant details. Use official ontologies where appropriate.
 
-It is OK to name an object something like ``ElectricalSeriesFromProbe1``, however the name alone is not sufficient
-documentation of the signal source. In this case, the source of the signal will be clear from the
-:ref:`nwb-schema:devices` linkage in the rows of the passed :ref:`hdmf-schema:sec-dynamictableregion` subsetting
-the full ``ElectrodeTable``, so you would not need to
-add any explicit metadata explaining these details.
-
-Slash characters ``'/'`` and ``'\'``  should not be used in the ``name`` of an object, because they can be
-confusing to systems that parse HDF5 files (which NWB uses as the primary backend, see the
-:nwb-overview:`NWB FAQ <faq_details/why_hdf5.html#why-hdf5>` for more details). The forward slash is used in `h5py` to specify a `Groups <https://schema-language.readthedocs.io/en/latest/description.html#groups>`_ hierarchy.
-For mathematical expressions, instead of including the special character in the name, please use an English equivalent
-instead. *E.g.*, instead of "Df/f" use "DfOverF".
+It is acceptable to name an object something like ``ElectricalSeriesFromProbe1`` as per the uniqueness requirement of :ref:`best_practice_object_names`, however the name alone is not sufficient documentation of the signal source. In this case, the source of the signal will be clear from the :ref:`nwb-schema:devices` linkage in the rows of the passed :ref:`hdmf-schema:sec-dynamictableregion` subsetting the full ``ElectrodeTable``, so you would not need to add any explicit metadata explaining these details.
 
 Check function: :py:meth:`~nwbinspector.checks.general.check_description`
+
+
+
+
+.. _best_practice_empty_string_for_optional_attribute:
+
+Empty Strings
+~~~~~~~~~~~~~
+
+Required free-text fields for certain neurodata types, such as a :py:attr:`description`, should always be specified and should not use placeholders such as empty strings or ``"no description"``.
+
+Many attributes of neurodata types in NWB are optional details to include. It is not necessary, therefore, to use placeholders such as empty strings for these attributes. Instead, they should not be specified at all.

--- a/docs/best_practices/general.rst
+++ b/docs/best_practices/general.rst
@@ -65,6 +65,6 @@ Check function: :py:meth:`~nwbinspector.checks.general.check_description`
 Empty Strings
 ~~~~~~~~~~~~~
 
-Required free-text fields for certain neurodata types, such as a :py:attr:`description`, should always be specified and should not use placeholders such as empty strings or ``"no description"``.
+Required free-text fields for neurodata types should not use placeholders such as empty strings (`""`), ``"no description"``, or ``"PLACEHOLDER"``. For example, the :py:attr:`description` field should always richly describe that particular neurodata type and its interpretation within the experiment.
 
-Many attributes of neurodata types in NWB are optional details to include. It is not necessary, therefore, to use placeholders such as empty strings for these attributes. Instead, they should not be specified at all.
+Many attributes of neurodata types in NWB are optional details to include. It is not necessary, therefore, to use placeholders for these attributes. Instead, they should not be specified at all.

--- a/docs/best_practices/todo.rst
+++ b/docs/best_practices/todo.rst
@@ -13,13 +13,6 @@ TODO
 Need to write section about DANDI regex pattern.
 
 
-.. _best_practice_empty_string_for_optional_attribute:
-
-TODO
-----
-
-Need to add a section about this somewhere.
-
 
 .. _best_practice_empty_table:
 

--- a/nwbinspector/checks/general.py
+++ b/nwbinspector/checks/general.py
@@ -13,7 +13,11 @@ def check_name_slashes(obj):
 
 @register_check(importance=Importance.BEST_PRACTICE_SUGGESTION, neurodata_type=None)
 def check_description(obj):
-    """Check if the description is a not missing or a placeholder."""
+    """
+    Check if the description is a not missing or a placeholder.
+    
+    Best Practice: :ref:`best_practice_placeholders`
+    """
     if not hasattr(obj, "description"):
         return
     if obj.description is None or obj.description.strip(" ") == "":

--- a/nwbinspector/checks/general.py
+++ b/nwbinspector/checks/general.py
@@ -15,7 +15,7 @@ def check_name_slashes(obj):
 def check_description(obj):
     """
     Check if the description is a not missing or a placeholder.
-    
+
     Best Practice: :ref:`best_practice_placeholders`
     """
     if not hasattr(obj, "description"):

--- a/nwbinspector/checks/nwb_containers.py
+++ b/nwbinspector/checks/nwb_containers.py
@@ -72,7 +72,7 @@ def check_empty_string_for_optional_attribute(nwb_container: NWBContainer):
     Parameters
     ----------
     nwb_container: NWBContainer
-    
+
     Best Practice: :ref:`best_practice_placeholders`
     """
     docval_args = type(nwb_container).__init__.__docval__["args"]

--- a/nwbinspector/checks/nwb_containers.py
+++ b/nwbinspector/checks/nwb_containers.py
@@ -72,6 +72,8 @@ def check_empty_string_for_optional_attribute(nwb_container: NWBContainer):
     Parameters
     ----------
     nwb_container: NWBContainer
+    
+    Best Practice: :ref:`best_practice_placeholders`
     """
     docval_args = type(nwb_container).__init__.__docval__["args"]
     optional_attrs = [arg["name"] for arg in docval_args if "default" in arg and arg["default"] is None]


### PR DESCRIPTION
For both required and optional attributes, placeholders should not be used. For optional ones, they shouldn't be specified at all if an empty string.