### PR TITLE
Add documentation about duplicated metadata in `Electrodes`

### DIFF
--- a/docs/best_practices/ecephys.rst
+++ b/docs/best_practices/ecephys.rst
@@ -61,7 +61,7 @@ that are close enough to share a neuron.
 Avoid Duplication of Metadata
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The ``ElectrodeTable`` should not contain redundant information that is present somewhere else within the :ref:`nwb-schema:sec-NWBFile` . Avoid adding columns to the `ElectrodeTable` that correspond to properties of the :ref:`nwb-schema:sec-ElectricalSeries` such as ``unit``, ``offsets`` or ``channel gains`` These properties should be stored in the corresponding attributes of the :ref:`nwb-schema:sec-ElectricalSeries` object. 
+The ``ElectrodeTable`` should not contain redundant information that is present somewhere else within the :ref:`nwb-schema:sec-NWBFile` . Avoid adding columns to the `ElectrodeTable` that correspond to properties of the :ref:`nwb-schema:sec-ElectricalSeries` such as ``unit``, ``offsets`` or ``channel gains`` These properties should be stored in the corresponding attributes of the :ref:`nwb-schema:sec-ElectricalSeries` object.
 
 As a concrete example, the package objects from the `SpikeInterface <https://spikeinterface.readthedocs.io/en/latest/>`__ package contain two properties named ``gain_to_uv`` and ``offset_to_uv`` that are used to convert the raw data to microvolts. These properties should not be stored in the `ElectrodeTable` but rather in the ``ElectricalSeries`` object as ``channel_conversion`` and ``offset`` respectively.
 
@@ -89,5 +89,3 @@ Observation Intervals
 The ``obs_intervals`` field of the :ref:`nwb-schema:sec-units-src` table is used to indicate periods of time where the underlying electrical signal(s) were not observed. This can happen if the recording site moves away from the unit, or if the recording is stopped. Since the channel is not observed, it is not determinable whether a spike occurred during this time. Therefore, there should not be any identified spike times for units matched to those electrical signal(s) occurring outside of the defined ``obs_intervals``. If this variable is not set, it is assumed that all time is observed.
 
 Check function: :py:meth:`~nwbinspector.checks.ecephys.check_spike_times_not_in_unobserved_interval`
-
-

--- a/docs/best_practices/ecephys.rst
+++ b/docs/best_practices/ecephys.rst
@@ -58,6 +58,12 @@ For relative position of an electrode on a probe, use ``rel_x``, ``rel_y``, and 
 that are close enough to share a neuron.
 
 
+Avoid Duplication of Metadata
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``ElectrodeTable`` should not contain redundant information that is present somewhere else within the :ref:`nwb-schema:sec-NWBFile` . Avoid adding columns to the `ElectrodeTable` that correspond to properties of the :ref:`nwb-schema:sec-ElectricalSeries` such as ``unit``, ``offsets`` or ``channel gains`` These properties should be stored in the corresponding attributes of the :ref:`nwb-schema:sec-ElectricalSeries` object. 
+
+As a concrete example, the package objects from the `SpikeInterface <https://spikeinterface.readthedocs.io/en/latest/>`__ package contain two properties named ``gain_to_uv`` and ``offset_to_uv`` that are used to convert the raw data to microvolts. These properties should not be stored in the `ElectrodeTable` but rather in the ``ElectricalSeries`` object as ``channel_conversion`` and ``offset`` respectively.
 
 Units Table
 -----------
@@ -83,3 +89,5 @@ Observation Intervals
 The ``obs_intervals`` field of the :ref:`nwb-schema:sec-units-src` table is used to indicate periods of time where the underlying electrical signal(s) were not observed. This can happen if the recording site moves away from the unit, or if the recording is stopped. Since the channel is not observed, it is not determinable whether a spike occurred during this time. Therefore, there should not be any identified spike times for units matched to those electrical signal(s) occurring outside of the defined ``obs_intervals``. If this variable is not set, it is assumed that all time is observed.
 
 Check function: :py:meth:`~nwbinspector.checks.ecephys.check_spike_times_not_in_unobserved_interval`
+
+

--- a/docs/best_practices/general.rst
+++ b/docs/best_practices/general.rst
@@ -68,3 +68,9 @@ Empty Strings
 Required free-text fields for neurodata types should not use placeholders such as empty strings (`""`), ``"no description"``, or ``"PLACEHOLDER"``. For example, the :py:attr:`description` field should always richly describe that particular neurodata type and its interpretation within the experiment.
 
 Many attributes of neurodata types in NWB are optional details to include. It is not necessary, therefore, to use placeholders for these attributes. Instead, they should not be specified at all.
+
+
+Avoid Duplication of Metadata 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Avoid duplication of metadata across different objects. If a piece of metadata is shared between multiple objects, consider creating a separate object to store that metadata and linking to it from the other objects. This will help to keep the metadata consistent and reduce the risk of errors when updating the metadata.

--- a/docs/best_practices/general.rst
+++ b/docs/best_practices/general.rst
@@ -70,7 +70,7 @@ Required free-text fields for neurodata types should not use placeholders such a
 Many attributes of neurodata types in NWB are optional details to include. It is not necessary, therefore, to use placeholders for these attributes. Instead, they should not be specified at all.
 
 
-Avoid Duplication of Metadata 
+Avoid Duplication of Metadata
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Avoid duplication of metadata across different objects. If a piece of metadata is shared between multiple objects, consider creating a separate object to store that metadata and linking to it from the other objects. This will help to keep the metadata consistent and reduce the risk of errors when updating the metadata.


### PR DESCRIPTION
## Motivation

As requested by @bendichter there are thee parts to this documentation.

* A general comment general about duplicating metadata.
* A general comment in the `ecephys` section of `Electrodes` about not writing columns that might be somewhere else.
* A very specific comment about avoiding writing the Spikeinterface's properties `offset_to_uv` and `gain_to_uv` to `Electrodes`.

Once we are satisfied with the documentation I can add a specific check for the spikeinterface mistake if that is desired.