### PR TITLE
[Bug fix]: hotfix configuration importance

### DIFF
--- a/src/nwbinspector/nwbinspector.py
+++ b/src/nwbinspector/nwbinspector.py
@@ -292,7 +292,7 @@ def inspect_all_cli(
     print_to_console(formatted_messages=formatted_messages)
     if report_file_path is not None:
         save_report(report_file_path=report_file_path, formatted_messages=formatted_messages, overwrite=overwrite)
-        print(f"{os.linesep*2}Report saved to {str(Path(json_file_path).absolute())}!{os.linesep}")
+        print(f"{os.linesep*2}Report saved to {str(Path(report_file_path).absolute())}!{os.linesep}")
 
 
 def inspect_all(

--- a/src/nwbinspector/nwbinspector.py
+++ b/src/nwbinspector/nwbinspector.py
@@ -1,4 +1,5 @@
 """Primary functions for inspecting NWBFiles."""
+import os
 import re
 import importlib
 import traceback
@@ -286,10 +287,12 @@ def inspect_all_cli(
         with open(file=json_file_path, mode="w") as fp:
             json_report = dict(header=get_report_header(), messages=messages)
             json.dump(obj=json_report, fp=fp, cls=InspectorOutputJSONEncoder)
+            print(f"{os.linesep*2}Report saved to {str(Path(json_file_path).absolute())}!{os.linesep}")
     formatted_messages = format_messages(messages=messages, levels=levels, reverse=reverse, detailed=detailed)
     print_to_console(formatted_messages=formatted_messages)
     if report_file_path is not None:
         save_report(report_file_path=report_file_path, formatted_messages=formatted_messages, overwrite=overwrite)
+        print(f"{os.linesep*2}Report saved to {str(Path(json_file_path).absolute())}!{os.linesep}")
 
 
 def inspect_all(

--- a/src/nwbinspector/register_checks.py
+++ b/src/nwbinspector/register_checks.py
@@ -120,20 +120,20 @@ def register_check(importance: Importance, neurodata_type):
 
         @wraps(check_function)
         def auto_parse_some_output(*args, **kwargs) -> InspectorMessage:
-
             if args:
                 obj = args[0]
             else:
                 obj = kwargs[list(kwargs)[0]]
             output = check_function(*args, **kwargs)
-            if isinstance(output, Iterable):
+            auto_parsed_result = None
+            if isinstance(output, InspectorMessage):
+                auto_parsed_result = auto_parse(check_function=check_function, obj=obj, result=output)
+            elif output is not None:
                 auto_parsed_result = list()
                 for result in output:
                     auto_parsed_result.append(auto_parse(check_function=check_function, obj=obj, result=result))
                 if not any(auto_parsed_result):
                     auto_parsed_result = None
-            else:
-                auto_parsed_result = auto_parse(check_function=check_function, obj=obj, result=output)
             return auto_parsed_result
 
         available_checks.append(auto_parse_some_output)

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -506,11 +506,24 @@ class TestInspector(TestCase):
         true_results = [
             InspectorMessage(
                 message="Subject is missing.",
-                importance=Importance.BEST_PRACTICE_SUGGESTION,
+                importance=Importance.CRITICAL,  # Normally a BEST_PRACTICE_SUGGESTION
                 check_function_name="check_subject_exists",
                 object_type="NWBFile",
                 object_name="root",
                 location="/",
+                file_path=self.nwbfile_paths[0],
+            ),
+            InspectorMessage(
+                message=(
+                    "Data may be in the wrong orientation. "
+                    "Time should be in the first dimension, and is usually the longest dimension. "
+                    "Here, another dimension is longer."
+                ),
+                importance=Importance.BEST_PRACTICE_VIOLATION,  # Normally CRITICAL, now a BEST_PRACTICE_VIOLATION
+                check_function_name="check_data_orientation",
+                object_type="SpatialSeries",
+                object_name="my_spatial_series",
+                location="/processing/behavior/Position/my_spatial_series",
                 file_path=self.nwbfile_paths[0],
             ),
             InspectorMessage(
@@ -532,19 +545,6 @@ class TestInspector(TestCase):
                 object_type="TimeSeries",
                 object_name="test_time_series_2",
                 location="/acquisition/test_time_series_2",
-                file_path=self.nwbfile_paths[0],
-            ),
-            InspectorMessage(
-                message=(
-                    "Data may be in the wrong orientation. "
-                    "Time should be in the first dimension, and is usually the longest dimension. "
-                    "Here, another dimension is longer."
-                ),
-                importance=Importance.CRITICAL,
-                check_function_name="check_data_orientation",
-                object_type="SpatialSeries",
-                object_name="my_spatial_series",
-                location="/processing/behavior/Position/my_spatial_series",
                 file_path=self.nwbfile_paths[0],
             ),
             InspectorMessage(


### PR DESCRIPTION
fix #302 

@djarecka and/or @yarikoptic (remember the `--config dandi`) If you can give this branch a try when you get a chance to ensure it works as expected

## Motivation

From the previous attempted fix of https://github.com/NeurodataWithoutBorders/nwbinspector/pull/218 from the state of https://github.com/NeurodataWithoutBorders/nwbinspector/pull/96 in response to #216, there was a subtle issue in which registered checks would indeed have their copied attributes correctly modified by the specified configuration; alas, the complexity of the nested wrappers in the registration (https://github.com/NeurodataWithoutBorders/nwbinspector/blob/dev/src/nwbinspector/register_checks.py#L121-L137) actually caused the non-configured importance level to backslide to the default value by wrapping only the original check (with original attributes) and refusing my attempts thus far to update these nested fields in the wrapper dynamically.

Regrettably, I had introduced tests for exactly this in #218 however I mistakenly set the ground truth values to the defaults instead of the expected `dandi` configuration. I've appended comments to the importance values to mentally ensure the test is now correct at a glance.

This PR introduces a hotfix to the problem which will at least restore the correct behavior, along with some other minor syntax updates I caught along the way.

Current output for me with this hotfix matches the expectation of

```shell
> nwbinspector some_file.nwb --config dandi


**************************************************
NWBInspector Report Summary

Timestamp: 2022-11-09 18:28:12.760474-05:00
Platform: Windows-10-10.0.19045-SP0
NWBInspector version: 0.4.17

Found 4 issues over 1 files:
       1 - CRITICAL
       3 - BEST_PRACTICE_SUGGESTION
**************************************************


0  CRITICAL
===========

0.0  some_file.nwb: check_subject_exists - 'NWBFile' object at location '/'
       Message: Subject is missing.

1  BEST_PRACTICE_SUGGESTION
===========================
...
```

I'll try a bit more to get a more proper fix, or otherwise rethink this approach to be less annoyingly magical (and less complex) to avoid things like this going forward.