### PR TITLE
[New Check]: TimeSeries rate is zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Upcoming
 
+### New Checks
+
+* Added `check_rate_is_not_zero` for ensuring non-zero rate value of `TimeSeries` that has more than one frame. [#389](https://github.com/NeurodataWithoutBorders/nwbinspector/issues/389)
+
 # v0.4.30
 
 ### Fixes

--- a/docs/best_practices/time_series.rst
+++ b/docs/best_practices/time_series.rst
@@ -165,7 +165,6 @@ Check function: :py::meth:`~nwbinspector.checks.time_series.check_resolution`
 Zero Rate
 ~~~~~~~~~
 
-If ``data`` field of :ref:`nwb-schema:sec-TimeSeries` has more than one frame, thus first dimension that represent time is
-greater than one, ``rate`` should not be 0.0.
+If the ``data`` field of :ref:`nwb-schema:sec-TimeSeries` has more than one frame, and according to :ref:`best_practice_data_orientation` this axis ought to be time, then the ``rate`` field should not be ``0.0``.
 
 Check function: :py::meth:`~nwbinspector.checks.time_series.check_rate_is_not_zero`

--- a/docs/best_practices/time_series.rst
+++ b/docs/best_practices/time_series.rst
@@ -157,3 +157,15 @@ Unknown Resolution
 If the ``resolution`` of a :ref:`nwb-schema:sec-TimeSeries` is unknown, use ``-1.0`` or ``NaN`` to indicate this.
 
 Check function: :py::meth:`~nwbinspector.checks.time_series.check_resolution`
+
+
+
+.. _best_practice_non_zero_rate:
+
+Zero Rate
+~~~~~~~~~~~~~~~~~~
+
+If ``data`` field of :ref:`nwb-schema:sec-TimeSeries` has more than one frame, thus first dimension that represent time is
+greater than one, ``rate`` should not be 0.0.
+
+Check function: :py::meth:`~nwbinspector.checks.time_series.check_rate_is_not_zero`

--- a/docs/best_practices/time_series.rst
+++ b/docs/best_practices/time_series.rst
@@ -163,7 +163,7 @@ Check function: :py::meth:`~nwbinspector.checks.time_series.check_resolution`
 .. _best_practice_non_zero_rate:
 
 Zero Rate
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~
 
 If ``data`` field of :ref:`nwb-schema:sec-TimeSeries` has more than one frame, thus first dimension that represent time is
 greater than one, ``rate`` should not be 0.0.

--- a/src/nwbinspector/checks/time_series.py
+++ b/src/nwbinspector/checks/time_series.py
@@ -133,9 +133,10 @@ def check_resolution(time_series: TimeSeries):
 
 @register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=TimeSeries)
 def check_rate_is_not_zero(time_series: TimeSeries):
-    if time_series.data is None and time_series.timestamps is None:
+    if time_series.data is None:
         return
-    data_shape = get_data_shape(time_series.data) 
-    timestamps_shape = get_data_shape(time_series.timestamps)
-    if time_series.rate == 0.0 and (data_shape[0] > 1 or timestamps_shape[0] > 1):
-        return InspectorMessage(f"{time_series.name} has a sampling rate value of 0.0Hz but the series has more than one frame.")
+    data_shape = get_data_shape(time_series.data)
+    if time_series.rate == 0.0 and data_shape[0] > 1:
+        return InspectorMessage(
+            f"{time_series.name} has a sampling rate value of 0.0Hz but the series has more than one frame."
+        )

--- a/src/nwbinspector/checks/time_series.py
+++ b/src/nwbinspector/checks/time_series.py
@@ -138,4 +138,4 @@ def check_rate_is_not_zero(time_series: TimeSeries):
     data_shape = get_data_shape(time_series.data) 
     timestamps_shape = get_data_shape(time_series.timestamps)
     if time_series.rate == 0.0 and (data_shape[0] > 1 or timestamps_shape[0] > 1):
-            return InspectorMessage(f"{time_series.name} has a sampling rate value of 0.0Hz but the series has more than one frame.")
+        return InspectorMessage(f"{time_series.name} has a sampling rate value of 0.0Hz but the series has more than one frame.")

--- a/src/nwbinspector/checks/time_series.py
+++ b/src/nwbinspector/checks/time_series.py
@@ -129,3 +129,14 @@ def check_resolution(time_series: TimeSeries):
         return InspectorMessage(
             message=f"'resolution' should use -1.0 or NaN for unknown instead of {time_series.resolution}."
         )
