### PR TITLE
fixed module search flag in nwbinspector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Upcoming
 
+# v0.4.34
+
+### Fixes
+
+* Fixed --modules flag in nwbinspector to allow for import of additional modules in the command line. This was necessary to be able to register new customized checks to the nwbinspector
+
 # v0.4.33
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-* Fixed --modules flag in nwbinspector to allow for import of additional modules in the command line. This was necessary to be able to register new customized checks to the nwbinspector
+* Fixed `--modules` flag in `nwbinspector` command line interface to allow for import of additional modules in the command line. This was necessary to be able to register new customized checks to the NWB Inspector. [#446](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/446)
 
 # v0.4.33
 

--- a/src/nwbinspector/nwbinspector.py
+++ b/src/nwbinspector/nwbinspector.py
@@ -252,6 +252,7 @@ def inspect_all_cli(
     DANDI archive (i.e., https://dandiarchive.org/dandiset/{dandiset_id}/{version_id}), or a six-digit Dandiset ID.
     """
     levels = ["importance", "file_path"] if levels is None else levels.split(",")
+    modules = [] if modules is None else modules.split(",")
     reverse = [False] * len(levels) if reverse is None else [strtobool(x) for x in reverse.split(",")]
     progress_bar = strtobool(progress_bar) if progress_bar is not None else True
     if config is not None:

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -390,7 +390,8 @@ class TestInspector(TestCase):
         console_output_file = self.tempdir / "test_console_output.txt"
         os.system(
             f"nwbinspector {str(self.tempdir)} --overwrite --select check_timestamps_match_first_dimension,"
-            "check_data_orientation,check_regular_timestamps,check_small_dataset_compression"
+            "check_data_orientation,check_regular_timestamps,check_small_dataset_compression "
+            "--modules random,math,datetime"
             f"> {console_output_file}"
         )
         self.assertLogFileContentsEqual(


### PR DESCRIPTION
## Motivation

I was testing adding custom checks to nwbinspector using the '--modules' flag. I was initially facing an error where the nwbinspector was only reading the first character after the --modules flag. I realized that nwbinspector.py was expecting the modules to be input as a comma separated strings of modules, but there was no code to split this module string into a list of strings causing the string itself to be looped over as an iterable. I added a line of code that splits the modules string at the commas to yield a list of strings.