### PR TITLE
Skip `check_timestamps_match_first_dimension` when `external_file` is specified and data is empty

### DIFF
--- a/src/nwbinspector/checks/time_series.py
+++ b/src/nwbinspector/checks/time_series.py
@@ -59,6 +59,12 @@ def check_timestamps_match_first_dimension(time_series: TimeSeries):
     if time_series.data is None or time_series.timestamps is None:
         return
 
+    if (
+        getattr(time_series, "external_file", None) is not None
+        and get_data_shape(time_series.data)[0] == 0
+    ):
+        return
+
     # A very specific edge case where this has been allowed, though much more preferable
     # to use a stack of Images rather than an ImageSeries
     if (

--- a/src/nwbinspector/checks/time_series.py
+++ b/src/nwbinspector/checks/time_series.py
@@ -59,10 +59,7 @@ def check_timestamps_match_first_dimension(time_series: TimeSeries):
     if time_series.data is None or time_series.timestamps is None:
         return
 
-    if (
-        getattr(time_series, "external_file", None) is not None
-        and get_data_shape(time_series.data)[0] == 0
-    ):
+    if getattr(time_series, "external_file", None) is not None and get_data_shape(time_series.data)[0] == 0:
         return
 
     # A very specific edge case where this has been allowed, though much more preferable

--- a/tests/unit_tests/test_image_series.py
+++ b/tests/unit_tests/test_image_series.py
@@ -13,6 +13,7 @@ from nwbinspector import (
     check_image_series_external_file_valid,
     check_image_series_external_file_relative,
     check_image_series_data_size,
+    check_timestamps_match_first_dimension,
 )
 from nwbinspector.tools import make_minimal_nwbfile
 from nwbinspector.testing import load_testing_config
@@ -121,6 +122,17 @@ def test_check_small_image_series_stored_internally():
     image_series = ImageSeries(name="ImageSeriesLarge", rate=1.0, data=data, unit="TestUnit")
 
     assert check_image_series_data_size(image_series=image_series) is None
+
+
+def test_check_image_series_external_file_no_data_valid_pass():
+    image_series = ImageSeries(
+        name="ImageSeriesLarge",
+        external_file=["Test"],
+        format="external",
+        timestamps=[0, 1, 2, 3],
+        unit="TestUnit",
+    )
+    assert check_timestamps_match_first_dimension(time_series=image_series) is None
 
 
 def test_check_large_image_series_stored_internally():


### PR DESCRIPTION
## Motivation

Fix #334
