### PR TITLE
Add inspector check for negative timestamps

### DIFF
--- a/docs/best_practices/nwbfile_metadata.rst
+++ b/docs/best_practices/nwbfile_metadata.rst
@@ -33,6 +33,7 @@ best guess. If the exact start time is unknown, then it is fine to simply set it
 Check functions: :py:meth:`~nwbinspector.checks.nwbfile_metadata.check_session_start_time_old_date`,
 :py:meth:`~nwbinspector.checks.nwbfile_metadata.check_session_start_time_future_date`,
 :py:meth:`~nwbinspector.checks.time_series.check_timestamp_of_the_first_sample_is_not_negative`
+:py:meth:`~nwbinspector.checks.tables.check_table_time_columns_are_not_negative`
 
 
 

--- a/docs/best_practices/nwbfile_metadata.rst
+++ b/docs/best_practices/nwbfile_metadata.rst
@@ -22,6 +22,9 @@ the ``timestamp_reference_time`` used across all of the NWBFiles may be set sepa
 All time-related data in the NWBFile should be synchronized to the ``timestamps_reference_time`` so that future users
 are able to understand the timing of all events contained within the NWBFile.
 
+The ``timestamps_reference_time`` should also be the earliest timestamp in the file, giving all other time references
+a positive value relative to that. There should be no time references which are negative.
+
 Given the importance of this field within an :ref:`nwb-schema:sec-NWBFile`, is it critical that it be set to a proper
 value. Default values should generally not be used for this field. If the true date is unknown, use your
 best guess. If the exact start time is unknown, then it is fine to simply set it to midnight on that date.
@@ -29,6 +32,7 @@ best guess. If the exact start time is unknown, then it is fine to simply set it
 
 Check functions: :py:meth:`~nwbinspector.checks.nwbfile_metadata.check_session_start_time_old_date`,
 :py:meth:`~nwbinspector.checks.nwbfile_metadata.check_session_start_time_future_date`,
+:py:meth:`~nwbinspector.checks.time_series.check_timestamp_of_the_first_sample_is_not_negative`
 
 
 

--- a/docs/best_practices/time_series.rst
+++ b/docs/best_practices/time_series.rst
@@ -107,23 +107,6 @@ Check function: :py:meth:`~nwbinspector.checks.time_series.check_regular_timesta
 
 
 
-
-.. _best_practice_timestamp_of_the_first_sample:
-
-Timestamp of the first sample
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The timestamp of the first sample of a :ref:`nwb-schema:sec-TimeSeries` defined by
-:ref:`nwb-schema:TimeSeries.starting_time <sec-TimeSeries>` or the first value in
-:ref:`nwb-schema:TimeSeries.timestamps <sec-TimeSeries>` should be `0.0` or any positive value.
-If you have multiple modalities with different timestamps, the earliest timestamp should
-correspond to `0.0` and every other time reference should be shifted by this timestamp.
-
-Check function: :py:meth:`~nwbinspector.checks.time_series.check_timestamp_of_the_first_sample_is_not_negative`
-
-
-
-
 .. _best_practice_chunk_data:
 
 Chunk Data

--- a/docs/best_practices/time_series.rst
+++ b/docs/best_practices/time_series.rst
@@ -107,6 +107,23 @@ Check function: :py:meth:`~nwbinspector.checks.time_series.check_regular_timesta
 
 
 
+
+.. _best_practice_timestamp_of_the_first_sample:
+
+Timestamp of the first sample
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The timestamp of the first sample of a :ref:`nwb-schema:sec-TimeSeries` defined by
+:ref:`nwb-schema:TimeSeries.starting_time <sec-TimeSeries>` or the first value in
+:ref:`nwb-schema:TimeSeries.timestamps <sec-TimeSeries>` should be `0.0` or any positive value.
+If you have multiple modalities with different timestamps, the earliest timestamp should
+correspond to `0.0` and every other time reference should be shifted by this timestamp.
+
+Check function: :py:meth:`~nwbinspector.checks.time_series.check_timestamp_of_the_first_sample_is_not_negative`
+
+
+
+
 .. _best_practice_chunk_data:
 
 Chunk Data

