### PR TITLE
move from ros3 to fsspec

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -43,7 +43,7 @@ body:
   - type: dropdown
     id: streaming
     attributes:
-      label: Were you streaming with ROS3?
+      label: Were you streaming?
       options:
         - 'Yes'
         - 'No'

--- a/.github/workflows/streaming-tests.yml
+++ b/.github/workflows/streaming-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.7", "3.10"]
+        python-version: ["3.8", "3.11"]
     steps:
       - uses: s-weigand/setup-conda@v1
         with:
@@ -26,10 +26,6 @@ jobs:
         run: |
           pip install -e .
           pip install dandi
-      - name: Uninstall h5py
-        run: pip uninstall -y h5py
-      - name: Install ROS3
-        run: conda install -c conda-forge h5py
 
       - name: Run pytest on stream tests
         run: pytest tests/ -rsx tests/streaming_tests.py

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.7", "3.10"]
+        python-version: ["3.8", "3.11"]
     steps:
       - uses: s-weigand/setup-conda@v1
         with:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -32,10 +32,6 @@ jobs:
         run: |
           dandi download "https://gui-staging.dandiarchive.org/#/dandiset/204919"
           python -c "from nwbinspector.testing import update_testing_config; update_testing_config(key='LOCAL_PATH', value='./204919/testing_files/')"
