### PR TITLE
Add in vitro support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 * Use cached extension namespaces when calling pynwb validate instead of just the core namespace. [#425](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/425)
 
+### Improvements
+
+* Added automatic suppression of certain subject related checks when inspecting files using the "dandi" configuration that have a `subject_id` that starts with the keyphrase "invitro"; _e.g._, "invitroCaMPARI3" to indicate the _in vitro_ subject of the experiment is a purified CaMPARI3 protein.
+
+
+
 # v0.4.30
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Improvements
 
-* Added automatic suppression of certain subject related checks when inspecting files using the "dandi" configuration that have a `subject_id` that starts with the keyphrase "invitro"; _e.g._, "invitroCaMPARI3" to indicate the _in vitro_ subject of the experiment is a purified CaMPARI3 protein.
+* Added automatic suppression of certain subject related checks when inspecting files using the "dandi" configuration that have a `subject_id` that starts with the keyphrase "protein"; _e.g._, "proteinCaMPARI3" to indicate the _in vitro_ subject of the experiment is a purified CaMPARI3 protein.
 
 
 

--- a/docs/best_practices/nwbfile_metadata.rst
+++ b/docs/best_practices/nwbfile_metadata.rst
@@ -184,7 +184,7 @@ A ``subject_id`` is required for upload to the :dandi-archive:`DANDI archive <>`
 not intended for DANDI upload, if the :ref:`nwb-schema:sec-Subject` is specified at all it should be given a
 ``subject_id`` for reference.
 
-In the special case of *in vitro* studies where the 'subject' of scientific interest may not have been a biological sample obtained from a living subject, such as the case of a purified protein, suppression of validation for additional subject attributes is possible by prepending the keyphrase "invitro" to the subject ID; *e.g*, "invitroCaMPARI3". In the case where the *in vitro* experiment is performed on an extracted or cultured biological sample, the other subject attributes (such as age and sex) should be specified as their values at the time the sample was collected.
+In the special case of *in vitro* studies where the 'subject' of scientific interest was not a tissue sample obtained from a living subject but was instead a purified protein, this will be annotated by prepending the keyphrase "protein" to the subject ID; *e.g*, "proteinCaMPARI3". In the case where the *in vitro* experiment is performed on an extracted or cultured biological sample, the other subject attributes (such as age and sex) should be specified as their values at the time the sample was collected.
 
 Check function: :py:meth:`~nwbinspector.checks.nwbfile_metadata.check_subject_id_exists`
 

--- a/docs/best_practices/nwbfile_metadata.rst
+++ b/docs/best_practices/nwbfile_metadata.rst
@@ -184,6 +184,8 @@ A ``subject_id`` is required for upload to the :dandi-archive:`DANDI archive <>`
 not intended for DANDI upload, if the :ref:`nwb-schema:sec-Subject` is specified at all it should be given a
 ``subject_id`` for reference.
 
+In the special case of *in vitro* studies where the 'subject' of scientific interest may not have been a biological sample obtained from a living subject, such as the case of a purified protein, suppression of validation for additional subject attributes is possible by prepending the keyphrase "invitro" to the subject ID; *e.g*, "invitroCaMPARI3". In the case where the *in vitro* experiment is performed on an extracted or cultured biological sample, the other subject attributes (such as age and sex) should be specified as their values at the time the sample was collected.
+
 Check function: :py:meth:`~nwbinspector.checks.nwbfile_metadata.check_subject_id_exists`
 
 

--- a/src/nwbinspector/nwbinspector.py
+++ b/src/nwbinspector/nwbinspector.py
@@ -604,6 +604,32 @@ def inspect_nwbfile(
             )
 
 
+def _intercept_in_vitro(nwbfile_object: pynwb.NWBFile, checks: Optional[list] = None) -> List[callable]:
+    """If the special 'in_vitro' subject_id is specified, return a truncated list of checks to run."""
+    subject_related_check_names = [
+        "check_subject_exists",
+        "check_subject_id_exists",
+        "check_subject_sex",
+        "check_subject_species_exists",
+        "check_subject_species_form",
+        "check_subject_age",
+        "check_subject_proper_age_range",
+    ]
+    subject_related_dandi_requirements = [
+        check.importance == Importance.CRITICAL for check in checks if check.__name__ in subject_related_check_names
+    ]
+
+    subject = getattr(nwbfile_object, "subject", None)
+    if (
+        any(subject_related_dandi_requirements)
+        and subject is not None
+        and getattr(subject, "subject_id", "") == "in_vitro"
+    ):
+        non_subject_checks = [check for check in checks if check.__name__ not in subject_related_check_names]
+        return non_subject_checks
+    return checks
+
+
 def inspect_nwbfile_object(
     nwbfile_object: pynwb.NWBFile,
     checks: Optional[list] = None,
@@ -651,7 +677,9 @@ def inspect_nwbfile_object(
             checks=checks, config=config, ignore=ignore, select=select, importance_threshold=importance_threshold
         )
 
-    for inspector_message in run_checks(nwbfile=nwbfile_object, checks=checks):
+    subject_dependent_checks = _intercept_in_vitro(nwbfile_object=nwbfile_object, checks=checks)
+
+    for inspector_message in run_checks(nwbfile=nwbfile_object, checks=subject_dependent_checks):
         yield inspector_message
 
 

--- a/src/nwbinspector/nwbinspector.py
+++ b/src/nwbinspector/nwbinspector.py
@@ -605,11 +605,11 @@ def inspect_nwbfile(
 
 
 # TODO: deprecate once subject types and dandi schemas have been extended
-def _intercept_in_vitro(nwbfile_object: pynwb.NWBFile, checks: Optional[list] = None) -> List[callable]:
+def _intercept_in_vitro_protein(nwbfile_object: pynwb.NWBFile, checks: Optional[list] = None) -> List[callable]:
     """
-    If the special 'invitro' subject_id is specified, return a truncated list of checks to run.
+    If the special 'protein' subject_id is specified, return a truncated list of checks to run.
 
-    This is a temporary method for allowing upload of in vitro data to DANDI and
+    This is a temporary method for allowing upload of certain in vitro data to DANDI and
     is expected to replaced in future versions.
     """
     subject_related_check_names = [
@@ -629,7 +629,7 @@ def _intercept_in_vitro(nwbfile_object: pynwb.NWBFile, checks: Optional[list] = 
     if (
         any(subject_related_dandi_requirements)
         and subject is not None
-        and getattr(subject, "subject_id", "").startswith("invitro")
+        and getattr(subject, "subject_id", "").startswith("protein")
     ):
         non_subject_checks = [check for check in checks if check.__name__ not in subject_related_check_names]
         return non_subject_checks
@@ -683,7 +683,7 @@ def inspect_nwbfile_object(
             checks=checks, config=config, ignore=ignore, select=select, importance_threshold=importance_threshold
         )
 
-    subject_dependent_checks = _intercept_in_vitro(nwbfile_object=nwbfile_object, checks=checks)
+    subject_dependent_checks = _intercept_in_vitro_protein(nwbfile_object=nwbfile_object, checks=checks)
 
     for inspector_message in run_checks(nwbfile=nwbfile_object, checks=subject_dependent_checks):
         yield inspector_message

--- a/src/nwbinspector/nwbinspector.py
+++ b/src/nwbinspector/nwbinspector.py
@@ -604,8 +604,14 @@ def inspect_nwbfile(
             )
 
 
+# TODO: deprecate once subject types and dandi schemas have been extended
 def _intercept_in_vitro(nwbfile_object: pynwb.NWBFile, checks: Optional[list] = None) -> List[callable]:
-    """If the special 'in_vitro' subject_id is specified, return a truncated list of checks to run."""
+    """
+    If the special 'invitro' subject_id is specified, return a truncated list of checks to run.
+
+    This is a temporary method for allowing upload of in vitro data to DANDI and
+    is expected to replaced in future versions.
+    """
     subject_related_check_names = [
         "check_subject_exists",
         "check_subject_id_exists",
@@ -623,7 +629,7 @@ def _intercept_in_vitro(nwbfile_object: pynwb.NWBFile, checks: Optional[list] = 
     if (
         any(subject_related_dandi_requirements)
         and subject is not None
-        and getattr(subject, "subject_id", "").startswith("in_vitro_")
+        and getattr(subject, "subject_id", "").startswith("invitro")
     ):
         non_subject_checks = [check for check in checks if check.__name__ not in subject_related_check_names]
         return non_subject_checks

--- a/src/nwbinspector/nwbinspector.py
+++ b/src/nwbinspector/nwbinspector.py
@@ -623,7 +623,7 @@ def _intercept_in_vitro(nwbfile_object: pynwb.NWBFile, checks: Optional[list] = 
     if (
         any(subject_related_dandi_requirements)
         and subject is not None
-        and getattr(subject, "subject_id", "") == "in_vitro"
+        and getattr(subject, "subject_id", "").startswith("in_vitro_")
     ):
         non_subject_checks = [check for check in checks if check.__name__ not in subject_related_check_names]
         return non_subject_checks

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -730,7 +730,7 @@ class TestCheckUniqueIdentifiersFail(TestCase):
 
 
 def test_dandi_config_in_vitro_injection():
-    """Test that a special subject_id of 'in_vitro' properly excludes meaningless CRITICAL-elevated subject checks."""
+    """Test that a subject_id starting with 'in_vitro_' excludes meaningless CRITICAL-elevated subject checks."""
     nwbfile = mock_NWBFile(
         subject=Subject(subject_id="in_vitro_CaMPARI3", description="A detailed description about the in vitro setup.")
     )

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -6,10 +6,10 @@ from unittest import TestCase
 from datetime import datetime
 
 import numpy as np
-import pynwb
 from pynwb import NWBFile, NWBHDF5IO, TimeSeries
-from pynwb.file import TimeIntervals
+from pynwb.file import TimeIntervals, Subject
 from pynwb.behavior import SpatialSeries, Position
+from pynwb.testing.mock.file import mock_NWBFile
 from hdmf.common import DynamicTable
 from natsort import natsorted
 
@@ -731,10 +731,8 @@ class TestCheckUniqueIdentifiersFail(TestCase):
 
 def test_dandi_config_in_vitro_injection():
     """Test that a special subject_id of 'in_vitro' properly excludes meaningless CRITICAL-elevated subject checks."""
-    nwbfile = pynwb.testing.mock.file.mock_NWBFile(
-        subject=pynwb.file.Subject(
-            subject_id="in_vitro", description="A detailed description about the in vitro setup."
-        )
+    nwbfile = mock_NWBFile(
+        subject=Subject(subject_id="in_vitro_CaMPARI3", description="A detailed description about the in vitro setup.")
     )
     config = load_config(filepath_or_keyword="dandi")
     importance_threshold = "CRITICAL"

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -1,5 +1,4 @@
 import os
-import pytest
 from shutil import rmtree
 from tempfile import mkdtemp
 from pathlib import Path
@@ -7,6 +6,7 @@ from unittest import TestCase
 from datetime import datetime
 
 import numpy as np
+import pynwb
 from pynwb import NWBFile, NWBHDF5IO, TimeSeries
 from pynwb.file import TimeIntervals
 from pynwb.behavior import SpatialSeries, Position
@@ -22,7 +22,7 @@ from nwbinspector import (
     check_subject_exists,
     load_config,
 )
-from nwbinspector import inspect_all, inspect_nwbfile, available_checks
+from nwbinspector import inspect_all, inspect_nwbfile, inspect_nwbfile_object, available_checks
 from nwbinspector.register_checks import Severity, InspectorMessage, register_check
 from nwbinspector.tools import make_minimal_nwbfile
 from nwbinspector.utils import FilePathType
@@ -727,3 +727,18 @@ class TestCheckUniqueIdentifiersFail(TestCase):
                 file_path=str(self.tempdir),
             )
         ]
+
+
+def test_dandi_config_in_vitro_injection():
+    """Test that a special subject_id of 'in_vitro' properly excludes meaningless CRITICAL-elevated subject checks."""
+    nwbfile = pynwb.testing.mock.file.mock_NWBFile(
+        subject=pynwb.file.Subject(
+            subject_id="in_vitro", description="A detailed description about the in vitro setup."
+        )
+    )
+    config = load_config(filepath_or_keyword="dandi")
+    importance_threshold = "CRITICAL"
+    messages = list(
+        inspect_nwbfile_object(nwbfile_object=nwbfile, config=config, importance_threshold=importance_threshold)
+    )
+    assert messages == []

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -732,7 +732,7 @@ def test_dandi_config_in_vitro_injection():
     """Test that a subject_id starting with 'invitro' excludes meaningless CRITICAL-elevated subject checks."""
     nwbfile = make_minimal_nwbfile()
     nwbfile.subject = Subject(
-        subject_id="invitroCaMPARI3", description="A detailed description about the in vitro setup."
+        subject_id="proteinCaMPARI3", description="A detailed description about the in vitro setup."
     )
     config = load_config(filepath_or_keyword="dandi")
     importance_threshold = "CRITICAL"

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -9,7 +9,6 @@ import numpy as np
 from pynwb import NWBFile, NWBHDF5IO, TimeSeries
 from pynwb.file import TimeIntervals, Subject
 from pynwb.behavior import SpatialSeries, Position
-from pynwb.testing.mock.file import mock_NWBFile
 from hdmf.common import DynamicTable
 from natsort import natsorted
 
@@ -731,8 +730,9 @@ class TestCheckUniqueIdentifiersFail(TestCase):
 
 def test_dandi_config_in_vitro_injection():
     """Test that a subject_id starting with 'invitro' excludes meaningless CRITICAL-elevated subject checks."""
-    nwbfile = mock_NWBFile(
-        subject=Subject(subject_id="invitroCaMPARI3", description="A detailed description about the in vitro setup.")
+    nwbfile = make_minimal_nwbfile()
+    nwbfile.subject = Subject(
+        subject_id="invitroCaMPARI3", description="A detailed description about the in vitro setup."
     )
     config = load_config(filepath_or_keyword="dandi")
     importance_threshold = "CRITICAL"

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -730,9 +730,9 @@ class TestCheckUniqueIdentifiersFail(TestCase):
 
 
 def test_dandi_config_in_vitro_injection():
-    """Test that a subject_id starting with 'in_vitro_' excludes meaningless CRITICAL-elevated subject checks."""
+    """Test that a subject_id starting with 'invitro' excludes meaningless CRITICAL-elevated subject checks."""
     nwbfile = mock_NWBFile(
-        subject=Subject(subject_id="in_vitro_CaMPARI3", description="A detailed description about the in vitro setup.")
+        subject=Subject(subject_id="invitroCaMPARI3", description="A detailed description about the in vitro setup.")
     )
     config = load_config(filepath_or_keyword="dandi")
     importance_threshold = "CRITICAL"

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -729,7 +729,7 @@ class TestCheckUniqueIdentifiersFail(TestCase):
 
 
 def test_dandi_config_in_vitro_injection():
-    """Test that a subject_id starting with 'invitro' excludes meaningless CRITICAL-elevated subject checks."""
+    """Test that a subject_id starting with 'protein' excludes meaningless CRITICAL-elevated subject checks."""
     nwbfile = make_minimal_nwbfile()
     nwbfile.subject = Subject(
         subject_id="proteinCaMPARI3", description="A detailed description about the in vitro setup."


### PR DESCRIPTION
## Motivation

From DANDI discussion: https://github.com/dandi/helpdesk/discussions/115#discussioncomment-7460542 and ensuing internal Slack discussion with DANDI team from around that time...

There is a group wanting to upload NWB-formatted _in vitro_ data to the archive; since so much of the current validation structure assumes _in vivo_, a workaround is needed to control certain requirements in this case

I propose that the simplest workaround is to specify the `subject_id` using the pattern `in_vitro_< some identifier >`; the NWB Inspector can then recognize this pattern and decide to automatically suppress certain nonsensical checks from being run, while allowing a human-readable filename ('sub-in-vitro-< some identifier >_ses-...') on the archive, making it obvious how the file content differs from the norm. As previously discussed, the existence of a 'participant'/'subject' and some ID for it is non-negotiable on the archive side since it's a core part of the metadata, and though the 'subject' of the _in vitro_ experiments is merely a protein, that can still count to this effect

If this becomes more common, the better longer-term solution would likely be an extension of the core Subject data type specific to _in vitro_ setups, but since they have already created their files this is currently a more costly solution

cc: @yarikoptic @satra @rly @oruebel @bendichter 

If this sounds OK, I'll write some Best Practice docs on this PR and send instructions to the uploader on how to proceed from here