### PR TITLE
Separate workflows for testing dandi dev between live and no network

### DIFF
--- a/.github/workflows/dailies.yml
+++ b/.github/workflows/dailies.yml
@@ -3,7 +3,7 @@ name: Daily workflows
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 16 * * *"  # Daily at noon EST
+    - cron: "0 14 * * *"  # Daily at 10am EST
 
 jobs:
 

--- a/.github/workflows/dandi_dev.yml
+++ b/.github/workflows/dandi_dev.yml
@@ -1,5 +1,8 @@
-name: Test against DANDI dev branch
+name: Test against DANDI dev branch - no network
 on: workflow_call
+
+env:
+  DANDI_TESTS_NONETWORK: "1"
 
 jobs:
   build-and-test:

--- a/.github/workflows/dandi_dev_live_service.yml
+++ b/.github/workflows/dandi_dev_live_service.yml
@@ -1,0 +1,35 @@
+name: Test against DANDI dev branch - all tests, including live service
+on: workflow_call
+
+jobs:
+  build-and-test:
+    name: Testing against current DANDI release and dev branch
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: s-weigand/setup-conda@v1
+        with:
+          update-conda: true
+          python-version: 3.9
+          conda-channels: conda-forge
+      - uses: actions/checkout@v3
+      - run: git fetch --prune --unshallow --tags
+
+      - name: Test against DANDI dev
+        run: |
+          pip install virtualenv
+          git clone https://github.com/NeurodataWithoutBorders/nwbinspector
+          git clone https://github.com/dandi/dandi-cli
+          cd dandi-cli
+          # Test against a specific branch or commit if needed
+          # git checkout a50c4fe243f9a3b72fbcecaea095943be02616d6  # error_fix branch with iteration issue
+          virtualenv --system-site-packages --python=python3 venvs/dev3
+          source venvs/dev3/bin/activate
+          pip install -e .[test]
+          cd ../nwbinspector
+          # Test against a specific branch or commit if needed
+          # git checkout add_downstream_ci
+          pip install -e .
+          cd ../dandi-cli
+          pytest -vv

--- a/.github/workflows/dandi_release.yml
+++ b/.github/workflows/dandi_release.yml
@@ -1,5 +1,8 @@
-name: Test against latest DANDI release
+name: Test against latest DANDI release - no network
 on: workflow_call
+
+env:
+  DANDI_TESTS_NONETWORK: "1"
 
 jobs:
   build-and-test:

--- a/.github/workflows/deploy-tests.yml
+++ b/.github/workflows/deploy-tests.yml
@@ -52,17 +52,17 @@ jobs:
   test-dandi-latest:
     needs: assess-file-changes
     if: ${{ needs.assess-file-changes.outputs.SOURCE_CHANGED == 'true' }}
-    uses: neurodatawithoutborders/nwbinspector/.github/workflows/dandi_release.yml@separate_dandi_live_vs_no_network
+    uses: neurodatawithoutborders/nwbinspector/.github/workflows/dandi_release.yml@dev
 
   test-dandi-dev:
     needs: assess-file-changes
     if: ${{ needs.assess-file-changes.outputs.SOURCE_CHANGED == 'true' }}
-    uses: neurodatawithoutborders/nwbinspector/.github/workflows/dandi_dev.yml@separate_dandi_live_vs_no_network
+    uses: neurodatawithoutborders/nwbinspector/.github/workflows/dandi_dev.yml@dev
 
   test-dandi-dev-live:
     needs: assess-file-changes
     if: ${{ needs.assess-file-changes.outputs.SOURCE_CHANGED == 'true' }}
-    uses: neurodatawithoutborders/nwbinspector/.github/workflows/dandi_dev_live_service.yml@separate_dandi_live_vs_no_network
+    uses: neurodatawithoutborders/nwbinspector/.github/workflows/dandi_dev_live_service.yml@dev
 
   check-final-status:
     name: All tests passing

--- a/.github/workflows/deploy-tests.yml
+++ b/.github/workflows/deploy-tests.yml
@@ -52,12 +52,17 @@ jobs:
   test-dandi-latest:
     needs: assess-file-changes
     if: ${{ needs.assess-file-changes.outputs.SOURCE_CHANGED == 'true' }}
-    uses: neurodatawithoutborders/nwbinspector/.github/workflows/dandi-release.yml@dev
+    uses: neurodatawithoutborders/nwbinspector/.github/workflows/dandi_release.yml@separate_dandi_live_vs_no_network
 
   test-dandi-dev:
     needs: assess-file-changes
     if: ${{ needs.assess-file-changes.outputs.SOURCE_CHANGED == 'true' }}
-    uses: neurodatawithoutborders/nwbinspector/.github/workflows/dandi-dev.yml@dev
+    uses: neurodatawithoutborders/nwbinspector/.github/workflows/dandi_dev.yml@separate_dandi_live_vs_no_network
+
+  test-dandi-dev-live:
+    needs: assess-file-changes
+    if: ${{ needs.assess-file-changes.outputs.SOURCE_CHANGED == 'true' }}
+    uses: neurodatawithoutborders/nwbinspector/.github/workflows/dandi_dev_live_service.yml@separate_dandi_live_vs_no_network
 
   check-final-status:
     name: All tests passing


### PR DESCRIPTION
## Motivation

DANDI dev tests can sometimes fail due to live service issues like http://purl.obolibrary.org/ failing to respond (see https://github.com/dandi/dandi-cli/issues/1405)

We should definitely still run all tests; but I'd prefer a separation so that when I get a notification of a failure, I can do a direct comparison between with network and without network, indicating that I should just wait a certain amount of time before rerunning the with network ones