-      - name: Uninstall h5py
-        run: pip uninstall -y h5py
-      - name: Install ROS3
-        run: conda install -c conda-forge h5py
 
       - name: Run pytest with coverage
         run: pytest -rsx --cov=./ --cov-report xml:./nwbinspector/nwbinspector/coverage.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Improvements
 * Added an intermediate workflow to the main `nwbinspector` call pattern, named `inspect_nwbfile_object`. [#364](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/364)
-
+* Use fsspec for streaming instead of ros3. [#379](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/379)
 
 
 # v0.4.27

--- a/docs/conf_extlinks.py
+++ b/docs/conf_extlinks.py
@@ -13,10 +13,6 @@ extlinks = {
         None,
     ),
     "dandi-archive": ("https://dandiarchive.org/%s", "%s"),
-    "ros3-tutorial": (
-        "https://pynwb.readthedocs.io/en/stable/tutorials/advanced_io/streaming.html#streaming-method-2-ros3%s",
-        None,
-    ),
     "alternative-streaming-tutorial": (
         "https://pynwb.readthedocs.io/en/stable/tutorials/advanced_io/streaming.html#streaming-method-1-fsspec%s",
         None,

--- a/docs/user_guide/using_the_command_line_interface.rst
+++ b/docs/user_guide/using_the_command_line_interface.rst
@@ -31,8 +31,6 @@ If the NWB file(s) you wish to inspect are already on the :dandi-archive:`DANDI 
 
     nwbinspector 000017 --stream
 
-This usage will require you to install the ROS3 driver - the general tutorial for ROS3 streaming of NWB files can be found on the :ros3-tutorial:`PyNWB documentation <>`. See :ref:`simple_streaming_api` for a more advanced tutorial using the API functions.
-
 .. note::
 
     You can also specify the exact S3 path instead of the DANDI set ID, if known. When specifying only the DANDI set ID, the S3 paths of all NWB assets are automatically fetched for your convenience.

--- a/docs/user_guide/using_the_library.rst
+++ b/docs/user_guide/using_the_library.rst
@@ -67,15 +67,15 @@ This has the same return structure as :py:class:`~nwbinspector.nwbinspector.insp
 
 .. _simple_streaming_api:
 
-Inspect a DANDI set (ROS3)
---------------------------
+Inspect a dandiset
+------------------
 
 It is a common use case to inspect and review entire datasets of NWB files that have already been uploaded to the
 :dandi-archive:`DANDI Archive <>`. While it is possible to simply download the entire dandiset to your local computer and
 run the NWB Inspector as usual, it can be more convenient to stream the data. This can be especially useful when the
 dandiset is large and impractical to download in full.
 
-Once you install the :ros3-tutorial:`ros3 driver <>`, you can inspect a dandiset by providing the six-digit identifier.
+You can inspect a dandiset by providing the six-digit identifier.
 
 .. code-block:: python
 

--- a/docs/user_guide/using_the_library_advanced.rst
+++ b/docs/user_guide/using_the_library_advanced.rst
@@ -47,10 +47,8 @@ Of course, the generator can be treated like any other iterable as well, such as
 
 .. _advanced_streaming_api:
 
-Fetching and inspecting individual DANDI assets (ROS3)
-------------------------------------------------------
-
-While the section explaining :ref:`basic steaming of a dandiset <simple_streaming_api>` covered the simplest and most convenient usage of the streaming feature, sometimes a greater degree of control or customization is required. The :py:attr:`driver` argument of the :py:class:`~pynwb.NWBHDF5IO` can be passed directly into our core inspection functions. In this case, the :py:attr:`path` or :py:attr:`nwbfile_path` arguments become the full S3 path on the DANDI archive. Resolution of these paths can be performed via the following code...
+Fetching and inspecting individual NWB files on DANDI
+-----------------------------------------------------
 
 
 .. code-block:: python
@@ -66,11 +64,7 @@ While the section explaining :ref:`basic steaming of a dandiset <simple_streamin
         dandiset = client.get_dandiset(dandiset_id, dandiset_type)
         for asset in dandiset.get_assets():
             s3_url = asset.get_content_url(follow_redirects=1, strip_query=True)
-            messages.extend(list(inspect_nwb(nwbfile_path=s3_url, driver="ros3")))
-
-.. note::
-
-    Since the :py:attr:`driver` argument can be passed directly into PyNWB, it should also be possible to utilize :alternative-streaming-tutorial:`alternative streaming methods <>` with the NWB Insector API.
+            messages.extend(list(inspect_nwb(nwbfile_path=s3_url, stream=True)))
 
 .. note::
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ tqdm
 isodate
 numpy>=1.20.0,<1.21.0;python_version<'3.8'
 numpy>=1.22.0;python_version>='3.8'  # PyNWB usually has some upper bound here, though
+fsspec

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ isodate
 numpy>=1.20.0,<1.21.0;python_version<'3.8'
 numpy>=1.22.0;python_version>='3.8'  # PyNWB usually has some upper bound here, though
 fsspec
+aiohttp
+requests

--- a/src/nwbinspector/nwbinspector.py
+++ b/src/nwbinspector/nwbinspector.py
@@ -312,10 +312,7 @@ def open_nwb(nwbfile_path: str, mode: str = "r", method: Literal["local", "fsspe
                     yield io
     else:
         with pynwb.NWBHDF5IO(
-            nwbfile_path,
-            mode=mode,
-            load_namespaces=True,
-            driver="ros3" if method == "ros3" else None
+            nwbfile_path, mode=mode, load_namespaces=True, driver="ros3" if method == "ros3" else None
         ) as io:
             yield io
 

--- a/src/nwbinspector/nwbinspector.py
+++ b/src/nwbinspector/nwbinspector.py
@@ -304,6 +304,7 @@ def inspect_all_cli(
 def read_nwb(nwbfile_path, stream: bool = False):
     if stream:
         import fsspec
+
         fs = fsspec.filesystem("http")
         f = fs.open(nwbfile_path, "rb")
         file = h5py.File(f)

--- a/src/nwbinspector/testing.py
+++ b/src/nwbinspector/testing.py
@@ -9,7 +9,7 @@ from packaging.version import Version
 from pynwb import NWBHDF5IO
 from pynwb.image import ImageSeries
 
-from .tools import check_streaming_enabled, make_minimal_nwbfile
+from .tools import make_minimal_nwbfile
 from .utils import is_module_installed, get_package_version
 
 
@@ -27,18 +27,14 @@ def check_streaming_tests_enabled() -> Tuple[bool, Optional[str]]:
         strtobool(os.environ.get("NWBI_SKIP_NETWORK_TESTS", "")) if environment_skip_flag != "" else False
     )
     if environment_skip_flag_bool:
-        failure_reason += "Environmental variable set to skip network tets."
-
-    streaming_enabled, streaming_failure_reason = check_streaming_enabled()
-    if not streaming_enabled:
-        failure_reason += streaming_failure_reason
+        failure_reason += "Environmental variable set to skip network tests."
 
     have_dandi = is_module_installed("dandi")
     if not have_dandi:
         failure_reason += "The DANDI package is not installed on the system."
 
     failure_reason = None if failure_reason == "" else failure_reason
-    return streaming_enabled and not environment_skip_flag_bool and have_dandi, failure_reason
+    return not environment_skip_flag_bool and have_dandi, failure_reason
 
 
 def load_testing_config() -> dict:

--- a/src/nwbinspector/tools.py
+++ b/src/nwbinspector/tools.py
@@ -78,19 +78,3 @@ def _get_content_url_and_path(asset, follow_redirects: int = 1, strip_query: boo
     Must be globally defined (not as a part of get_s3_urls..) in order to be pickled.
     """
     return {asset.get_content_url(follow_redirects=1, strip_query=True): asset.path}
-
-
-def check_streaming_enabled() -> Tuple[bool, Optional[str]]:
-    """
-    General purpose helper for determining if the environment can support S3 DANDI streaming.
-
-    Returns the boolean status of the check and, if False, provides a string reason for the failure for the user to
-    utilize as they please (raise an error or warning with that message, print it, or ignore it).
-    """
-    try:
-        request.urlopen("https://dandiarchive.s3.amazonaws.com/ros3test.nwb", timeout=1)
-    except request.URLError:
-        return False, "Internet access to DANDI failed."
-    if "ros3" not in h5py.registered_drivers():
-        return False, "ROS3 driver not installed."
-    return True, None

--- a/tests/streaming_tests.py
+++ b/tests/streaming_tests.py
@@ -16,7 +16,7 @@ STREAMING_TESTS_ENABLED, DISABLED_STREAMING_TESTS_REASON = check_streaming_tests
 
 @pytest.mark.skipif(not STREAMING_TESTS_ENABLED, reason=DISABLED_STREAMING_TESTS_REASON or "")
 def test_dandiset_streaming():
-    messages = list(inspect_all(path="000126", select=["check_subject_species_exists"], stream=True))
+    messages = list(inspect_all(path="000126", select=["check_subject_species_exists"], method="fsspec"))
     assert messages[0] == InspectorMessage(
         message="Subject species is missing.",
         importance=Importance.BEST_PRACTICE_VIOLATION,
@@ -30,7 +30,7 @@ def test_dandiset_streaming():
 
 @pytest.mark.skipif(not STREAMING_TESTS_ENABLED, reason=DISABLED_STREAMING_TESTS_REASON or "")
 def test_dandiset_streaming_parallel():
-    messages = list(inspect_all(path="000126", select=["check_subject_species_exists"], stream=True, n_jobs=2))
+    messages = list(inspect_all(path="000126", select=["check_subject_species_exists"], method="fsspec", n_jobs=2))
     assert messages[0] == InspectorMessage(
         message="Subject species is missing.",
         importance=Importance.BEST_PRACTICE_VIOLATION,

--- a/tests/unit_tests/test_time_series.py
+++ b/tests/unit_tests/test_time_series.py
@@ -16,7 +16,7 @@ from nwbinspector import (
     check_resolution,
     check_timestamp_of_the_first_sample_is_not_negative,
 )
-from nwbinspector.nwbinspector import read_nwb
+from nwbinspector.nwbinspector import open_nwb
 from nwbinspector.tools import make_minimal_nwbfile
 from nwbinspector.testing import check_streaming_tests_enabled
 from nwbinspector.utils import get_package_version
@@ -305,8 +305,8 @@ def test_check_none_matnwb_resolution_pass():
 
     produced with MatNWB, when read with PyNWB~=2.0.1 and HDMF<=3.2.1 contains a resolution value of None.
     """
-    with read_nwb(
-        "https://dandiarchive.s3.amazonaws.com/blobs/da5/107/da510761-653e-4b81-a330-9cdae4838180", stream=True
+    with open_nwb(
+        "https://dandiarchive.s3.amazonaws.com/blobs/da5/107/da510761-653e-4b81-a330-9cdae4838180", method="fsspec"
     ) as io:
         nwbfile = io.read()
         time_series = nwbfile.processing["video_files"]["video"].time_series["20170203_KIB_01_s1.1.h264"]

--- a/tests/unit_tests/test_time_series.py
+++ b/tests/unit_tests/test_time_series.py
@@ -16,9 +16,10 @@ from nwbinspector import (
     check_resolution,
     check_timestamp_of_the_first_sample_is_not_negative,
 )
+from nwbinspector.nwbinspector import read_nwb
 from nwbinspector.tools import make_minimal_nwbfile
 from nwbinspector.testing import check_streaming_tests_enabled
-from nwbinspector.utils import get_package_version, robust_s3_read
+from nwbinspector.utils import get_package_version
 
 STREAMING_TESTS_ENABLED, DISABLED_STREAMING_TESTS_REASON = check_streaming_tests_enabled()
 
@@ -304,17 +305,12 @@ def test_check_none_matnwb_resolution_pass():
 
     produced with MatNWB, when read with PyNWB~=2.0.1 and HDMF<=3.2.1 contains a resolution value of None.
     """
-    with pynwb.NWBHDF5IO(
-        path="https://dandiarchive.s3.amazonaws.com/blobs/da5/107/da510761-653e-4b81-a330-9cdae4838180",
-        mode="r",
-        load_namespaces=True,
-        driver="ros3",
+    with read_nwb(
+            "https://dandiarchive.s3.amazonaws.com/blobs/da5/107/da510761-653e-4b81-a330-9cdae4838180",
+            stream=True
     ) as io:
-        nwbfile = robust_s3_read(command=io.read)
-        time_series = robust_s3_read(
-            command=nwbfile.processing["video_files"]["video"].time_series.get,
-            command_args=["20170203_KIB_01_s1.1.h264"],
-        )
+        nwbfile = io.read()
+        time_series = nwbfile.processing["video_files"]["video"].time_series["20170203_KIB_01_s1.1.h264"]
     assert check_resolution(time_series) is None
 
 

--- a/tests/unit_tests/test_time_series.py
+++ b/tests/unit_tests/test_time_series.py
@@ -306,8 +306,7 @@ def test_check_none_matnwb_resolution_pass():
     produced with MatNWB, when read with PyNWB~=2.0.1 and HDMF<=3.2.1 contains a resolution value of None.
     """
     with read_nwb(
-            "https://dandiarchive.s3.amazonaws.com/blobs/da5/107/da510761-653e-4b81-a330-9cdae4838180",
-            stream=True
+        "https://dandiarchive.s3.amazonaws.com/blobs/da5/107/da510761-653e-4b81-a330-9cdae4838180", stream=True
     ) as io:
         nwbfile = io.read()
         time_series = nwbfile.processing["video_files"]["video"].time_series["20170203_KIB_01_s1.1.h264"]


### PR DESCRIPTION
also created a context manager `read_nwb`, which will probably migrate to PyNWB eventually

## Motivation

fix #293 

I'd like to build zarr support into the new read_nwb context manager, so I'd like to get this merged before looking at supporting the zarr backend
