### PR TITLE
[New Check]: Add check electricalseries of dtype int16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Upcoming
 
+### New Checks
+
+* Add `check_electrical_series_dtype` [#395](https://github.com/NeurodataWithoutBorders/nwbinspector/issues/395)
+
 # v0.4.30
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### New Checks
 
-* Add `check_electrical_series_dtype` [#395](https://github.com/NeurodataWithoutBorders/nwbinspector/issues/395)
+* Added `check_electrical_series_conversion_factors` for ensuring non-default conversion/offset factors of any `ElectricalSeries` that has an integer data type. [#395](https://github.com/NeurodataWithoutBorders/nwbinspector/issues/395)
 
 # v0.4.30
 

--- a/src/nwbinspector/checks/ecephys.py
+++ b/src/nwbinspector/checks/ecephys.py
@@ -82,7 +82,7 @@ def check_spike_times_not_in_unobserved_interval(units_table: Units, nunits: int
 
 
 @register_check(importance=Importance.CRITICAL, neurodata_type=ElectricalSeries)
-def check_electrical_series_dtype(electrical_series: ElectricalSeries):
+def check_electrical_series_conversion_factors(electrical_series: ElectricalSeries):
     data = electrical_series.data
     if (
         np.issubdtype(data.dtype, np.integer)

--- a/src/nwbinspector/checks/ecephys.py
+++ b/src/nwbinspector/checks/ecephys.py
@@ -79,3 +79,16 @@ def check_spike_times_not_in_unobserved_interval(units_table: Units, nunits: int
                     "observed intervals."
                 )
             )
+
+
+@register_check(importance=Importance.CRITICAL, neurodata_type=ElectricalSeries)
+def check_electrical_series_dtype(electrical_series: ElectricalSeries):
+    data = electrical_series.data
+    if (
+        np.issubdtype(data.dtype, np.integer)
+        and electrical_series.conversion == electrical_series.DEFAULT_CONVERSION
+        and electrical_series.offset == electrical_series.DEFAULT_OFFSET
+    ):
+        return InspectorMessage(
+            message="ElectricalSeries data type is integer and conversion factor and offset are both default, the value may not be in the correct unit"
+        )

--- a/tests/unit_tests/test_ecephys.py
+++ b/tests/unit_tests/test_ecephys.py
@@ -15,6 +15,7 @@ from nwbinspector import (
     check_electrical_series_dims,
     check_electrical_series_reference_electrodes_table,
     check_spike_times_not_in_unobserved_interval,
+    check_electrical_series_dtype,
 )
 
 
@@ -154,6 +155,76 @@ class TestCheckElectricalSeries(TestCase):
             check_electrical_series_reference_electrodes_table(electrical_series).message
             == "electrodes does not  reference an electrodes table."
         )
+
+    def test_check_electrical_series_dtype_pass(self):
+        electrodes = self.nwbfile.create_electrode_table_region(region=[0, 1, 2, 3, 4], description="all")
+
+        electrical_series = ElectricalSeries(
+            name="elec_series",
+            description="desc",
+            data=np.ones((100, 5), dtype=float),
+            electrodes=electrodes,
+            rate=30.0,
+        )
+
+        self.nwbfile.add_acquisition(electrical_series)
+
+        assert check_electrical_series_dtype(electrical_series) is None
+
+    def test_check_electrical_series_dtype_fail(self):
+        electrodes = self.nwbfile.create_electrode_table_region(region=[0, 1, 2, 3, 4], description="all")
+
+        electrical_series = ElectricalSeries(
+            name="elec_series",
+            description="desc",
+            data=np.ones((100, 5), dtype=np.dtype("int16")),
+            electrodes=electrodes,
+            rate=30.0,
+        )
+
+        self.nwbfile.add_acquisition(electrical_series)
+
+        assert check_electrical_series_dtype(electrical_series) == InspectorMessage(
+            message=(
+                "ElectricalSeries data type is integer and conversion factor and offset are both default, the value may not be in the correct unit"
+            ),
+            importance=Importance.CRITICAL,
+            check_function_name="check_electrical_series_dtype",
+            object_type="ElectricalSeries",
+            object_name="elec_series",
+        )
+
+    def test_check_electrical_series_dtype_non_default_conversion_skip(self):
+        electrodes = self.nwbfile.create_electrode_table_region(region=[0, 1, 2, 3, 4], description="all")
+
+        electrical_series = ElectricalSeries(
+            name="elec_series",
+            description="desc",
+            data=np.ones((100, 5), dtype=np.dtype("int16")),
+            electrodes=electrodes,
+            rate=30.0,
+            conversion=0.1,
+        )
+
+        self.nwbfile.add_acquisition(electrical_series)
+
+        assert check_electrical_series_dtype(electrical_series) is None
+
+    def test_check_electrical_series_dtype_non_default_offet_skip(self):
+        electrodes = self.nwbfile.create_electrode_table_region(region=[0, 1, 2, 3, 4], description="all")
+
+        electrical_series = ElectricalSeries(
+            name="elec_series",
+            description="desc",
+            data=np.ones((100, 5), dtype=np.dtype("int16")),
+            electrodes=electrodes,
+            rate=30.0,
+            offset=0.1,
+        )
+
+        self.nwbfile.add_acquisition(electrical_series)
+
+        assert check_electrical_series_dtype(electrical_series) is None
 
 
 def test_check_spike_times_not_in_unobserved_interval_pass():

--- a/tests/unit_tests/test_ecephys.py
+++ b/tests/unit_tests/test_ecephys.py
@@ -162,7 +162,7 @@ class TestCheckElectricalSeries(TestCase):
         electrical_series = ElectricalSeries(
             name="elec_series",
             description="desc",
-            data=np.ones((100, 5), dtype=float),
+            data=np.ones((100, 5), dtype=np.dtype("float64")),
             electrodes=electrodes,
             rate=30.0,
         )

--- a/tests/unit_tests/test_ecephys.py
+++ b/tests/unit_tests/test_ecephys.py
@@ -15,7 +15,7 @@ from nwbinspector import (
     check_electrical_series_dims,
     check_electrical_series_reference_electrodes_table,
     check_spike_times_not_in_unobserved_interval,
-    check_electrical_series_dtype,
+    check_electrical_series_conversion_factors,
 )
 
 
@@ -169,7 +169,7 @@ class TestCheckElectricalSeries(TestCase):
 
         self.nwbfile.add_acquisition(electrical_series)
 
-        assert check_electrical_series_dtype(electrical_series) is None
+        assert check_electrical_series_conversion_factors(electrical_series) is None
 
     def test_check_electrical_series_dtype_fail(self):
         electrodes = self.nwbfile.create_electrode_table_region(region=[0, 1, 2, 3, 4], description="all")
@@ -184,7 +184,7 @@ class TestCheckElectricalSeries(TestCase):
 
         self.nwbfile.add_acquisition(electrical_series)
 
-        assert check_electrical_series_dtype(electrical_series) == InspectorMessage(
+        assert check_electrical_series_conversion_factors(electrical_series) == InspectorMessage(
             message=(
                 "ElectricalSeries data type is integer and conversion factor and offset are both default, the value may not be in the correct unit"
             ),
@@ -208,7 +208,7 @@ class TestCheckElectricalSeries(TestCase):
 
         self.nwbfile.add_acquisition(electrical_series)
 
-        assert check_electrical_series_dtype(electrical_series) is None
+        assert check_electrical_series_conversion_factors(electrical_series) is None
 
     def test_check_electrical_series_dtype_non_default_offet_skip(self):
         electrodes = self.nwbfile.create_electrode_table_region(region=[0, 1, 2, 3, 4], description="all")
@@ -224,7 +224,7 @@ class TestCheckElectricalSeries(TestCase):
 
         self.nwbfile.add_acquisition(electrical_series)
 
-        assert check_electrical_series_dtype(electrical_series) is None
+        assert check_electrical_series_conversion_factors(electrical_series) is None
 
 
 def test_check_spike_times_not_in_unobserved_interval_pass():


### PR DESCRIPTION
Fix #395 

Add check on ElectricalSeries data type: if the conversion and offset are DEFAULT values and the data type is any integer ("uint16", "int16", etc). 

- [x] add check function
- [x] add unit tests
- [ ] add check function documentation in ecephys.rst 
- [x] update CHANGELOG.md 