--- a/src/nwbinspector/checks/tables.py
+++ b/src/nwbinspector/checks/tables.py
@@ -235,3 +235,24 @@ def check_ids_unique(table: DynamicTable, nelems: Optional[int] = NELEMS):
     data = table.id[:nelems]
     if len(set(data)) != len(data):
         return InspectorMessage(message="This table has ids that are not unique.")
+
+
+@register_check(importance=Importance.BEST_PRACTICE_SUGGESTION, neurodata_type=DynamicTable)
+def check_table_time_columns_are_not_negative(table: DynamicTable):
+    """
+    Check that time columns are not negative.
+
+    Best Practice: :ref:`best_practice_global_time_reference`
+
+    Parameters
+    ----------
+    table: DynamicTable
+    """
+    for column_name in table.colnames:
+        if column_name.endswith("_time"):
+            first_timestamp = table[column_name][0]
+            if first_timestamp < 0:
+                yield InspectorMessage(
+                    message=f"Timestamps in column {column_name} should not be negative."
+                    " It is recommended to align the `session_start_time` or `timestamps_reference_time` to be the earliest time value that occurs in the data, and shift all other signals accordingly."
+                )

--- a/src/nwbinspector/checks/time_series.py
+++ b/src/nwbinspector/checks/time_series.py
@@ -99,7 +99,7 @@ def check_timestamp_of_the_first_sample_is_not_negative(time_series: TimeSeries)
     first_timestamp = time_series.starting_time if time_series.starting_time is not None else time_series.timestamps[0]
     if first_timestamp < 0:
         return InspectorMessage(
-            message=f"{time_series.name} timestamp of the first sample should not be negative value."
+            message=f"Timestamps should not be negative."
             " It is recommended to align the `session_start_time` or `timestamps_reference_time` to be the earliest time value that occurs in the data, and shift all other signals accordingly."
         )
 

--- a/src/nwbinspector/checks/time_series.py
+++ b/src/nwbinspector/checks/time_series.py
@@ -99,7 +99,7 @@ def check_timestamp_of_the_first_sample_is_not_negative(time_series: TimeSeries)
     first_timestamp = time_series.starting_time if time_series.starting_time is not None else time_series.timestamps[0]
     if first_timestamp < 0:
         return InspectorMessage(
-            message=f"{time_series.name} timestamp of the first sample should not be negative value."
+            message=f"{time_series.name} timestamp of the first sample should not be negative value. It is recommended to align the `session_start_time` or `timestamps_reference_time` to be the earliest time value that occurs in the data, and shift all other signals accordingly."
         )
 
 

--- a/src/nwbinspector/checks/time_series.py
+++ b/src/nwbinspector/checks/time_series.py
@@ -89,6 +89,21 @@ def check_timestamps_ascending(time_series: TimeSeries, nelems=200):
 
 
 @register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=TimeSeries)
+def check_timestamp_of_the_first_sample_is_not_negative(time_series: TimeSeries):
+    """
+    Check that the timestamp of the first sample is not negative.
+
+    Best Practice: :ref:`best_practice_timestamp_of_the_first_sample`
+    """
+
+    first_timestamp = time_series.starting_time if time_series.starting_time is not None else time_series.timestamps[0]
+    if first_timestamp < 0:
+        return InspectorMessage(
+            message=f"{time_series.name} timestamp of the first sample should not be negative value."
+        )
+
+
+@register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=TimeSeries)
 def check_missing_unit(time_series: TimeSeries):
     """
     Check if the TimeSeries.unit field is empty.

--- a/src/nwbinspector/checks/time_series.py
+++ b/src/nwbinspector/checks/time_series.py
@@ -93,13 +93,14 @@ def check_timestamp_of_the_first_sample_is_not_negative(time_series: TimeSeries)
     """
     Check that the timestamp of the first sample is not negative.
 
