### PR TITLE
Use paths instead of io in pynwb.validate call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * Added `check_rate_is_not_zero` for ensuring non-zero rate value of `TimeSeries` that has more than one frame. [#389](https://github.com/NeurodataWithoutBorders/nwbinspector/issues/389)
 
+### Fixes
+
+* Use cached extension namespaces when calling pynwb validate instead of just the core namespace. [#425](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/425)
+
 # v0.4.30
 
 ### Fixes

--- a/src/nwbinspector/nwbinspector.py
+++ b/src/nwbinspector/nwbinspector.py
@@ -551,15 +551,16 @@ def inspect_nwbfile(
     filterwarnings(action="ignore", message="Ignoring cached namespace .*")
 
     if not skip_validate:
-        validation_errors = pynwb.validate(paths=[nwbfile_path], driver=driver)
-        for validation_error in validation_errors:
-            yield InspectorMessage(
-                message=validation_error.reason,
-                importance=Importance.PYNWB_VALIDATION,
-                check_function_name=validation_error.name,
-                location=validation_error.location,
-                file_path=nwbfile_path,
-            )
+        validation_error_list = pynwb.validate(paths=[nwbfile_path], driver=driver)
+        for validation_namespace_errors in validation_error_list:
+            for validation_error in validation_namespace_errors:
+                yield InspectorMessage(
+                    message=validation_error.reason,
+                    importance=Importance.PYNWB_VALIDATION,
+                    check_function_name=validation_error.name,
+                    location=validation_error.location,
+                    file_path=nwbfile_path,
+                )
 
     with pynwb.NWBHDF5IO(path=nwbfile_path, mode="r", load_namespaces=True, driver=driver) as io:
         try:

--- a/src/nwbinspector/nwbinspector.py
+++ b/src/nwbinspector/nwbinspector.py
@@ -550,18 +550,18 @@ def inspect_nwbfile(
     filterwarnings(action="ignore", message="No cached namespaces found in .*")
     filterwarnings(action="ignore", message="Ignoring cached namespace .*")
 
-    with pynwb.NWBHDF5IO(path=nwbfile_path, mode="r", load_namespaces=True, driver=driver) as io:
-        if not skip_validate:
-            validation_errors = pynwb.validate(io=io)
-            for validation_error in validation_errors:
-                yield InspectorMessage(
-                    message=validation_error.reason,
-                    importance=Importance.PYNWB_VALIDATION,
-                    check_function_name=validation_error.name,
-                    location=validation_error.location,
-                    file_path=nwbfile_path,
-                )
+    if not skip_validate:
+        validation_errors = pynwb.validate(paths=[nwbfile_path], driver=driver)
+        for validation_error in validation_errors:
+            yield InspectorMessage(
+                message=validation_error.reason,
+                importance=Importance.PYNWB_VALIDATION,
+                check_function_name=validation_error.name,
+                location=validation_error.location,
+                file_path=nwbfile_path,
+            )
 
+    with pynwb.NWBHDF5IO(path=nwbfile_path, mode="r", load_namespaces=True, driver=driver) as io:
         try:
             nwbfile_object = robust_s3_read(command=io.read, max_retries=max_retries)
             for inspector_message in inspect_nwbfile_object(

--- a/src/nwbinspector/nwbinspector.py
+++ b/src/nwbinspector/nwbinspector.py
@@ -551,7 +551,7 @@ def inspect_nwbfile(
     filterwarnings(action="ignore", message="Ignoring cached namespace .*")
 
     if not skip_validate:
-        validation_error_list = pynwb.validate(paths=[nwbfile_path], driver=driver)
+        validation_error_list, _ = pynwb.validate(paths=[nwbfile_path], driver=driver)
         for validation_namespace_errors in validation_error_list:
             for validation_error in validation_namespace_errors:
                 yield InspectorMessage(

--- a/src/nwbinspector/nwbinspector.py
+++ b/src/nwbinspector/nwbinspector.py
@@ -13,6 +13,7 @@ from types import FunctionType
 from warnings import filterwarnings, warn
 from distutils.util import strtobool
 from collections import defaultdict
+from packaging.version import Version
 
 import click
 import pynwb
@@ -29,7 +30,14 @@ from .inspector_tools import (
 )
 from .register_checks import InspectorMessage, Importance
 from .tools import get_s3_urls_and_dandi_paths
-from .utils import FilePathType, PathType, OptionalListOfStrings, robust_s3_read, calculate_number_of_cpu
+from .utils import (
+    FilePathType,
+    PathType,
+    OptionalListOfStrings,
+    robust_s3_read,
+    calculate_number_of_cpu,
+    get_package_version,
+)
 from nwbinspector import __version__
 
 INTERNAL_CONFIGS = dict(dandi=Path(__file__).parent / "internal_configs" / "dandi.inspector_config.yaml")
@@ -550,7 +558,7 @@ def inspect_nwbfile(
     filterwarnings(action="ignore", message="No cached namespaces found in .*")
     filterwarnings(action="ignore", message="Ignoring cached namespace .*")
 
-    if not skip_validate:
+    if not skip_validate and get_package_version("pynwb") >= Version("2.2.0"):
         validation_error_list, _ = pynwb.validate(paths=[nwbfile_path], driver=driver)
         for validation_namespace_errors in validation_error_list:
             for validation_error in validation_namespace_errors:
@@ -563,6 +571,17 @@ def inspect_nwbfile(
                 )
 
     with pynwb.NWBHDF5IO(path=nwbfile_path, mode="r", load_namespaces=True, driver=driver) as io:
+        if not skip_validate and get_package_version("pynwb") < Version("2.2.0"):
+            validation_errors = pynwb.validate(io=io)
+            for validation_error in validation_errors:
+                yield InspectorMessage(
+                    message=validation_error.reason,
+                    importance=Importance.PYNWB_VALIDATION,
+                    check_function_name=validation_error.name,
+                    location=validation_error.location,
+                    file_path=nwbfile_path,
+                )
+
         try:
             nwbfile_object = robust_s3_read(command=io.read, max_retries=max_retries)
             for inspector_message in inspect_nwbfile_object(


### PR DESCRIPTION
Addresses issue in https://github.com/NeurodataWithoutBorders/pynwb/issues/1777

In short, `validate(paths=[nwbfile_path])` performs the expected behavior of validating against all cached namespaces in the file except for dependent ones and `validate(io=io)` does not. Changing `validate(io=io)` to perform the expected behavior would be a breaking change in pynwb. I think we should make that breaking change in pynwb as soon as possible, but given the urgency of the issue and that `validate(paths=[nwbfile_path])` does the expected behavior, I think we should also change nwbinspector to use `validate(paths=[nwbfile_path])` now.