### PR TITLE
Fix #375

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Upcoming
+### Fixes
+* `check_time_interval_time_columns` now only checks for `start_time`  with `is_ascending_series` . [#382](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/382)
 
 # v0.4.28
 

--- a/src/nwbinspector/checks/tables.py
+++ b/src/nwbinspector/checks/tables.py
@@ -58,7 +58,7 @@ def check_time_interval_time_columns(time_intervals: TimeIntervals, nelems: Opti
     """
     unsorted_cols = []
     for column in time_intervals.columns:
-        if column.name[-5:] == "_time":
+        if column.name == "start_time":
             if not is_ascending_series(column.data, nelems):
                 unsorted_cols.append(column.name)
     if unsorted_cols:

--- a/src/nwbinspector/utils.py
+++ b/src/nwbinspector/utils.py
@@ -92,9 +92,9 @@ def is_ascending_series(series: Union[h5py.Dataset, ArrayLike], nelems: Optional
     if isinstance(series, h5py.Dataset):
         differences = np.diff(_cache_data_selection(data=series, selection=slice(nelems)))
     else:
-        differences = np.diff(series[:nelems])
+        differences = np.diff(series[:nelems]) # already in memory, no need to cache
 
-    return np.all(differences >= 0)  # already in memory, no need to cache
+    return np.all(differences >= 0)  
 
 
 def is_dict_in_string(string: str):

--- a/src/nwbinspector/utils.py
+++ b/src/nwbinspector/utils.py
@@ -92,9 +92,9 @@ def is_ascending_series(series: Union[h5py.Dataset, ArrayLike], nelems: Optional
     if isinstance(series, h5py.Dataset):
         differences = np.diff(_cache_data_selection(data=series, selection=slice(nelems)))
     else:
-        differences = np.diff(series[:nelems]) # already in memory, no need to cache
+        differences = np.diff(series[:nelems])  # already in memory, no need to cache
 
-    return np.all(differences >= 0)  
+    return np.all(differences >= 0)
 
 
 def is_dict_in_string(string: str):

--- a/tests/unit_tests/test_tables.py
+++ b/tests/unit_tests/test_tables.py
@@ -86,7 +86,7 @@ def test_check_time_interval_time_columns():
 
     assert check_time_interval_time_columns(time_intervals) == InspectorMessage(
         message=(
-            "['start_time', 'stop_time'] are time columns but the values are not in ascending order. "
+            "['start_time'] are time columns but the values are not in ascending order. "
             "All times should be in seconds with respect to the session start time."
         ),
         importance=Importance.BEST_PRACTICE_VIOLATION,


### PR DESCRIPTION
This should fix #375. 

Give the discussion in #375 this should probably be the only function that is checked. All the other time columns might not be in ascending order for perfectbly acceptable reasons I think.