-    Best Practice: :ref:`best_practice_timestamp_of_the_first_sample`
+    Best Practice: :ref:`best_practice_global_time_reference`
     """
 
     first_timestamp = time_series.starting_time if time_series.starting_time is not None else time_series.timestamps[0]
     if first_timestamp < 0:
         return InspectorMessage(
-            message=f"{time_series.name} timestamp of the first sample should not be negative value. It is recommended to align the `session_start_time` or `timestamps_reference_time` to be the earliest time value that occurs in the data, and shift all other signals accordingly."
+            message=f"{time_series.name} timestamp of the first sample should not be negative value."
+            " It is recommended to align the `session_start_time` or `timestamps_reference_time` to be the earliest time value that occurs in the data, and shift all other signals accordingly."
         )
 
 

--- a/src/nwbinspector/checks/time_series.py
+++ b/src/nwbinspector/checks/time_series.py
@@ -88,7 +88,7 @@ def check_timestamps_ascending(time_series: TimeSeries, nelems=200):
         return InspectorMessage(f"{time_series.name} timestamps are not ascending.")
 
 
-@register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=TimeSeries)
+@register_check(importance=Importance.BEST_PRACTICE_SUGGESTION, neurodata_type=TimeSeries)
 def check_timestamp_of_the_first_sample_is_not_negative(time_series: TimeSeries):
     """
     Check that the timestamp of the first sample is not negative.
@@ -99,7 +99,7 @@ def check_timestamp_of_the_first_sample_is_not_negative(time_series: TimeSeries)
     first_timestamp = time_series.starting_time if time_series.starting_time is not None else time_series.timestamps[0]
     if first_timestamp < 0:
         return InspectorMessage(
-            message=f"Timestamps should not be negative."
+            message="Timestamps should not be negative."
             " It is recommended to align the `session_start_time` or `timestamps_reference_time` to be the earliest time value that occurs in the data, and shift all other signals accordingly."
         )
 

