### PR TITLE
Fix suggested rate for timeseries with regular timestamps

### DIFF
--- a/.github/workflows/dandi_release.yml
+++ b/.github/workflows/dandi_release.yml
@@ -42,8 +42,8 @@ jobs:
         python -m pip install --upgrade pip wheel
         pip install "dandi[extras,test]"
 
-    - name: Install dev versions of NWB Inspector
-      run: pip install git+https://github.com/NeurodataWithoutBorders/nwbinspector
+    - name: Install this branch of NWB Inspector
+      run: pip install -e .
 
-    - name: Run all tests
+    - name: Run all NWB Inspector tests
       run: python -m pytest -s -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Upcoming
 
+### Fixes
+
+* Fixed the suggested rate in `check_regular_timestamps` to be in Hz [#467](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/467)
+
 # v0.4.35
 
 ### Fixes

--- a/src/nwbinspector/checks/time_series.py
+++ b/src/nwbinspector/checks/time_series.py
@@ -18,6 +18,7 @@ def check_regular_timestamps(
         time_series.timestamps is not None
         and len(time_series.timestamps) > 2
         and is_regular_series(series=time_series.timestamps, tolerance_decimals=time_tolerance_decimals)
+        and (time_series.timestamps[1] - time_series.timestamps[0]) != 0
     ):
         timestamps = np.array(time_series.timestamps)
         if timestamps.size * timestamps.dtype.itemsize > gb_severity_threshold * 1e9:
@@ -29,7 +30,7 @@ def check_regular_timestamps(
             message=(
                 "TimeSeries appears to have a constant sampling rate. "
                 f"Consider specifying starting_time={time_series.timestamps[0]} "
-                f"and rate={time_series.timestamps[1] - time_series.timestamps[0]} instead of timestamps."
+                f"and rate={1 / (time_series.timestamps[1] - time_series.timestamps[0])} instead of timestamps."
             ),
         )
 

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -158,7 +158,7 @@ class TestInspector(TestCase):
             InspectorMessage(
                 message=(
                     "TimeSeries appears to have a constant sampling rate. Consider specifying starting_time=1.2 "
-                    "and rate=2.0 instead of timestamps."
+                    "and rate=0.5 instead of timestamps."
                 ),
                 importance=Importance.BEST_PRACTICE_VIOLATION,
                 severity=Severity.LOW,
@@ -194,7 +194,7 @@ class TestInspector(TestCase):
             InspectorMessage(
                 message=(
                     "TimeSeries appears to have a constant sampling rate. Consider specifying starting_time=1.2 "
-                    "and rate=2.0 instead of timestamps."
+                    "and rate=0.5 instead of timestamps."
                 ),
                 importance=Importance.BEST_PRACTICE_VIOLATION,
                 severity=Severity.LOW,
@@ -225,7 +225,7 @@ class TestInspector(TestCase):
                 InspectorMessage(
                     message=(
                         "TimeSeries appears to have a constant sampling rate. Consider specifying starting_time=1.2 "
-                        "and rate=2.0 instead of timestamps."
+                        "and rate=0.5 instead of timestamps."
                     ),
                     importance=Importance.BEST_PRACTICE_VIOLATION,
                     severity=Severity.LOW,
@@ -263,7 +263,7 @@ class TestInspector(TestCase):
                 InspectorMessage(
                     message=(
                         "TimeSeries appears to have a constant sampling rate. Consider specifying starting_time=1.2 "
-                        "and rate=2.0 instead of timestamps."
+                        "and rate=0.5 instead of timestamps."
                     ),
                     importance=Importance.BEST_PRACTICE_VIOLATION,
                     severity=Severity.LOW,
@@ -292,7 +292,7 @@ class TestInspector(TestCase):
             InspectorMessage(
                 message=(
                     "TimeSeries appears to have a constant sampling rate. Consider specifying starting_time=1.2 and "
-                    "rate=2.0 instead of timestamps."
+                    "rate=0.5 instead of timestamps."
                 ),
                 severity=Severity.LOW,
                 importance=Importance.BEST_PRACTICE_VIOLATION,
@@ -542,7 +542,7 @@ class TestInspector(TestCase):
             InspectorMessage(
                 message=(
                     "TimeSeries appears to have a constant sampling rate. "
-                    "Consider specifying starting_time=1.2 and rate=2.0 instead of timestamps."
+                    "Consider specifying starting_time=1.2 and rate=0.5 instead of timestamps."
                 ),
                 importance=Importance.BEST_PRACTICE_VIOLATION,
                 check_function_name="check_regular_timestamps",

--- a/tests/true_nwbinspector_default_report.txt
+++ b/tests/true_nwbinspector_default_report.txt
@@ -25,7 +25,7 @@ Found 5 issues over 2 files:
 ==========================
 
 1.2  ./testing0.nwb and 1 other file: check_regular_timestamps - 'TimeSeries' object at location '/acquisition/test_time_series_2'
-       Message: TimeSeries appears to have a constant sampling rate. Consider specifying starting_time=1.2 and rate=2.0 instead of timestamps.
+       Message: TimeSeries appears to have a constant sampling rate. Consider specifying starting_time=1.2 and rate=0.5 instead of timestamps.
 
 2  BEST_PRACTICE_SUGGESTION
 ===========================

--- a/tests/unit_tests/test_time_series.py
+++ b/tests/unit_tests/test_time_series.py
@@ -34,7 +34,7 @@ def test_check_regular_timestamps():
         )
     ) == InspectorMessage(
         message=(
-            "TimeSeries appears to have a constant sampling rate. Consider specifying starting_time=1.2 and rate=2.0 "
+            "TimeSeries appears to have a constant sampling rate. Consider specifying starting_time=1.2 and rate=0.5 "
             "instead of timestamps."
         ),
         importance=Importance.BEST_PRACTICE_VIOLATION,


### PR DESCRIPTION
## Motivation

Fix #466. Update the suggested rate to be in Hz.
