### PR TITLE
C elegens metadata

### DIFF
--- a/docs/best_practices/nwbfile_metadata.rst
+++ b/docs/best_practices/nwbfile_metadata.rst
@@ -195,7 +195,7 @@ Sex
 The ``sex`` of the :ref:`nwb-schema:sec-Subject` should be specified as a single upper-case character among the
 following four possibilities: "M" (male), "F" (female), "U" (unknown), or "O" (other, for asexual species).
 
-C. elegens are an exception to this rule. For C. elegens, the sex should either be "XO" (male) or "XX" (hermaphrodite).
+C. elegans are an exception to this rule. For C. elegans, the sex should either be "XO" (male) or "XX" (hermaphrodite).
 
 Check function: :py:meth:`~nwbinspector.checks.nwbfile_metadata.check_subject_sex`
 

--- a/docs/best_practices/nwbfile_metadata.rst
+++ b/docs/best_practices/nwbfile_metadata.rst
@@ -195,6 +195,8 @@ Sex
 The ``sex`` of the :ref:`nwb-schema:sec-Subject` should be specified as a single upper-case character among the
 following four possibilities: "M" (male), "F" (female), "U" (unknown), or "O" (other, for asexual species).
 
+C. elegens are an exception to this rule. For C. elegens, the sex should either be "XO" (male) or "XX" (hermaphrodite).
+
 Check function: :py:meth:`~nwbinspector.checks.nwbfile_metadata.check_subject_sex`
 
 

--- a/src/nwbinspector/checks/nwbfile_metadata.py
+++ b/src/nwbinspector/checks/nwbfile_metadata.py
@@ -197,10 +197,12 @@ def check_subject_id_exists(subject: Subject):
 
 @register_check(importance=Importance.BEST_PRACTICE_SUGGESTION, neurodata_type=Subject)
 def check_subject_sex(subject: Subject):
-    """Check if the subject sex has been specified, if one exists."""
+    """Check that the subject sex has been correctly specified."""
     if subject and not subject.sex:
         return InspectorMessage(message="Subject.sex is missing.")
-    elif subject.sex not in ("M", "F", "O", "U"):
+    if subject.species in ("Caenorhabditis elegens", "C. elegens") and subject.sex not in ("XO", "XX"):
+        return InspectorMessage(message="For C. elegens, Subject.sex should be 'XO' or 'XX'.")
+    if subject.sex not in ("M", "F", "O", "U"):
         return InspectorMessage(
             message="Subject.sex should be one of: 'M' (male), 'F' (female), 'O' (other), or 'U' (unknown)."
         )

--- a/src/nwbinspector/checks/nwbfile_metadata.py
+++ b/src/nwbinspector/checks/nwbfile_metadata.py
@@ -200,9 +200,10 @@ def check_subject_sex(subject: Subject):
     """Check that the subject sex has been correctly specified."""
     if subject and not subject.sex:
         return InspectorMessage(message="Subject.sex is missing.")
-    if subject.species in ("Caenorhabditis elegans", "C. elegans") and subject.sex not in ("XO", "XX"):
-        return InspectorMessage(message="For C. elegans, Subject.sex should be 'XO' or 'XX'.")
-    if subject.sex not in ("M", "F", "O", "U"):
+    if subject.species in ("Caenorhabditis elegans", "C. elegans"):
+        if subject.sex not in ("XO", "XX"):
+            return InspectorMessage(message="For C. elegans, Subject.sex should be 'XO' or 'XX'.")
+    elif subject.sex not in ("M", "F", "O", "U"):
         return InspectorMessage(
             message="Subject.sex should be one of: 'M' (male), 'F' (female), 'O' (other), or 'U' (unknown)."
         )

--- a/src/nwbinspector/checks/nwbfile_metadata.py
+++ b/src/nwbinspector/checks/nwbfile_metadata.py
@@ -201,7 +201,7 @@ def check_subject_sex(subject: Subject):
     if subject and not subject.sex:
         return InspectorMessage(message="Subject.sex is missing.")
     if subject.species in ("Caenorhabditis elegans", "C. elegans") and subject.sex not in ("XO", "XX"):