--- a/tests/unit_tests/test_time_series.py
+++ b/tests/unit_tests/test_time_series.py
@@ -225,7 +225,7 @@ def test_check_timestamp_of_the_first_sample_is_not_negative_with_timestamps_fai
     )
     assert check_timestamp_of_the_first_sample_is_not_negative(time_series) == InspectorMessage(
         message=message,
-        importance=Importance.BEST_PRACTICE_VIOLATION,
+        importance=Importance.BEST_PRACTICE_SUGGESTION,
         check_function_name="check_timestamp_of_the_first_sample_is_not_negative",
         object_type="TimeSeries",
         object_name="test_time_series",
@@ -249,7 +249,7 @@ def test_check_timestamp_of_the_first_sample_is_not_negative_with_starting_time_
     )
     assert check_timestamp_of_the_first_sample_is_not_negative(time_series) == InspectorMessage(
         message=message,
-        importance=Importance.BEST_PRACTICE_VIOLATION,
+        importance=Importance.BEST_PRACTICE_SUGGESTION,
         check_function_name="check_timestamp_of_the_first_sample_is_not_negative",
         object_type="TimeSeries",
         object_name="test_time_series",

--- a/tests/unit_tests/test_time_series.py
+++ b/tests/unit_tests/test_time_series.py
@@ -14,7 +14,7 @@ from nwbinspector import (
     check_timestamps_ascending,
     check_missing_unit,
     check_resolution,
-    check_timestamp_of_the_first_sample_is_not_negative
+    check_timestamp_of_the_first_sample_is_not_negative,
 )
 from nwbinspector.tools import make_minimal_nwbfile
 from nwbinspector.testing import check_streaming_tests_enabled
@@ -217,8 +217,7 @@ def test_check_timestamps_ascending_fail():
 
 
 def test_check_timestamp_of_the_first_sample_is_not_negative_with_timestamps_fail():
-    time_series = pynwb.TimeSeries(name="test_time_series", unit="test_units",
-                                   data=[1, 2, 3], timestamps=[-1, 0, 1])
+    time_series = pynwb.TimeSeries(name="test_time_series", unit="test_units", data=[1, 2, 3], timestamps=[-1, 0, 1])
     assert check_timestamp_of_the_first_sample_is_not_negative(time_series) == InspectorMessage(
         message="test_time_series timestamp of the first sample should not be negative value.",
         importance=Importance.BEST_PRACTICE_VIOLATION,
@@ -230,14 +229,14 @@ def test_check_timestamp_of_the_first_sample_is_not_negative_with_timestamps_fai
 
 
 def test_check_timestamp_of_the_first_sample_is_not_negative_with_timestamps_pass():
-    time_series = pynwb.TimeSeries(name="test_time_series", unit="test_units",
-                                   data=[1, 2, 3], timestamps=[0, 1, 2])
+    time_series = pynwb.TimeSeries(name="test_time_series", unit="test_units", data=[1, 2, 3], timestamps=[0, 1, 2])
     assert check_timestamp_of_the_first_sample_is_not_negative(time_series) is None
 
 
 def test_check_timestamp_of_the_first_sample_is_not_negative_with_starting_time_fail():
-    time_series = pynwb.TimeSeries(name="test_time_series", unit="test_units",
-                                   data=[1, 2, 3], starting_time=-1.0, rate=30.0)
+    time_series = pynwb.TimeSeries(
+        name="test_time_series", unit="test_units", data=[1, 2, 3], starting_time=-1.0, rate=30.0
+    )
     assert check_timestamp_of_the_first_sample_is_not_negative(time_series) == InspectorMessage(
         message="test_time_series timestamp of the first sample should not be negative value.",
         importance=Importance.BEST_PRACTICE_VIOLATION,
@@ -249,8 +248,9 @@ def test_check_timestamp_of_the_first_sample_is_not_negative_with_starting_time_
 
 
 def test_check_timestamp_of_the_first_sample_is_not_negative_with_starting_time_pass():
-    time_series = pynwb.TimeSeries(name="test_time_series", unit="test_units",
-                                   data=[1, 2, 3],  starting_time=0.0, rate=30.0)
+    time_series = pynwb.TimeSeries(
+        name="test_time_series", unit="test_units", data=[1, 2, 3], starting_time=0.0, rate=30.0
+    )
     assert check_timestamp_of_the_first_sample_is_not_negative(time_series) is None
 
 

--- a/tests/unit_tests/test_time_series.py
+++ b/tests/unit_tests/test_time_series.py
@@ -14,6 +14,7 @@ from nwbinspector import (
     check_timestamps_ascending,
     check_missing_unit,
     check_resolution,
+    check_timestamp_of_the_first_sample_is_not_negative
 )
 from nwbinspector.tools import make_minimal_nwbfile
 from nwbinspector.testing import check_streaming_tests_enabled
@@ -213,6 +214,44 @@ def test_check_timestamps_ascending_fail():
         object_name="test_time_series",
         location="/",
     )
+
+
+def test_check_timestamp_of_the_first_sample_is_not_negative_with_timestamps_fail():
+    time_series = pynwb.TimeSeries(name="test_time_series", unit="test_units",
+                                   data=[1, 2, 3], timestamps=[-1, 0, 1])
+    assert check_timestamp_of_the_first_sample_is_not_negative(time_series) == InspectorMessage(
+        message="test_time_series timestamp of the first sample should not be negative value.",
+        importance=Importance.BEST_PRACTICE_VIOLATION,
+        check_function_name="check_timestamp_of_the_first_sample_is_not_negative",
+        object_type="TimeSeries",
+        object_name="test_time_series",
+        location="/",
+    )
+
+
+def test_check_timestamp_of_the_first_sample_is_not_negative_with_timestamps_pass():
+    time_series = pynwb.TimeSeries(name="test_time_series", unit="test_units",
+                                   data=[1, 2, 3], timestamps=[0, 1, 2])
+    assert check_timestamp_of_the_first_sample_is_not_negative(time_series) is None
+
+
+def test_check_timestamp_of_the_first_sample_is_not_negative_with_starting_time_fail():
+    time_series = pynwb.TimeSeries(name="test_time_series", unit="test_units",
+                                   data=[1, 2, 3], starting_time=-1.0, rate=30.0)
+    assert check_timestamp_of_the_first_sample_is_not_negative(time_series) == InspectorMessage(
+        message="test_time_series timestamp of the first sample should not be negative value.",
+        importance=Importance.BEST_PRACTICE_VIOLATION,
+        check_function_name="check_timestamp_of_the_first_sample_is_not_negative",
+        object_type="TimeSeries",
+        object_name="test_time_series",
+        location="/",
+    )
+
+
+def test_check_timestamp_of_the_first_sample_is_not_negative_with_starting_time_pass():
+    time_series = pynwb.TimeSeries(name="test_time_series", unit="test_units",
+                                   data=[1, 2, 3],  starting_time=0.0, rate=30.0)
+    assert check_timestamp_of_the_first_sample_is_not_negative(time_series) is None
 
 
 def test_check_missing_unit_pass():

--- a/tests/unit_tests/test_time_series.py
+++ b/tests/unit_tests/test_time_series.py
@@ -218,8 +218,13 @@ def test_check_timestamps_ascending_fail():
 
 def test_check_timestamp_of_the_first_sample_is_not_negative_with_timestamps_fail():
     time_series = pynwb.TimeSeries(name="test_time_series", unit="test_units", data=[1, 2, 3], timestamps=[-1, 0, 1])
+    message = (
+        "test_time_series timestamp of the first sample should not be negative value. "
+        "It is recommended to align the `session_start_time` or `timestamps_reference_time` "
+        "to be the earliest time value that occurs in the data, and shift all other signals accordingly."
+    )
     assert check_timestamp_of_the_first_sample_is_not_negative(time_series) == InspectorMessage(
-        message="test_time_series timestamp of the first sample should not be negative value.",
+        message=message,
         importance=Importance.BEST_PRACTICE_VIOLATION,
         check_function_name="check_timestamp_of_the_first_sample_is_not_negative",
         object_type="TimeSeries",
@@ -237,8 +242,13 @@ def test_check_timestamp_of_the_first_sample_is_not_negative_with_starting_time_
     time_series = pynwb.TimeSeries(
         name="test_time_series", unit="test_units", data=[1, 2, 3], starting_time=-1.0, rate=30.0
     )
+    message = (
+        "test_time_series timestamp of the first sample should not be negative value. "
+        "It is recommended to align the `session_start_time` or `timestamps_reference_time` "
+        "to be the earliest time value that occurs in the data, and shift all other signals accordingly."
+    )
     assert check_timestamp_of_the_first_sample_is_not_negative(time_series) == InspectorMessage(
-        message="test_time_series timestamp of the first sample should not be negative value.",
+        message=message,
         importance=Importance.BEST_PRACTICE_VIOLATION,
         check_function_name="check_timestamp_of_the_first_sample_is_not_negative",
         object_type="TimeSeries",

--- a/tests/unit_tests/test_time_series.py
+++ b/tests/unit_tests/test_time_series.py
@@ -219,8 +219,8 @@ def test_check_timestamps_ascending_fail():
 def test_check_timestamp_of_the_first_sample_is_not_negative_with_timestamps_fail():
     time_series = pynwb.TimeSeries(name="test_time_series", unit="test_units", data=[1, 2, 3], timestamps=[-1, 0, 1])
     message = (
-        "test_time_series timestamp of the first sample should not be negative value. "
-        "It is recommended to align the `session_start_time` or `timestamps_reference_time` "
+        "Timestamps should not be negative."
+        " It is recommended to align the `session_start_time` or `timestamps_reference_time` "
         "to be the earliest time value that occurs in the data, and shift all other signals accordingly."
     )
     assert check_timestamp_of_the_first_sample_is_not_negative(time_series) == InspectorMessage(
@@ -243,8 +243,8 @@ def test_check_timestamp_of_the_first_sample_is_not_negative_with_starting_time_
         name="test_time_series", unit="test_units", data=[1, 2, 3], starting_time=-1.0, rate=30.0
     )
     message = (
-        "test_time_series timestamp of the first sample should not be negative value. "
-        "It is recommended to align the `session_start_time` or `timestamps_reference_time` "
+        "Timestamps should not be negative."
+        " It is recommended to align the `session_start_time` or `timestamps_reference_time` "
         "to be the earliest time value that occurs in the data, and shift all other signals accordingly."
     )
     assert check_timestamp_of_the_first_sample_is_not_negative(time_series) == InspectorMessage(


### PR DESCRIPTION
## Motivation

Add a Best Practice and an Inspector check to make sure the timestamp of the first sample in a `TimeSeries` is not negative.  When `starting_time` or the first value in the `timestamps` vector of a `TimeSeries` is negative, the Inspector will output a Best Practice Violation message. 