### PR TITLE
Added special skip condition for check_timestamps_match

### DIFF
--- a/tests/unit_tests/test_time_series.py
+++ b/tests/unit_tests/test_time_series.py
@@ -138,7 +138,7 @@ def test_check_timestamps_match_first_dimension_special_skip(tmp_path):
         pynwb.image.IndexSeries(
             name="IndexSeries",
             unit="n.a.",
-            data=[0,1],
+            data=[0, 1],
             indexed_timeseries=image_series,
             timestamps=np.arange(0, num_images, 0.1),
         )

--- a/tests/unit_tests/test_time_series.py
+++ b/tests/unit_tests/test_time_series.py
@@ -138,7 +138,7 @@ def test_check_timestamps_match_first_dimension_special_skip(tmp_path):
         pynwb.image.IndexSeries(
             name="IndexSeries",
             unit="n.a.",
-            data=np.empty(shape=num_images),
+            data=[0,1],
             indexed_timeseries=image_series,
             timestamps=np.arange(0, num_images, 0.1),
         )

--- a/tests/unit_tests/test_time_series.py
+++ b/tests/unit_tests/test_time_series.py
@@ -140,7 +140,7 @@ def test_check_timestamps_match_first_dimension_special_skip(tmp_path):
             unit="n.a.",
             data=[0, 1],
             indexed_timeseries=image_series,
-            timestamps=np.arange(0, num_images, 0.1),
+            timestamps=[0.5, 0.6],
         )
     )
 


### PR DESCRIPTION
## Motivation

As per discussion.

What is the name of the file on Globus to test? Upload seems to have only finished right now for `1109699524.spikes.nwb` and that only has a bunch of `BEST_PRACTICE_SUGGESTION`'s.

Anyway I tried my best to replicate the issue and new expected behavior in the test.

@bendichter If it's easier than waiting for globus, can you try running this branch on the file you have and see if it clears up the isssue?