### PR TITLE
Include compression in ImageSeries size check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Upcoming
 
+### Improvements
+
+* Added compression size consideration to `check_image_series_size`. [PR #311](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/311)
+
+
+
 # v0.4.19
 
 ### Fixes

--- a/src/nwbinspector/checks/image_series.py
+++ b/src/nwbinspector/checks/image_series.py
@@ -57,6 +57,11 @@ def check_image_series_data_size(image_series: ImageSeries, gb_lower_bound: floa
     Best Practice: :ref:`best_practice_use_external_mode`
     """
     data = image_series.data
-    data_size_gb = data.size * data.dtype.itemsize / 1e9
+
+    if getattr(data, "compression", None) is not None:
+        data_size_gb = data.id.get_storage_size() / 1e9
+    else:
+        data_size_gb = data.size * data.dtype.itemsize / 1e9
+
     if data_size_gb > gb_lower_bound:
-        return InspectorMessage(message=f"ImageSeries {image_series.name} is too large. Use external mode for storage")
+        return InspectorMessage(message="ImageSeries is very large. Consider using external mode for better storage.")


### PR DESCRIPTION
## Motivation

From discussion in https://github.com/NeurodataWithoutBorders/nwbinspector/pull/301#discussion_r1030951416

Include compression size consideration with `check_image series_size` threshold comparison
