### PR TITLE
Should check_subject_exists be CRITICAL? (i.e., should it block DANDI upload)

### DIFF
--- a/src/nwbinspector/checks/nwbfile_metadata.py
+++ b/src/nwbinspector/checks/nwbfile_metadata.py
@@ -104,7 +104,7 @@ def check_keywords(nwbfile: NWBFile):
         return InspectorMessage(message="Metadata /general/keywords is missing.")
 
 
-@register_check(importance=Importance.BEST_PRACTICE_SUGGESTION, neurodata_type=NWBFile)
+@register_check(importance=Importance.CRITICAL, neurodata_type=NWBFile)
 def check_subject_exists(nwbfile: NWBFile):
     """Check if subject exists."""
     if nwbfile.subject is None:


### PR DESCRIPTION
## Motivation

Noticed when looking at the report from someone at the User Days, this check should maybe have a higher importance since dandi upload is actually impossible if a Subject is not in the file
