### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix few typos

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,23 @@
+# Codespell configuration is within pyproject.toml
+---
+name: Codespell
+
+on:
+  push:
+    branches: [dev]
+  pull_request:
+    branches: [dev]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,11 @@ repos:
     rev: 24.4.0
     hooks:
     -   id: black
+
+- repo: https://github.com/codespell-project/codespell
+  # Configuration for codespell is in pyproject.toml
+  rev: v2.2.6
+  hooks:
+  - id: codespell
+    additional_dependencies:
+    - tomli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,7 +191,7 @@
 # v0.4.14
 
 ### Fixes
-* Fixed an error with attribute retrieval specific to the `cell_id` of the `IntracellularElectrode` neurodata type that occured with respect to older versions of PyNWB. [PR #264](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/264)
+* Fixed an error with attribute retrieval specific to the `cell_id` of the `IntracellularElectrode` neurodata type that occurred with respect to older versions of PyNWB. [PR #264](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/264)
 
 
 

--- a/docs/best_practices/best_practices_index.rst
+++ b/docs/best_practices/best_practices_index.rst
@@ -7,7 +7,7 @@ and its ecosystem of software tools.
 
 To enable NWB to accommodate the needs of the diverse neuroscience community, NWB provides a great degree of flexibility.
 In particular, the number of instances of a particular neurodata_type and corresponding names are often not fixed, to enable,
-e.g., storage of data from arbitrary numbers of devices withing the same file. While this flexibility is essential to enable
+e.g., storage of data from arbitrary numbers of devices within the same file. While this flexibility is essential to enable
 coverage of a broad range of use-cases, it can also lead to ambiguity. At the same time, we ultimately have the desire to have
 the schema as strict-as-possible to provide users and tool builders with a consistent organization of data. As such, we need to
 strike a fine balance between flexibility to enable support for varying experiments and use-cases and strictness in the schema

--- a/docs/best_practices/extensions.rst
+++ b/docs/best_practices/extensions.rst
@@ -5,7 +5,7 @@ Extend the core NWB schema only when necessary. Extensions are an essential mech
 data with NWB that is otherwise not supported. However, we here need to consider that there are certain costs associated
 with extensions, *e.g.*, cost of creating, supporting, documenting, and maintaining new extensions and effort for users
 to use and learn already-created extensions. As such, users should attempt to use core ``neurodata_types`` or
-pre-existing extentions before creating new ones. :ref:`hdmf-schema:sec-dynamictable`, which are used throughout the
+pre-existing extensions before creating new ones. :ref:`hdmf-schema:sec-dynamictable`, which are used throughout the
 NWB schema to store information about time intervals, electrodes, or spiking output, provide the ability to
 dynamically add columns without the need for extensions, and can help avoid the need for custom extensions in many
 cases.

--- a/docs/user_guide/using_the_command_line_interface.rst
+++ b/docs/user_guide/using_the_command_line_interface.rst
@@ -25,7 +25,7 @@ the most useful of these options.
 Streaming
 ---------
 
-If the NWB file(s) you wish to inspect are already on the :dandi-archive:`DANDI archive <>`, you can run the NWB Inspector directly on that DANDI set instead of having to download it. All that is needed is to specfy the DANDI set ID (six-digit identifier) as the path and add the ``--stream`` flag.
+If the NWB file(s) you wish to inspect are already on the :dandi-archive:`DANDI archive <>`, you can run the NWB Inspector directly on that DANDI set instead of having to download it. All that is needed is to specify the DANDI set ID (six-digit identifier) as the path and add the ``--stream`` flag.
 
 ::
 
@@ -75,7 +75,7 @@ For example,
     numbers like ``"0, 1"``.
 
 
-The defalt report also aggregates identical outputs into a summary over multiple files; running
+The default report also aggregates identical outputs into a summary over multiple files; running
 
 ::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,10 @@ extend-exclude = '''
   |dist
 )/
 '''
+
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git*,*.pdf,*.css'
+check-hidden = true
+# ignore-regex = ''
+# ignore-words-list = ''


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.