### PR TITLE
[Bug]: Correctly skip Images checks for PyNWB<2.1.0

### DIFF
--- a/src/nwbinspector/checks/images.py
+++ b/src/nwbinspector/checks/images.py
@@ -7,7 +7,7 @@ from ..register_checks import register_check, Importance, InspectorMessage
 from ..utils import get_package_version
 
 # The Images neurodata type was unavailable prior to PyNWB v.2.1.0
-if get_package_version(name="pynwb") < Version("2.1.0"):
+if get_package_version(name="pynwb") >= Version("2.1.0"):
     from pynwb.base import Images
 
     @register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=Images)

--- a/src/nwbinspector/checks/images.py
+++ b/src/nwbinspector/checks/images.py
@@ -7,7 +7,7 @@ from ..register_checks import register_check, Importance, InspectorMessage
 from ..utils import get_package_version
 
 # The Images neurodata type was unavailable prior to PyNWB v.2.1.0
-if get_package_version(name="pynwb") <= Version("2.1.0"):
+if get_package_version(name="pynwb") < Version("2.1.0"):
     from pynwb.base import Images
 
     @register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=Images)

--- a/src/nwbinspector/checks/images.py
+++ b/src/nwbinspector/checks/images.py
@@ -1,16 +1,14 @@
 """Checks specific to the Images neurodata type."""
-from ..register_checks import register_check, Importance, InspectorMessage
-
-try:  # The Images neurodata type was unavailable prior to PyNWB v.2.1.0
-    from pynwb.base import Images
-
-    HAVE_IMAGES = True
-except ImportError:
-    HAVE_IMAGES = False
+from packaging.version import Version
 
 from pynwb.image import IndexSeries
 
-if HAVE_IMAGES:
+from ..register_checks import register_check, Importance, InspectorMessage
+from ..utils import get_package_version
+
+# The Images neurodata type was unavailable prior to PyNWB v.2.1.0
+if get_package_version(name="pynwb") <= Version("2.1.0"):
+    from pynwb.base import Images
 
     @register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=Images)
     def check_order_of_images_unique(images: Images):

--- a/tests/unit_tests/test_images.py
+++ b/tests/unit_tests/test_images.py
@@ -11,14 +11,10 @@ from nwbinspector.checks.images import (
     check_index_series_points_to_image,
 )
 
-try:
-    from pynwb.base import Images, ImageReferences
-
-    HAVE_IMAGES = True
-except ImportError:
-    HAVE_IMAGES = False
+HAVE_IMAGES = get_package_version(name="pynwb") >= Version("2.1.0"):
 skip_reason = "You must have PyNWB>=v2.1.0 to run these tests!"
-
+if HAVE_IMAGES:
+    from pynwb.base import Images, ImageReferences
 
 @pytest.mark.skipif(not HAVE_IMAGES, reason=skip_reason)
 def test_check_order_of_images_unique():

--- a/tests/unit_tests/test_images.py
+++ b/tests/unit_tests/test_images.py
@@ -3,6 +3,7 @@ import pytest
 import numpy as np
 from pynwb import TimeSeries
 from pynwb.image import GrayscaleImage, IndexSeries
+from packaging.version import Version
 
 from nwbinspector import InspectorMessage, Importance
 from nwbinspector.checks.images import (
@@ -10,6 +11,7 @@ from nwbinspector.checks.images import (
     check_order_of_images_len,
     check_index_series_points_to_image,
 )
+from nwbinspector.utils import get_package_version
 
 HAVE_IMAGES = get_package_version(name="pynwb") >= Version("2.1.0")
 skip_reason = "You must have PyNWB>=v2.1.0 to run these tests!"

--- a/tests/unit_tests/test_images.py
+++ b/tests/unit_tests/test_images.py
@@ -16,6 +16,7 @@ skip_reason = "You must have PyNWB>=v2.1.0 to run these tests!"
 if HAVE_IMAGES:
     from pynwb.base import Images, ImageReferences
 
+
 @pytest.mark.skipif(not HAVE_IMAGES, reason=skip_reason)
 def test_check_order_of_images_unique():
     imgs = [GrayscaleImage(name=f"image{i}", data=np.random.randn(10, 10)) for i in range(5)]

--- a/tests/unit_tests/test_images.py
+++ b/tests/unit_tests/test_images.py
@@ -11,7 +11,7 @@ from nwbinspector.checks.images import (
     check_index_series_points_to_image,
 )
 
-HAVE_IMAGES = get_package_version(name="pynwb") >= Version("2.1.0"):
+HAVE_IMAGES = get_package_version(name="pynwb") >= Version("2.1.0")
 skip_reason = "You must have PyNWB>=v2.1.0 to run these tests!"
 if HAVE_IMAGES:
     from pynwb.base import Images, ImageReferences


### PR DESCRIPTION
## Motivation

Hotfix for users running the NWB Inspector using PyNWB v2.0.0

The previous conditional logic apparently does not correctly exclude the checks regarding usage of the attributes

TODO: figure out why tests didn't catch this (we test against 2 previous PyNWB versions, I thought...)

