### PR TITLE
Add daily link checks

### DIFF
--- a/.github/workflows/dailies.yml
+++ b/.github/workflows/dailies.yml
@@ -1,0 +1,13 @@
+name: Daily workflows
+
+on:
+  schedule:
+    - cron: "0 16 * * *"  # Daily at noon EST
+
+jobs:
+
+  run-daily-tests:
+    uses: neurodatawithoutborders/nwbinspector/.github/workflows/testing.yml@dev
+
+  run-daily-doc-link-checks:
+    uses: neurodatawithoutborders/nwbinspector/.github/workflows/doc-link-checks.yml@dev

--- a/.github/workflows/doc-link-checks.yml
+++ b/.github/workflows/doc-link-checks.yml
@@ -1,5 +1,9 @@
-name: Testing External Links
-on: pull_request
+name: Testing Documentation Links
+
+on:
+  pull_request:
+  workflow_call:
+
 jobs:
   build-and-test:
     name: Testing External Links
@@ -13,9 +17,14 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
-      - name: Install sphinx Dependencies
+
+      - name: Install Sphinx dependencies
         run: pip install -r requirements-rtd.txt
       - name: Install package for API docs
         run: pip install -e .
+
       - name: Test External Links
         run: sphinx-build -b linkcheck ./docs ./test_build
+        
+      - name: Test All Internal Links
+        run: sphinx-build -W --keep-going ./docs ./test_build

--- a/.github/workflows/doc-link-checks.yml
+++ b/.github/workflows/doc-link-checks.yml
@@ -23,6 +23,6 @@ jobs:
 
       - name: Test External Links
         run: sphinx-build -b linkcheck ./docs ./test_build
-        
+
       - name: Test All Internal Links
         run: sphinx-build -W --keep-going ./docs ./test_build

--- a/.github/workflows/doc-link-checks.yml
+++ b/.github/workflows/doc-link-checks.yml
@@ -1,8 +1,6 @@
 name: Testing Documentation Links
 
-on:
-  pull_request:
-  workflow_call:
+on: workflow_call
 
 jobs:
   build-and-test:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,8 +1,5 @@
 name: Testing
-on:
-  schedule:
-    - cron: "0 0 * * *"  # daily
-  workflow_call:
+on: workflow_call
 
 jobs:
   build-and-test:


### PR DESCRIPTION
## Motivation

The readthedocs build would run this sort of thing on each push to a PR, but not daily.

This harnesses re-usable workflows to dispatch both testing and doc link checks on a daily basis. I'll add a badge for it to the front page as well once it's on `dev`.