### PR TITLE
Pin Zarr for tests

### DIFF
--- a/.github/workflows/dev-gallery.yml
+++ b/.github/workflows/dev-gallery.yml
@@ -22,9 +22,8 @@ jobs:
           pip install pytest-cov
       - name: Install package
         run: |
-          pip install -e .
+          pip install -e ".[dandi]"
           pip install git+https://github.com/neurodatawithoutborders/pynwb@dev
-          pip install dandi
       - name: Download testing data and set config path
         run: |
           dandi download "https://gui-staging.dandiarchive.org/#/dandiset/204919"

--- a/.github/workflows/streaming-tests.yml
+++ b/.github/workflows/streaming-tests.yml
@@ -23,9 +23,7 @@ jobs:
         run: pip install pytest
 
       - name: Install package
-        run: |
-          pip install .
-          pip install dandi
+        run: pip install ".[dandi]"
       - name: Install HDMF-zarr # temporary
         run: pip install hdmf-zarr
       - name: Install latest HDMF # temporary

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -29,9 +29,7 @@ jobs:
           pip install pytest-cov
 
       - name: Install package
-        run: |
-          pip install .
-          pip install dandi
+        run: pip install ".[dandi]"
       - name: Download testing data and set config path
         run: |
           dandi download "https://gui-staging.dandiarchive.org/#/dandiset/204919"

--- a/.github/workflows/version-gallery.yml
+++ b/.github/workflows/version-gallery.yml
@@ -26,9 +26,8 @@ jobs:
           pip install pytest-cov
       - name: Install package
         run: |
-          pip install -e .
+          pip install -e ".[dandi]"
           pip install pynwb==${{ matrix.pynwb-version }}
-          pip install dandi
       - name: Download testing data and set config path
         run: |
           dandi download "https://gui-staging.dandiarchive.org/#/dandiset/204919"

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     package_dir={"": "src"},
     include_package_data=True,  # Includes files described in MANIFEST.in in the installation
     install_requires=install_requires,
-    extras_require=dict(dandi=["dandi>=0.39.2"], zarr=["hdmf_zarr>=0.3.0", "zarr<2.18.0"]),
+    extras_require=dict(dandi=["dandi>=0.39.2", "zarr<2.18.0"], zarr=["hdmf_zarr>=0.3.0", "zarr<2.18.0"]),
     entry_points={"console_scripts": ["nwbinspector=nwbinspector.nwbinspector:inspect_all_cli"]},
     license="BSD-3-Clause",
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     package_dir={"": "src"},
     include_package_data=True,  # Includes files described in MANIFEST.in in the installation
     install_requires=install_requires,
-    extras_require=dict(dandi=["dandi>=0.39.2"], zarr=["hdmf_zarr>=0.3.0,zarr<2.18.0"]),
+    extras_require=dict(dandi=["dandi>=0.39.2"], zarr=["hdmf_zarr>=0.3.0", "zarr<2.18.0"]),
     entry_points={"console_scripts": ["nwbinspector=nwbinspector.nwbinspector:inspect_all_cli"]},
     license="BSD-3-Clause",
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     package_dir={"": "src"},
     include_package_data=True,  # Includes files described in MANIFEST.in in the installation
     install_requires=install_requires,
-    extras_require=dict(dandi=["dandi>=0.39.2"], zarr=["hdmf_zarr>=0.3.0"]),
+    extras_require=dict(dandi=["dandi>=0.39.2"], zarr=["hdmf_zarr>=0.3.0,zarr<2.18.0"]),
     entry_points={"console_scripts": ["nwbinspector=nwbinspector.nwbinspector:inspect_all_cli"]},
     license="BSD-3-Clause",
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
     package_dir={"": "src"},
     include_package_data=True,  # Includes files described in MANIFEST.in in the installation
     install_requires=install_requires,
+    # zarr<2.18.0 because of https://github.com/NeurodataWithoutBorders/nwbinspector/pull/460
     extras_require=dict(dandi=["dandi>=0.39.2", "zarr<2.18.0"], zarr=["hdmf_zarr>=0.3.0", "zarr<2.18.0"]),
     entry_points={"console_scripts": ["nwbinspector=nwbinspector.nwbinspector:inspect_all_cli"]},
     license="BSD-3-Clause",


### PR DESCRIPTION
Analog of https://github.com/catalystneuro/neuroconv/pull/845 for here as well

Tests just failed today due to a surprise break from Zarr release yesterday - some issue with decoding Blosc

Shouldn't effect actual typical usage of the backend feature aside from Blosc I assume, since none of the other compressor tests complain

https://github.com/hdmf-dev/hdmf-zarr/issues/192 so team knows about it, and if it's an issue with the way they specify the read from the IO level (I doubt it, but never know)

Downpinning in tests temporarily to fix the CI, will check over time if resolved automagically