### PR TITLE
do not upper bound numpy on python >= 3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ click
 tqdm
 isodate
 numpy>=1.20.0,<1.21.0;python_version<'3.8'
-numpy>=1.22.0,<1.23.0;python_version>='3.8'  # <1.23 bound is from PyNWB
+numpy>=1.22.0;python_version>='3.8'


### PR DESCRIPTION
Original commit which added those bounds (f0db1aaa773127249e365627136a4fb9d834da0d) provides no information on the rationale. But in my experience bounding like this is more of causing problems (if done within setup.py, but here setup.py just reuses what is in requirements.txt) down the road, although possibly providing momentary problem fixing at earlier time.

ATM e.g. it complicates providing dandi-cli update for python 3.11 which @jwodder tried to accomplish, see
https://github.com/dandi/dandi-cli/pull/1143#issuecomment-1355512856 for more detail

I left it for older pythons although also not sure if needed/desired since AFAIK recent numpy should support any supported python version (such as 3.7), doesn't it?