### PR TITLE
add email notification of daily failures

### DIFF
--- a/.github/workflows/dailies.yml
+++ b/.github/workflows/dailies.yml
@@ -11,3 +11,18 @@ jobs:
 
   run-daily-doc-link-checks:
     uses: neurodatawithoutborders/nwbinspector/.github/workflows/doc-link-checks.yml@dev
+
+  notify:
+      if: failure()
+      name: Notify the email list
+      uses: dawidd6/action-send-mail@v3
+      with:
+        server_address: smtp.gmail.com
+        secure: true
+        username: ${{ secrets.MAIL_USERNAME }}
+        password: ${{ secrets.MAIL_PASSWORD }}
+        subject: NWB Inspector Daily Failure
+        to: ${{ secrets.DAILY_NOTIFICATION_EMAIL_LIST }}
+        from: NWB Inspector
+        body: "The daily workflow for the NWB Inspector failed: please check status at https://github.com/NeurodataWithoutBorders/nwbinspector/actions/workflows/dailies.yml"
+        priority: high

--- a/.github/workflows/dailies.yml
+++ b/.github/workflows/dailies.yml
@@ -13,16 +13,16 @@ jobs:
     uses: neurodatawithoutborders/nwbinspector/.github/workflows/doc-link-checks.yml@dev
 
   notify:
-      if: failure()
-      name: Notify the email list
-      uses: dawidd6/action-send-mail@v3
-      with:
-        server_address: smtp.gmail.com
-        secure: true
-        username: ${{ secrets.MAIL_USERNAME }}
-        password: ${{ secrets.MAIL_PASSWORD }}
-        subject: NWB Inspector Daily Failure
-        to: ${{ secrets.DAILY_NOTIFICATION_EMAIL_LIST }}
-        from: NWB Inspector
-        body: "The daily workflow for the NWB Inspector failed: please check status at https://github.com/NeurodataWithoutBorders/nwbinspector/actions/workflows/dailies.yml"
-        priority: high
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dawidd6/action-send-mail@v3.7.1
+        with:
+          server_address: smtp.gmail.com
+          secure: true
+          username: ${{ secrets.MAIL_USERNAME }}
+          password: ${{ secrets.MAIL_PASSWORD }}
+          subject: NWB Inspector Daily Failure
+          to: ${{ secrets.DAILY_NOTIFICATION_EMAIL_LIST }}
+          from: NWB Inspector
+          body: "The daily workflow for the NWB Inspector failed: please check status at https://github.com/NeurodataWithoutBorders/nwbinspector/actions/workflows/dailies.yml"
+          priority: high

--- a/.github/workflows/dailies.yml
+++ b/.github/workflows/dailies.yml
@@ -22,7 +22,7 @@ jobs:
           username: ${{ secrets.MAIL_USERNAME }}
           password: ${{ secrets.MAIL_PASSWORD }}
           subject: NWB Inspector Daily Failure
-          to: ${{ secrets.DAILY_NOTIFICATION_EMAIL_LIST }}
+          to: cody.baker@catalystneuro.com
           from: NWB Inspector
           body: "The daily workflow for the NWB Inspector failed: please check status at https://github.com/NeurodataWithoutBorders/nwbinspector/actions/workflows/dailies.yml"
           priority: high


### PR DESCRIPTION
The recent failures in the dailies would have been caught sooner if I had been getting my usual emails - but apparently the built-in notification feature on GitHub only applies to the person who last modified the action file in question, which was not myself

Setting up an actual email notification also allows me to add other individuals to the email list that might be interested if it starts failing

@oruebel @rly @bendichter let me know if any of you would like to be on that email list