+
+
+@register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=TimeSeries)
+def check_rate_is_not_zero(time_series: TimeSeries):
+    if time_series.data is not None:
+        data_shape = get_data_shape(time_series.data) 
+    if time_series.timestamps is not None:
+        timestamps_shape = get_data_shape(time_series.timestamps)
+    if time_series.rate == 0.0:
+        if (data_shape[0] > 1 or timestamps_shape[0] > 1):
+            return InspectorMessage(f"{time_series.name} has a sampling rate value of 0.0Hz but the series has more than one frame.")

--- a/src/nwbinspector/checks/time_series.py
+++ b/src/nwbinspector/checks/time_series.py
@@ -133,10 +133,9 @@ def check_resolution(time_series: TimeSeries):
 
 @register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=TimeSeries)
 def check_rate_is_not_zero(time_series: TimeSeries):
-    if time_series.data is not None:
-        data_shape = get_data_shape(time_series.data) 
-    if time_series.timestamps is not None:
-        timestamps_shape = get_data_shape(time_series.timestamps)
-    if time_series.rate == 0.0:
-        if (data_shape[0] > 1 or timestamps_shape[0] > 1):
+    if time_series.data is None and time_series.timestamps is None:
+        return
+    data_shape = get_data_shape(time_series.data) 
+    timestamps_shape = get_data_shape(time_series.timestamps)
+    if time_series.rate == 0.0 and (data_shape[0] > 1 or timestamps_shape[0] > 1):
             return InspectorMessage(f"{time_series.name} has a sampling rate value of 0.0Hz but the series has more than one frame.")

--- a/src/nwbinspector/checks/time_series.py
+++ b/src/nwbinspector/checks/time_series.py
@@ -131,7 +131,7 @@ def check_resolution(time_series: TimeSeries):
         )
 
 
-@register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=TimeSeries)
+@register_check(importance=Importance.CRITICAL, neurodata_type=TimeSeries)
 def check_rate_is_not_zero(time_series: TimeSeries):
     if time_series.data is None:
         return

--- a/tests/unit_tests/test_time_series.py
+++ b/tests/unit_tests/test_time_series.py
@@ -303,14 +303,14 @@ def test_check_rate_is_not_zero_single_frame_pass():
     assert check_rate_is_not_zero(time_series) is None
 
 
-def test_check_rate_is_not_zero_timestamp_is_none_fail():
-    time_series = pynwb.TimeSeries(name="TimeSeriesTestt", unit="n.a.", data=[1, 2, 3], rate=0.0)
+def test_check_rate_is_not_zero_fail():
+    time_series = pynwb.TimeSeries(name="TimeSeriesTest", unit="n.a.", data=[1, 2, 3], rate=0.0)
     assert check_rate_is_not_zero(time_series) == InspectorMessage(
         message="TimeSeriesTest has a sampling rate value of 0.0Hz but the series has more than one frame.",
-        importance=Importance.BEST_PRACTICE_VIOLATION,
+        importance=Importance.CRITICAL,
         check_function_name="check_rate_is_not_zero",
         object_type="TimeSeries",
-        object_name="test",
+        object_name="TimeSeriesTest",
         location="/",
     )
 

--- a/tests/unit_tests/test_time_series.py
+++ b/tests/unit_tests/test_time_series.py
@@ -304,9 +304,9 @@ def test_check_rate_is_not_zero_single_frame_pass():
 
 
 def test_check_rate_is_not_zero_timestamp_is_none_fail():
