### PR TITLE
Fix best practices typos

### DIFF
--- a/docs/best_practices/extensions.rst
+++ b/docs/best_practices/extensions.rst
@@ -14,7 +14,7 @@ If an extension is required, tutorials for the process may be found through the
 :nwb-overview:`NWB Overview for Extensions <extensions_tutorial/extensions_tutorial_home.html>`.
 
 It is also encouraged for extensions to contain their own check functions for their own best practices.
-See the` :ref:`adding_custom_checks` section of the Developer Guide for how to do this.
+See the :ref:`adding_custom_checks` section of the Developer Guide for how to do this.
 
 
 

--- a/docs/best_practices/nwbfile_metadata.rst
+++ b/docs/best_practices/nwbfile_metadata.rst
@@ -140,7 +140,7 @@ The ``keywords`` field should be specified. This allows metadata collection prog
 :dandi-archive:`DANDI archive <>` to easily scan NWBFiles to enhance keyword-based search functionality. Try to think
 of what combination of words might make your file(s) unique or descriptive to help users trying to search for it. This
 could include the general modality or approach, the general region of cortex you wanted to study, or the type of neural
-data properties you were examining. Some examples are``"neuropixel"``, ``"hippocampus"``, ``"lateral septum"``,
+data properties you were examining. Some examples are ``"neuropixel"``, ``"hippocampus"``, ``"lateral septum"``,
 ``"waveforms"``, ``"cell types"``, ``"granule cells"``, etc.
 
 If you are unsure of what keywords to use, try searching existing datasets on the :dandi-archive:`DANDI archive <>` for


### PR DESCRIPTION
## Motivation

Found a couple of tiny typos in the Best Practices section of the docs