### PR TITLE
[Bug]: config check name reference

### DIFF
--- a/src/nwbinspector/__init__.py
+++ b/src/nwbinspector/__init__.py
@@ -13,3 +13,5 @@ from .checks.ophys import *
 from .checks.tables import *
 from .checks.time_series import *
 from .checks.icephys import *
+
+default_check_registry = {check.__name__: check for check in available_checks}

--- a/src/nwbinspector/internal_configs/dandi.inspector_config.yaml
+++ b/src/nwbinspector/internal_configs/dandi.inspector_config.yaml
@@ -3,7 +3,7 @@ CRITICAL:  # All the fields under CRITICAL will be required for dandi validate t
   - check_subject_id_exists
   - check_subject_sex
   - check_subject_species_exists
-  - check_subject_species_latin_binomial
+  - check_subject_species_form
   - check_subject_age
   - check_subject_proper_age_range
 BEST_PRACTICE_VIOLATION:

--- a/tests/test_check_configuration.py
+++ b/tests/test_check_configuration.py
@@ -8,6 +8,7 @@ from nwbinspector import (
     check_data_orientation,
     check_timestamps_match_first_dimension,
     available_checks,
+    default_check_registry,
 )
 from nwbinspector.nwbinspector import validate_config, configure_checks, _copy_function, load_config
 
@@ -94,7 +95,7 @@ class TestCheckConfiguration(TestCase):
                     "check_subject_id_exists",
                     "check_subject_sex",
                     "check_subject_species_exists",
-                    "check_subject_species_latin_binomial",
+                    "check_subject_species_form",
                     "check_subject_age",
                     "check_subject_proper_age_range",
                 ],
@@ -103,3 +104,11 @@ class TestCheckConfiguration(TestCase):
                 ],
             ),
         )
+
+    def test_all_config_check_names_are_in_default_registry(self):
+        config = load_config(filepath_or_keyword="dandi")
+        for importance_level, check_names in config.items():
+            for check_name in check_names:
+                assert check_name in default_check_registry, "Check name {check_name} was not found in the default registry!"
+        
+        

--- a/tests/test_check_configuration.py
+++ b/tests/test_check_configuration.py
@@ -111,4 +111,4 @@ class TestCheckConfiguration(TestCase):
             for check_name in check_names:
                 assert (
                     check_name in default_check_registry
-                ), "Check name {check_name} was not found in the default registry!"
+                ), f"Check name {check_name} was not found in the default registry!"

--- a/tests/test_check_configuration.py
+++ b/tests/test_check_configuration.py
@@ -109,6 +109,6 @@ class TestCheckConfiguration(TestCase):
         config = load_config(filepath_or_keyword="dandi")
         for importance_level, check_names in config.items():
             for check_name in check_names:
-                assert check_name in default_check_registry, "Check name {check_name} was not found in the default registry!"
-        
-        
+                assert (
+                    check_name in default_check_registry
+                ), "Check name {check_name} was not found in the default registry!"


### PR DESCRIPTION
## Motivation

The name of the latin binomial check was altered in #290 but was not updated in the config file

Revealed by @garrettflynn in https://github.com/NeurodataWithoutBorders/nwb-guide/pull/96