-    time_series = pynwb.TimeSeries(name="test", unit="test_units", data=[1, 2, 3], rate=0.0)
+    time_series = pynwb.TimeSeries(name="TimeSeriesTestt", unit="n.a.", data=[1, 2, 3], rate=0.0)
     assert check_rate_is_not_zero(time_series) == InspectorMessage(
-        message=f"{time_series.name} has a sampling rate value of 0.0Hz but the series has more than one frame.",
+        message="TimeSeriesTest has a sampling rate value of 0.0Hz but the series has more than one frame.",
         importance=Importance.BEST_PRACTICE_VIOLATION,
         check_function_name="check_rate_is_not_zero",
         object_type="TimeSeries",

--- a/tests/unit_tests/test_time_series.py
+++ b/tests/unit_tests/test_time_series.py
@@ -293,23 +293,18 @@ def test_check_unknown_resolution_pass():
         assert check_resolution(time_series) is None
 
 
-def test_check_check_rate_is_not_zero_timestamp_is_none_pass():
-    time_series = pynwb.TimeSeries(name="test", unit="test", data=[1, 2, 3], timestamps=None, rate=4.0)
+def test_check_rate_is_not_zero_pass():
+    time_series = pynwb.TimeSeries(name="test", unit="test_units", data=[1, 2, 3], rate=4.0)
     assert check_rate_is_not_zero(time_series) is None
 
 
-def test_check_check_rate_is_not_zero_data_is_none_pass():
-    time_series = pynwb.TimeSeries(name="test", unit="test", data=None, timestamps=[1, 2, 3], rate=4.0)
+def test_check_rate_is_not_zero_single_frame_pass():
+    time_series = pynwb.TimeSeries(name="test", unit="test_units", data=[1], rate=0.0)
     assert check_rate_is_not_zero(time_series) is None
 
 
-def test_check_check_rate_is_not_zero_timestamp_and_data_are_none_pass():
-    time_series = pynwb.TimeSeries(name="test", unit="test", data=None, timestamps=None, rate=4.0)
-    assert check_rate_is_not_zero(time_series) is None
-
-
-def test_check_check_rate_is_not_zero_fail():
-    time_series = pynwb.TimeSeries(name="test", unit="test", data=[1, 2, 3], timestamps=None, rate=0.0)
+def test_check_rate_is_not_zero_timestamp_is_none_fail():
+    time_series = pynwb.TimeSeries(name="test", unit="test_units", data=[1, 2, 3], rate=0.0)
     assert check_rate_is_not_zero(time_series) == InspectorMessage(
         message=f"{time_series.name} has a sampling rate value of 0.0Hz but the series has more than one frame.",
         importance=Importance.BEST_PRACTICE_VIOLATION,

--- a/tests/unit_tests/test_time_series.py
+++ b/tests/unit_tests/test_time_series.py
@@ -200,6 +200,28 @@ def test_check_timestamps_empty_timestamps():
     )
 
 
+def test_check_rate_is_not_zero_pass():
+    time_series = pynwb.TimeSeries(name="test", unit="test_units", data=[1, 2, 3], rate=4.0)
+    assert check_rate_is_not_zero(time_series) is None
+
+
+def test_check_rate_is_not_zero_single_frame_pass():
+    time_series = pynwb.TimeSeries(name="test", unit="test_units", data=[1], rate=0.0)
+    assert check_rate_is_not_zero(time_series) is None
+
+
+def test_check_rate_is_not_zero_fail():
+    time_series = pynwb.TimeSeries(name="TimeSeriesTest", unit="n.a.", data=[1, 2, 3], rate=0.0)
+    assert check_rate_is_not_zero(time_series) == InspectorMessage(
+        message="TimeSeriesTest has a sampling rate value of 0.0Hz but the series has more than one frame.",
+        importance=Importance.CRITICAL,
+        check_function_name="check_rate_is_not_zero",
+        object_type="TimeSeries",
+        object_name="TimeSeriesTest",
+        location="/",
+    )
+
+
 def test_pass_check_timestamps_ascending_pass():
     time_series = pynwb.TimeSeries(name="test_time_series", unit="test_units", data=[1, 2, 3], timestamps=[1, 2, 3])
     assert check_timestamps_ascending(time_series) is None
@@ -291,28 +313,6 @@ def test_check_unknown_resolution_pass():
     for valid_unknown in [-1.0, np.nan]:
         time_series = pynwb.TimeSeries(name="test", unit="test", data=[1], timestamps=[1], resolution=valid_unknown)
         assert check_resolution(time_series) is None
-
-
-def test_check_rate_is_not_zero_pass():
-    time_series = pynwb.TimeSeries(name="test", unit="test_units", data=[1, 2, 3], rate=4.0)
-    assert check_rate_is_not_zero(time_series) is None
-
-
-def test_check_rate_is_not_zero_single_frame_pass():
-    time_series = pynwb.TimeSeries(name="test", unit="test_units", data=[1], rate=0.0)
-    assert check_rate_is_not_zero(time_series) is None
-
-
-def test_check_rate_is_not_zero_fail():
-    time_series = pynwb.TimeSeries(name="TimeSeriesTest", unit="n.a.", data=[1, 2, 3], rate=0.0)
-    assert check_rate_is_not_zero(time_series) == InspectorMessage(
-        message="TimeSeriesTest has a sampling rate value of 0.0Hz but the series has more than one frame.",
-        importance=Importance.CRITICAL,
-        check_function_name="check_rate_is_not_zero",
-        object_type="TimeSeries",
-        object_name="TimeSeriesTest",
-        location="/",
-    )
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Related to Issue #389 
Add a check function to check if the sampling rate is set to 0.0Hz

- [x]  add check function
- [x]  add unit tests
- [x]  add check function documentation
- [x]  update CHANGELOG.md