### PR TITLE
BF: do or to "" to ensure that we do not end up treating None as str

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Upcoming
 
+# v0.4.33
+
+### Fixes
+
+* Add safer retrieval of `subject_id` for _in vitro_ protein filtering. [#433](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/433)
+
 
 
 # v0.4.32

--- a/src/nwbinspector/nwbinspector.py
+++ b/src/nwbinspector/nwbinspector.py
@@ -629,7 +629,7 @@ def _intercept_in_vitro_protein(nwbfile_object: pynwb.NWBFile, checks: Optional[
     if (
         any(subject_related_dandi_requirements)
         and subject is not None
-        and getattr(subject, "subject_id", "").startswith("protein")
+        and (getattr(subject, "subject_id") or "").startswith("protein")
     ):
         non_subject_checks = [check for check in checks if check.__name__ not in subject_related_check_names]
         return non_subject_checks

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -740,3 +740,15 @@ def test_dandi_config_in_vitro_injection():
         inspect_nwbfile_object(nwbfile_object=nwbfile, config=config, importance_threshold=importance_threshold)
     )
     assert messages == []
+
+def test_dandi_config_in_vitro_injection():
+    """Test the safe subject ID retrieval of the in vitro injection."""
+    nwbfile = make_minimal_nwbfile()
+    nwbfile.subject = Subject(
+        subject_id=None, description="A detailed description about the in vitro setup."
+    )
+    config = load_config(filepath_or_keyword="dandi")
+    messages = list(
+        inspect_nwbfile_object(nwbfile_object=nwbfile, config=config)
+    )
+    assert len(messages) != 0

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -741,14 +741,11 @@ def test_dandi_config_in_vitro_injection():
     )
     assert messages == []
 
+
 def test_dandi_config_in_vitro_injection():
     """Test the safe subject ID retrieval of the in vitro injection."""
     nwbfile = make_minimal_nwbfile()
-    nwbfile.subject = Subject(
-        subject_id=None, description="A detailed description about the in vitro setup."
-    )
+    nwbfile.subject = Subject(subject_id=None, description="A detailed description about the in vitro setup.")
     config = load_config(filepath_or_keyword="dandi")
-    messages = list(
-        inspect_nwbfile_object(nwbfile_object=nwbfile, config=config)
-    )
+    messages = list(inspect_nwbfile_object(nwbfile_object=nwbfile, config=config))
     assert len(messages) != 0


### PR DESCRIPTION
We started to get a test in dandi-cli to error out

```
E     +     '"/opt/hostedtoolcache/Python/3.12.1/x64/lib/python3.12/site-packages/nwbinspector/nwbinspector.py", '
E     +     'line 632, in _intercept_in_vitro_protein\n'
E     +     '    and getattr(subject, "subject_id", "").startswith("protein")\n'
E     +     '        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n'
E     +     "AttributeError: 'NoneType' object has no attribute 'startswith'\n",
```

I didn't test yet but this I think should fix it