-        return InspectorMessage(message="For C. elegens, Subject.sex should be 'XO' or 'XX'.")
+        return InspectorMessage(message="For C. elegans, Subject.sex should be 'XO' or 'XX'.")
     if subject.sex not in ("M", "F", "O", "U"):
         return InspectorMessage(
             message="Subject.sex should be one of: 'M' (male), 'F' (female), 'O' (other), or 'U' (unknown)."

--- a/src/nwbinspector/checks/nwbfile_metadata.py
+++ b/src/nwbinspector/checks/nwbfile_metadata.py
@@ -195,6 +195,20 @@ def check_subject_id_exists(subject: Subject):
         return InspectorMessage(message="subject_id is missing.")
 
 
+def _check_subject_sex_defaults(sex: str):
+    """Check if the subject sex has been specified properly for the C. elegans species."""
+    if sex not in ("M", "F", "O", "U"):
+        return InspectorMessage(
+            message="Subject.sex should be one of: 'M' (male), 'F' (female), 'O' (other), or 'U' (unknown)."
+        )
+
+
+def _check_subject_sex_c_elegans(sex: str):
+    """Check if the subject sex has been specified properly for the C. elegans species."""
+    if sex not in ("XO", "XX"):
+        return InspectorMessage(message="For C. elegans, Subject.sex should be 'XO' (male) or 'XX' (hermaphrodite).")
+
+
 @register_check(importance=Importance.BEST_PRACTICE_SUGGESTION, neurodata_type=Subject)
 def check_subject_sex(subject: Subject):
     """
@@ -205,12 +219,9 @@ def check_subject_sex(subject: Subject):
     if subject and not subject.sex:
         return InspectorMessage(message="Subject.sex is missing.")
     if subject.species in ("Caenorhabditis elegans", "C. elegans"):
-        if subject.sex not in ("XO", "XX"):
-            return InspectorMessage(message="For C. elegans, Subject.sex should be 'XO' or 'XX'.")
-    elif subject.sex not in ("M", "F", "O", "U"):
-        return InspectorMessage(
-            message="Subject.sex should be one of: 'M' (male), 'F' (female), 'O' (other), or 'U' (unknown)."
-        )
+        return _check_subject_sex_c_elegans(sex=subject.sex)
+    else:
+        return _check_subject_sex_defaults(sex=subject.sex)
 
 
 @register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=Subject)

--- a/src/nwbinspector/checks/nwbfile_metadata.py
+++ b/src/nwbinspector/checks/nwbfile_metadata.py
@@ -198,7 +198,7 @@ def check_subject_id_exists(subject: Subject):
 @register_check(importance=Importance.BEST_PRACTICE_SUGGESTION, neurodata_type=Subject)
 def check_subject_sex(subject: Subject):
     """
-    Check if the subject sex has been specified, and if so if it has has the correct form.
+    Check if the subject sex has been specified and ensure that it has has the correct form depending on the species.
 
     Best Practice: :ref:`best_practice_subject_sex`
     """

--- a/src/nwbinspector/checks/nwbfile_metadata.py
+++ b/src/nwbinspector/checks/nwbfile_metadata.py
@@ -200,7 +200,7 @@ def check_subject_sex(subject: Subject):
     """Check that the subject sex has been correctly specified."""
     if subject and not subject.sex:
         return InspectorMessage(message="Subject.sex is missing.")
-    if subject.species in ("Caenorhabditis elegens", "C. elegens") and subject.sex not in ("XO", "XX"):
+    if subject.species in ("Caenorhabditis elegans", "C. elegans") and subject.sex not in ("XO", "XX"):
         return InspectorMessage(message="For C. elegens, Subject.sex should be 'XO' or 'XX'.")
     if subject.sex not in ("M", "F", "O", "U"):
         return InspectorMessage(

--- a/tests/unit_tests/test_nwbfile_metadata.py
+++ b/tests/unit_tests/test_nwbfile_metadata.py
@@ -495,7 +495,7 @@ def test_check_subject_species_c_elegans():
     subject = Subject(subject_id="001", species="C. elegans")
 
     assert check_subject_species_form(subject) == InspectorMessage(
-        message="Subject species 'Human' should be in latin binomial form, e.g. 'Mus musculus' and 'Homo sapiens'",
+        message="Subject species 'C. elegans' should be in latin binomial form, e.g. 'Mus musculus' and 'Homo sapiens'",
         importance=Importance.BEST_PRACTICE_VIOLATION,
         check_function_name="check_subject_species_form",
         object_type="Subject",

--- a/tests/unit_tests/test_nwbfile_metadata.py
+++ b/tests/unit_tests/test_nwbfile_metadata.py
@@ -267,7 +267,7 @@ def test_check_subject_sex():
     nwbfile = NWBFile(session_description="", identifier=str(uuid4()), session_start_time=datetime.now().astimezone())
     nwbfile.subject = Subject(subject_id="001")
 
-    assert check_subject_sex(nwbfile.subject) == InspectorMessage(
+    assert check_subject_sex(subject=nwbfile.subject) == InspectorMessage(
         message="Subject.sex is missing.",
         importance=Importance.BEST_PRACTICE_SUGGESTION,
         check_function_name="check_subject_sex",
@@ -277,10 +277,10 @@ def test_check_subject_sex():
     )
 
 
-def test_check_subject_sex_other_value():
+def test_check_subject_sex_wrong_value():
     subject = Subject(subject_id="001", sex="Female")
 
-    assert check_subject_sex(subject) == InspectorMessage(
+    assert check_subject_sex(subject=subject) == InspectorMessage(
         message="Subject.sex should be one of: 'M' (male), 'F' (female), 'O' (other), or 'U' (unknown).",
         importance=Importance.BEST_PRACTICE_SUGGESTION,
         check_function_name="check_subject_sex",
@@ -288,6 +288,44 @@ def test_check_subject_sex_other_value():
         object_name="subject",
         location="/general/subject",
     )
+
+
+def test_check_subject_sex_caenorhabditis_elegans_default_sex():
+    subject = Subject(subject_id="001", species="Caenorhabditis elegans", sex="F")
+
+    assert check_subject_sex(subject=subject) == InspectorMessage(
+        message="For C. elegans, Subject.sex should be 'XO' (male) or 'XX' (hermaphrodite).",
+        importance=Importance.BEST_PRACTICE_SUGGESTION,
+        check_function_name="check_subject_sex",
+        object_type="Subject",
+        object_name="subject",
+        location="/general/subject",
+    )
+
+
+def test_check_subject_sex_c_elegans_default_sex():
+    subject = Subject(subject_id="001", species="C. elegans", sex="F")
+
+    assert check_subject_sex(subject=subject) == InspectorMessage(
+        message="For C. elegans, Subject.sex should be 'XO' (male) or 'XX' (hermaphrodite).",
+        importance=Importance.BEST_PRACTICE_SUGGESTION,
+        check_function_name="check_subject_sex",
+        object_type="Subject",
+        object_name="subject",
+        location="/general/subject",
+    )
+
+
+def test_check_subject_sex_c_elegans_xo_sex():
+    subject = Subject(subject_id="001", species="C. elegans", sex="XO")
+
+    assert check_subject_sex(subject) is None
+
+
+def test_check_subject_sex_c_elegans_xx_sex():
+    subject = Subject(subject_id="001", species="C. elegans", sex="XX")
+
+    assert check_subject_sex(subject) is None
 
 
 def test_pass_check_subject_age_with_dob():
@@ -442,6 +480,19 @@ def check_subject_species_ncbi_pass():
 
 def test_check_subject_species_not_binomial():
     subject = Subject(subject_id="001", species="Human")
+
+    assert check_subject_species_form(subject) == InspectorMessage(
+        message="Subject species 'Human' should be in latin binomial form, e.g. 'Mus musculus' and 'Homo sapiens'",
+        importance=Importance.BEST_PRACTICE_VIOLATION,
+        check_function_name="check_subject_species_form",
+        object_type="Subject",
+        object_name="subject",
+        location="/general/subject",
+    )
+
+
+def test_check_subject_species_c_elegans():
+    subject = Subject(subject_id="001", species="C. elegans")
 
     assert check_subject_species_form(subject) == InspectorMessage(
         message="Subject species 'Human' should be in latin binomial form, e.g. 'Mus musculus' and 'Homo sapiens'",


### PR DESCRIPTION
## Motivation

From conversation with Daniel Sprague:

> I was wondering if there were possible changes we could make to the restrictions imposed on age and sex. C. elegans growth stages are defined from L1-L4 followed by adulthood. Most of the worms we use are designated 'YA' for young adult. I believe for our purposes, this is a more useful designation than dahs or weeks old since the lifesplan of the owrm is relatively short. Furthermore, for sex, C. elegans have two sexes: male 'XO' and hermaphrodite 'XX' which are designated by their sex chromosomes. I see that there is an option for other, but since the hermaphrodite is the typical system we study, I think it would be useful to be able to just input the chromosomal designations if that's possible.

What do you think, @CodyCBakerPhD ?
