### PR TITLE
skip predefined columns

### DIFF
--- a/src/nwbinspector/checks/tables.py
+++ b/src/nwbinspector/checks/tables.py
@@ -111,7 +111,10 @@ def check_column_binary_capability(table: DynamicTable, nelems: Optional[int] = 
         very long so you don't need to load the entire array into memory. Use None to
         load the entire arrays.
     """
+    pre_defined_column_names = [column["name"] for column in getattr(table, "__columns__", list())]
     for column in table.columns:
+        if column.name in pre_defined_column_names:
+            continue  # The column name and data type cannot be changed by the user
         if hasattr(column, "data") and not isinstance(column, VectorIndex):
             if np.asarray(column.data[0]).itemsize == 1:
                 continue  # already boolean, int8, or uint8

--- a/tests/unit_tests/test_tables.py
+++ b/tests/unit_tests/test_tables.py
@@ -222,6 +222,14 @@ class TestCheckBinaryColumns(TestCase):
         assert check_column_binary_capability(table=self.table) is None
 
 
+def test_check_binary_skip_pre_defined_columns():
+    units = Units()
+    units.add_unit(spike_times=[0], waveform_mean=[0])
+    units.add_unit(spike_times=[1], waveform_mean=[1])
+
+    assert check_column_binary_capability(table=units) is None
+
+
 def test_check_single_row_pass():
     table = DynamicTable(name="test_table", description="")
     table.add_column(name="test_column", description="")


### PR DESCRIPTION
fix #347 

## Motivation

`check_binary_column` was running on predefined columns that a user has no control over naming, so the check does not make sense to run in those cases
