### PR TITLE
More ruff (isort)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,11 @@ fixable = ["ALL"]
 "src/nwbinspector/version/__init__.py" = ["F401", "I"]
 "src/nwbinspector/register_checks/__init__.py" = ["F401", "I"]
 
+[tool.ruff.lint.isort]
+relative-imports-order = "closest-to-furthest"
+known-first-party = ["nwbinspector"]
+
+
 
 [tool.codespell]
 skip = '.git*,*.pdf,*.css'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ extend-exclude = '''
 exclude = ["docs/*"]
 
 [tool.ruff.lint]
-select = ["F401", "I002"] # TODO: eventually, expand to other 'I', 'D', and other 'F' linting
+select = ["F401", "I"] # TODO: eventually, expand to other 'D', and other 'F' linting
 fixable = ["ALL"]
 
 [tool.ruff.lint.per-file-ignores]

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
-from setuptools import setup, find_packages
 from pathlib import Path
 from shutil import copy
+
+from setuptools import find_packages, setup
 
 root = Path(__file__).parent
 with open(root / "README.md", "r") as f:

--- a/src/nwbinspector/_configuration.py
+++ b/src/nwbinspector/_configuration.py
@@ -1,18 +1,19 @@
 """Primary functions for inspecting NWBFiles."""
 
 import json
-import jsonschema
 from pathlib import Path
-from typing import Optional, List
 from types import FunctionType
+from typing import List, Optional
 
+import jsonschema
 import yaml
 
-from . import available_checks
-from ._registration import Importance
 from nwbinspector.utils._utils import (
     PathType,
 )
+
+from . import available_checks
+from ._registration import Importance
 
 INTERNAL_CONFIGS = dict(dandi=Path(__file__).parent / "internal_configs" / "dandi.inspector_config.yaml")
 

--- a/src/nwbinspector/_formatting.py
+++ b/src/nwbinspector/_formatting.py
@@ -1,20 +1,20 @@
 """Internally used tools specifically for rendering more human-readable output from collected check results."""
 
-import os
 import json
+import os
 import sys
-from typing import Dict, List, Optional, Union
-from pathlib import Path
-from enum import Enum
-from datetime import datetime
-from platform import platform
 from collections import defaultdict
+from datetime import datetime
+from enum import Enum
+from pathlib import Path
+from platform import platform
+from typing import Dict, List, Optional, Union
 
 import numpy as np
 
-from ._types import InspectorMessage, Importance
 from ._organization import organize_messages
-from .utils import get_package_version, FilePathType
+from ._types import Importance, InspectorMessage
+from .utils import FilePathType, get_package_version
 
 
 class InspectorOutputJSONEncoder(json.JSONEncoder):

--- a/src/nwbinspector/_inspection.py
+++ b/src/nwbinspector/_inspection.py
@@ -1,29 +1,29 @@
 """Primary functions for inspecting NWBFiles."""
 
-import re
 import importlib
+import re
 import traceback
-from pathlib import Path
-from typing import Union, Optional, List, Iterable
-from concurrent.futures import ProcessPoolExecutor, as_completed
-from warnings import filterwarnings, warn
 from collections import defaultdict
-from packaging.version import Version
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+from typing import Iterable, List, Optional, Union
+from warnings import filterwarnings, warn
 
 import pynwb
-from tqdm import tqdm
 from natsort import natsorted
+from packaging.version import Version
+from tqdm import tqdm
 
 from . import available_checks, configure_checks
-from ._registration import InspectorMessage, Importance
+from ._registration import Importance, InspectorMessage
 from .tools import get_s3_urls_and_dandi_paths
 from .utils import (
     FilePathType,
-    PathType,
     OptionalListOfStrings,
-    robust_s3_read,
+    PathType,
     calculate_number_of_cpu,
     get_package_version,
+    robust_s3_read,
 )
 
 

--- a/src/nwbinspector/_inspection_cli.py
+++ b/src/nwbinspector/_inspection_cli.py
@@ -1,16 +1,24 @@
 """Primary functions for inspecting NWBFiles."""
 
+import json
 import os
 import re
-import json
 from pathlib import Path
 from typing import Optional
 from warnings import warn
 
 import click
 
-from ._formatting import _get_report_header, InspectorOutputJSONEncoder
-from . import Importance, inspect_all, format_messages, print_to_console, save_report, __version__, load_config
+from . import (
+    Importance,
+    __version__,
+    format_messages,
+    inspect_all,
+    load_config,
+    print_to_console,
+    save_report,
+)
+from ._formatting import InspectorOutputJSONEncoder, _get_report_header
 from .utils import strtobool
 
 

--- a/src/nwbinspector/_organization.py
+++ b/src/nwbinspector/_organization.py
@@ -1,7 +1,7 @@
 """Internally used tools specifically for rendering more human-readable output from collected check results."""
 
-from typing import List, Optional
 from enum import Enum
+from typing import List, Optional
 
 from natsort import natsorted
 

--- a/src/nwbinspector/_registration.py
+++ b/src/nwbinspector/_registration.py
@@ -5,11 +5,10 @@ from typing import Optional
 
 import h5py
 from pynwb import NWBFile
-from pynwb.file import Subject
 from pynwb.ecephys import Device, ElectrodeGroup
+from pynwb.file import Subject
 
-from ._types import Importance, Severity, InspectorMessage
-
+from ._types import Importance, InspectorMessage, Severity
 
 available_checks = list()
 

--- a/src/nwbinspector/_types.py
+++ b/src/nwbinspector/_types.py
@@ -1,7 +1,7 @@
 """Primary decorator used on a check function to add it to the registry and automatically parse its output."""
 
-from enum import Enum
 from dataclasses import dataclass
+from enum import Enum
 from typing import Optional
 
 

--- a/src/nwbinspector/checks/__init__.py
+++ b/src/nwbinspector/checks/__init__.py
@@ -1,12 +1,21 @@
+from ._behavior import (
+    check_compass_direction_unit,
+    check_spatial_series_degrees_magnitude,
+    check_spatial_series_dims,
+    check_spatial_series_radians_magnitude,
+)
 from ._ecephys import (
-    check_negative_spike_times,
     check_electrical_series_dims,
     check_electrical_series_reference_electrodes_table,
+    check_negative_spike_times,
     check_spike_times_not_in_unobserved_interval,
 )
 from ._general import (
     check_description,
     check_name_slashes,
+)
+from ._icephys import (
+    check_intracellular_electrode_cell_id_exists,
 )
 from ._image_series import (
     check_image_series_data_size,
@@ -14,74 +23,65 @@ from ._image_series import (
     check_image_series_external_file_valid,
 )
 from ._images import (
-    check_order_of_images_unique,
-    check_order_of_images_len,
     check_index_series_points_to_image,
+    check_order_of_images_len,
+    check_order_of_images_unique,
 )
 from ._nwb_containers import (
     check_empty_string_for_optional_attribute,
-    check_small_dataset_compression,
     check_large_dataset_compression,
+    check_small_dataset_compression,
 )
 from ._nwbfile_metadata import (
-    check_keywords,
-    check_institution,
-    check_subject_age,
-    check_subject_sex,
-    check_subject_exists,
     check_doi_publications,
-    check_experimenter_form,
-    check_experimenter_exists,
     check_experiment_description,
+    check_experimenter_exists,
+    check_experimenter_form,
+    check_institution,
+    check_keywords,
+    check_processing_module_name,
+    check_session_start_time_future_date,
+    check_session_start_time_old_date,
+    check_subject_age,
+    check_subject_exists,
     check_subject_id_exists,
+    check_subject_proper_age_range,
+    check_subject_sex,
     check_subject_species_exists,
     check_subject_species_form,
-    check_subject_proper_age_range,
-    check_session_start_time_future_date,
-    check_processing_module_name,
-    check_session_start_time_old_date,
 )
 from ._ogen import (
     check_optogenetic_stimulus_site_has_optogenetic_series,
 )
 from ._ophys import (
+    check_emission_lambda_in_nm,
     check_excitation_lambda_in_nm,
     check_plane_segmentation_image_mask_shape_against_ref_images,
     check_roi_response_series_dims,
-    check_emission_lambda_in_nm,
     check_roi_response_series_link_to_plane_segmentation,
 )
 from ._tables import (
-    check_single_row,
-    check_ids_unique,
-    check_empty_table,
     check_col_not_nan,
     check_column_binary_capability,
     check_dynamic_table_region_data_validity,
+    check_empty_table,
+    check_ids_unique,
+    check_single_row,
+    check_table_time_columns_are_not_negative,
+    check_table_values_for_dict,
     check_time_interval_time_columns,
     check_time_intervals_stop_after_start,
-    check_table_values_for_dict,
-    check_table_time_columns_are_not_negative,
 )
 from ._time_series import (
-    check_resolution,
-    check_missing_unit,
-    check_regular_timestamps,
-    check_timestamps_ascending,
     check_data_orientation,
-    check_timestamps_without_nans,
-    check_timestamps_match_first_dimension,
-    check_timestamp_of_the_first_sample_is_not_negative,
+    check_missing_unit,
     check_rate_is_not_zero,
-)
-from ._icephys import (
-    check_intracellular_electrode_cell_id_exists,
-)
-from ._behavior import (
-    check_compass_direction_unit,
-    check_spatial_series_radians_magnitude,
-    check_spatial_series_dims,
-    check_spatial_series_degrees_magnitude,
+    check_regular_timestamps,
+    check_resolution,
+    check_timestamp_of_the_first_sample_is_not_negative,
+    check_timestamps_ascending,
+    check_timestamps_match_first_dimension,
+    check_timestamps_without_nans,
 )
 
 __all__ = [

--- a/src/nwbinspector/checks/_behavior.py
+++ b/src/nwbinspector/checks/_behavior.py
@@ -1,9 +1,9 @@
 """Checks for types belonging to the pynwb.behavior module."""
 
 import numpy as np
-from pynwb.behavior import SpatialSeries, CompassDirection
+from pynwb.behavior import CompassDirection, SpatialSeries
 
-from .._registration import register_check, Importance, InspectorMessage
+from .._registration import Importance, InspectorMessage, register_check
 
 
 @register_check(importance=Importance.CRITICAL, neurodata_type=SpatialSeries)

--- a/src/nwbinspector/checks/_ecephys.py
+++ b/src/nwbinspector/checks/_ecephys.py
@@ -1,12 +1,11 @@
 """Check functions specific to extracellular electrophysiology neurodata types."""
 
 import numpy as np
-
-from pynwb.misc import Units
 from pynwb.ecephys import ElectricalSeries
+from pynwb.misc import Units
 
+from .._registration import Importance, InspectorMessage, register_check
 from ..utils import get_data_shape
-from .._registration import register_check, Importance, InspectorMessage
 
 
 @register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=Units)

--- a/src/nwbinspector/checks/_general.py
+++ b/src/nwbinspector/checks/_general.py
@@ -1,6 +1,6 @@
 """Check functions that examine any general neurodata_type with the available attributes."""
 
-from .._registration import register_check, InspectorMessage, Importance
+from .._registration import Importance, InspectorMessage, register_check
 
 COMMON_DESCRIPTION_PLACEHOLDERS = ["no description", "no desc", "none", "placeholder"]
 

--- a/src/nwbinspector/checks/_icephys.py
+++ b/src/nwbinspector/checks/_icephys.py
@@ -2,7 +2,7 @@
 
 from pynwb.icephys import IntracellularElectrode
 
-from .._registration import register_check, Importance, InspectorMessage
+from .._registration import Importance, InspectorMessage, register_check
 
 
 @register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=IntracellularElectrode)

--- a/src/nwbinspector/checks/_image_series.py
+++ b/src/nwbinspector/checks/_image_series.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from pynwb.image import ImageSeries
 from pynwb.ophys import TwoPhotonSeries
 
-from .._registration import register_check, Importance, InspectorMessage
+from .._registration import Importance, InspectorMessage, register_check
 from ..tools import get_nwbfile_path_from_internal_object
 
 

--- a/src/nwbinspector/checks/_images.py
+++ b/src/nwbinspector/checks/_images.py
@@ -1,10 +1,9 @@
 """Checks specific to the Images neurodata type."""
 
 from packaging.version import Version
-
 from pynwb.image import IndexSeries
 
-from .._registration import register_check, Importance, InspectorMessage
+from .._registration import Importance, InspectorMessage, register_check
 from ..utils import get_package_version
 
 # The Images neurodata type was unavailable prior to PyNWB v.2.1.0

--- a/src/nwbinspector/checks/_nwb_containers.py
+++ b/src/nwbinspector/checks/_nwb_containers.py
@@ -5,8 +5,7 @@ import os
 import h5py
 from pynwb import NWBContainer
 
-
-from .._registration import register_check, Importance, InspectorMessage, Severity
+from .._registration import Importance, InspectorMessage, Severity, register_check
 
 
 @register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=NWBContainer)

--- a/src/nwbinspector/checks/_nwbfile_metadata.py
+++ b/src/nwbinspector/checks/_nwbfile_metadata.py
@@ -3,11 +3,11 @@
 import re
 from datetime import datetime
 
-from isodate import parse_duration, Duration
+from isodate import Duration, parse_duration
 from pynwb import NWBFile, ProcessingModule
 from pynwb.file import Subject
 
-from .._registration import register_check, InspectorMessage, Importance
+from .._registration import Importance, InspectorMessage, register_check
 from ..utils import is_module_installed
 
 duration_regex = (
@@ -79,7 +79,9 @@ def check_experimenter_form(nwbfile: NWBFile):
     if nwbfile.experimenter is None:
         return
     if is_module_installed(module_name="dandi"):
-        from dandischema.models import NAME_PATTERN  # for most up to date version of the regex
+        from dandischema.models import (
+            NAME_PATTERN,  # for most up to date version of the regex
+        )
     else:
         NAME_PATTERN = r"^([\w\s\-\.']+),\s+([\w\s\-\.']+)$"  # copied on 7/12/22
 

--- a/src/nwbinspector/checks/_ogen.py
+++ b/src/nwbinspector/checks/_ogen.py
@@ -1,6 +1,6 @@
 from pynwb.ogen import OptogeneticSeries, OptogeneticStimulusSite
 
-from .._registration import register_check, Importance, InspectorMessage
+from .._registration import Importance, InspectorMessage, register_check
 
 
 @register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=OptogeneticStimulusSite)

--- a/src/nwbinspector/checks/_ophys.py
+++ b/src/nwbinspector/checks/_ophys.py
@@ -1,14 +1,14 @@
 """Check functions specific to optical electrophysiology neurodata types."""
 
 from pynwb.ophys import (
-    RoiResponseSeries,
-    PlaneSegmentation,
-    OpticalChannel,
     ImagingPlane,
+    OpticalChannel,
+    PlaneSegmentation,
+    RoiResponseSeries,
 )
 
+from .._registration import Importance, InspectorMessage, register_check
 from ..utils import get_data_shape
-from .._registration import register_check, Importance, InspectorMessage
 
 MIN_LAMBDA = 10.0  # trigger warnings for wavelength values less than this value
 

--- a/src/nwbinspector/checks/_tables.py
+++ b/src/nwbinspector/checks/_tables.py
@@ -7,16 +7,15 @@ import numpy as np
 from hdmf.common import DynamicTable, DynamicTableRegion, VectorIndex
 from pynwb.file import TimeIntervals, Units
 
-from .._registration import register_check, InspectorMessage, Importance
+from .._registration import Importance, InspectorMessage, register_check
 from ..utils import (
     cache_data_selection,
     format_byte_size,
+    get_data_shape,
     is_ascending_series,
     is_dict_in_string,
     is_string_json_loadable,
-    get_data_shape,
 )
-
 
 NELEMS = 200
 

--- a/src/nwbinspector/checks/_time_series.py
+++ b/src/nwbinspector/checks/_time_series.py
@@ -1,12 +1,11 @@
 """Check functions that can apply to any descendant of TimeSeries."""
 
 import numpy as np
-
 from pynwb import TimeSeries
 from pynwb.image import ImageSeries, IndexSeries
 
-from .._registration import register_check, Importance, Severity, InspectorMessage
-from ..utils import is_regular_series, is_ascending_series, get_data_shape
+from .._registration import Importance, InspectorMessage, Severity, register_check
+from ..utils import get_data_shape, is_ascending_series, is_regular_series
 
 
 @register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=TimeSeries)

--- a/src/nwbinspector/testing/__init__.py
+++ b/src/nwbinspector/testing/__init__.py
@@ -1,14 +1,14 @@
 from ._testing import (
-    check_streaming_tests_enabled,
-    check_streaming_enabled,
-    check_hdf5_io_open,
-    check_zarr_io_open,
-    load_testing_config,
-    update_testing_config,
-    generate_testing_files,
-    generate_image_series_testing_files,
-    make_minimal_nwbfile,
     TESTING_CONFIG_FILE_PATH,
+    check_hdf5_io_open,
+    check_streaming_enabled,
+    check_streaming_tests_enabled,
+    check_zarr_io_open,
+    generate_image_series_testing_files,
+    generate_testing_files,
+    load_testing_config,
+    make_minimal_nwbfile,
+    update_testing_config,
 )
 
 __all__ = [

--- a/src/nwbinspector/testing/_testing.py
+++ b/src/nwbinspector/testing/_testing.py
@@ -1,12 +1,12 @@
 """Helper functions for internal use across the testing suite."""
 
-import os
 import json
-from uuid import uuid4
-from pathlib import Path
+import os
 from datetime import datetime
-from typing import Tuple, Optional
+from pathlib import Path
+from typing import Optional, Tuple
 from urllib import request
+from uuid import uuid4
 
 import h5py
 from hdmf.backends.hdf5 import HDF5IO
@@ -15,7 +15,7 @@ from packaging.version import Version
 from pynwb import NWBHDF5IO, NWBFile
 from pynwb.image import ImageSeries
 
-from ..utils import is_module_installed, get_package_version, strtobool
+from ..utils import get_package_version, is_module_installed, strtobool
 
 # The tests must be invoked at the outer level of the repository
 TESTING_CONFIG_FILE_PATH = Path.cwd() / "tests" / "testing_config.json"

--- a/src/nwbinspector/tools/_dandi.py
+++ b/src/nwbinspector/tools/_dandi.py
@@ -1,11 +1,10 @@
 """Helper functions related to DANDI for internal use that rely on external dependencies (i.e., dandi)."""
 
 import re
-from typing import Optional, Dict
 from concurrent.futures import ProcessPoolExecutor, as_completed
+from typing import Dict, Optional
 
-
-from ..utils import is_module_installed, calculate_number_of_cpu
+from ..utils import calculate_number_of_cpu, is_module_installed
 
 
 def get_s3_urls_and_dandi_paths(dandiset_id: str, version_id: Optional[str] = None, n_jobs: int = 1) -> Dict[str, str]:

--- a/src/nwbinspector/tools/_read_nwbfile.py
+++ b/src/nwbinspector/tools/_read_nwbfile.py
@@ -1,8 +1,8 @@
 """Temporary module for thorough testing and evaluation of the proposed `read_nwbfile` helper function."""
 
 from pathlib import Path
+from typing import Literal, Optional, Union
 from warnings import filterwarnings
-from typing import Optional, Literal, Union
 
 import h5py
 from pynwb import NWBHDF5IO, NWBFile

--- a/src/nwbinspector/utils/_utils.py
+++ b/src/nwbinspector/utils/_utils.py
@@ -1,20 +1,19 @@
 """Commonly reused logic for evaluating conditions; must not have external dependencies."""
 
+import json
 import os
 import re
-import json
-from typing import TypeVar, Union, Optional, List, Dict, Callable, Tuple
-from pathlib import Path
-from importlib import import_module
-from packaging import version
-from time import sleep
 from functools import lru_cache
+from importlib import import_module
+from pathlib import Path
+from time import sleep
+from typing import Callable, Dict, List, Optional, Tuple, TypeVar, Union
 
 import h5py
 import numpy as np
-from numpy.typing import ArrayLike
 from hdmf.backends.hdf5.h5_utils import H5Dataset
-
+from numpy.typing import ArrayLike
+from packaging import version
 
 # TODO: deprecated these in favor of explicit typing
 PathType = TypeVar("PathType", str, Path)  # For types that can be either files or folders

--- a/tests/read_nwbfile_tests.py
+++ b/tests/read_nwbfile_tests.py
@@ -5,15 +5,15 @@ from pathlib import Path
 import pytest
 from hdmf_zarr import NWBZarrIO
 from pynwb import NWBHDF5IO
-from pynwb.testing.mock.file import mock_NWBFile
 from pynwb.testing.mock.base import mock_TimeSeries
+from pynwb.testing.mock.file import mock_NWBFile
 
-from nwbinspector.tools import read_nwbfile
 from nwbinspector.testing import (
-    check_streaming_tests_enabled,
     check_hdf5_io_open,
+    check_streaming_tests_enabled,
     check_zarr_io_open,
 )
+from nwbinspector.tools import read_nwbfile
 
 STREAMING_TESTS_ENABLED, DISABLED_STREAMING_TESTS_REASON = check_streaming_tests_enabled()
 

--- a/tests/streaming_tests.py
+++ b/tests/streaming_tests.py
@@ -1,17 +1,17 @@
 """All tests that specifically require streaming to be enabled (i.e., ROS3 version of h5py, fsspec, etc.)."""
 
 import os
-import pytest
+from pathlib import Path
 from shutil import rmtree
 from tempfile import mkdtemp
-from pathlib import Path
 from unittest import TestCase
 
-from nwbinspector import Importance, inspect_all, InspectorMessage
-from nwbinspector.tools import read_nwbfile
-from nwbinspector.testing import check_streaming_tests_enabled, check_hdf5_io_open
-from nwbinspector.utils import FilePathType
+import pytest
 
+from nwbinspector import Importance, InspectorMessage, inspect_all
+from nwbinspector.testing import check_hdf5_io_open, check_streaming_tests_enabled
+from nwbinspector.tools import read_nwbfile
+from nwbinspector.utils import FilePathType
 
 STREAMING_TESTS_ENABLED, DISABLED_STREAMING_TESTS_REASON = check_streaming_tests_enabled()
 PERSISTENT_READ_NWBFILE_HDF5_EXAMPLE_HTTPS = (

--- a/tests/test_check_configuration.py
+++ b/tests/test_check_configuration.py
@@ -1,21 +1,22 @@
-from jsonschema import ValidationError
 from unittest import TestCase
+
+from jsonschema import ValidationError
 
 from nwbinspector import (
     Importance,
     available_checks,
-    default_check_registry,
-    validate_config,
     configure_checks,
+    default_check_registry,
     load_config,
-)
-from nwbinspector.checks import (
-    check_small_dataset_compression,
-    check_regular_timestamps,
-    check_data_orientation,
-    check_timestamps_match_first_dimension,
+    validate_config,
 )
 from nwbinspector._configuration import _copy_function
+from nwbinspector.checks import (
+    check_data_orientation,
+    check_regular_timestamps,
+    check_small_dataset_compression,
+    check_timestamps_match_first_dimension,
+)
 
 
 class TestCheckConfiguration(TestCase):

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -1,34 +1,34 @@
 import os
+from datetime import datetime
+from pathlib import Path
 from shutil import rmtree
 from tempfile import mkdtemp
-from pathlib import Path
 from unittest import TestCase
-from datetime import datetime
 
 import numpy as np
-from pynwb import NWBFile, NWBHDF5IO, TimeSeries
-from pynwb.file import TimeIntervals, Subject
-from pynwb.behavior import SpatialSeries, Position
 from hdmf.common import DynamicTable
 from natsort import natsorted
+from pynwb import NWBHDF5IO, NWBFile, TimeSeries
+from pynwb.behavior import Position, SpatialSeries
+from pynwb.file import Subject, TimeIntervals
 
 from nwbinspector import (
     Importance,
-    Severity,
     InspectorMessage,
-    register_check,
-    load_config,
+    Severity,
+    available_checks,
     inspect_all,
     inspect_nwbfile,
     inspect_nwbfile_object,
-    available_checks,
+    load_config,
+    register_check,
 )
 from nwbinspector.checks import (
-    check_small_dataset_compression,
-    check_regular_timestamps,
     check_data_orientation,
-    check_timestamps_match_first_dimension,
+    check_regular_timestamps,
+    check_small_dataset_compression,
     check_subject_exists,
+    check_timestamps_match_first_dimension,
 )
 from nwbinspector.testing import make_minimal_nwbfile
 from nwbinspector.utils import FilePathType

--- a/tests/test_register_check.py
+++ b/tests/test_register_check.py
@@ -4,7 +4,7 @@ from hdmf.common import DynamicTable
 from hdmf.testing import TestCase
 from pynwb import TimeSeries
 
-from nwbinspector import register_check, Importance, Severity, InspectorMessage
+from nwbinspector import Importance, InspectorMessage, Severity, register_check
 
 
 class TestRegisterClass(TestCase):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,11 +1,11 @@
-import numpy as np
-from uuid import uuid4
 from datetime import datetime
+from uuid import uuid4
 
+import numpy as np
 import pynwb
 from hdmf.testing import TestCase
 
-from nwbinspector import InspectorMessage, Importance, Severity, organize_messages
+from nwbinspector import Importance, InspectorMessage, Severity, organize_messages
 from nwbinspector.tools import all_of_type
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,23 +1,20 @@
 import os
-from packaging import version
 
+import numpy as np
+import pytest
 from hdmf.testing import TestCase
+from packaging import version
 
 from nwbinspector import Importance
 from nwbinspector.utils import (
-    format_byte_size,
-    is_regular_series,
-    is_dict_in_string,
-    get_package_version,
     calculate_number_of_cpu,
+    format_byte_size,
+    get_package_version,
     is_ascending_series,
+    is_dict_in_string,
+    is_regular_series,
     strtobool,
 )
-
-
-import pytest
-
-import numpy as np
 
 
 def test_format_byte_size():

--- a/tests/unit_tests/test_behavior.py
+++ b/tests/unit_tests/test_behavior.py
@@ -1,11 +1,11 @@
-from pynwb.behavior import SpatialSeries, CompassDirection
 import numpy as np
+from pynwb.behavior import CompassDirection, SpatialSeries
 
-from nwbinspector import InspectorMessage, Importance
+from nwbinspector import Importance, InspectorMessage
 from nwbinspector.checks import (
     check_compass_direction_unit,
-    check_spatial_series_dims,
     check_spatial_series_degrees_magnitude,
+    check_spatial_series_dims,
     check_spatial_series_radians_magnitude,
 )
 

--- a/tests/unit_tests/test_ecephys.py
+++ b/tests/unit_tests/test_ecephys.py
@@ -3,16 +3,16 @@ from unittest import TestCase
 from uuid import uuid4
 
 import numpy as np
+from hdmf.common.table import DynamicTable, DynamicTableRegion
 from pynwb import NWBFile
 from pynwb.ecephys import ElectricalSeries
 from pynwb.misc import Units
-from hdmf.common.table import DynamicTableRegion, DynamicTable
 
-from nwbinspector import InspectorMessage, Importance
+from nwbinspector import Importance, InspectorMessage
 from nwbinspector.checks import (
-    check_negative_spike_times,
     check_electrical_series_dims,
     check_electrical_series_reference_electrodes_table,
+    check_negative_spike_times,
     check_spike_times_not_in_unobserved_interval,
 )
 

--- a/tests/unit_tests/test_general.py
+++ b/tests/unit_tests/test_general.py
@@ -1,7 +1,7 @@
 from hdmf.common import DynamicTable
 
-from nwbinspector import InspectorMessage, Importance
-from nwbinspector.checks import check_name_slashes, check_description
+from nwbinspector import Importance, InspectorMessage
+from nwbinspector.checks import check_description, check_name_slashes
 
 
 def test_check_name_slashes_pass():

--- a/tests/unit_tests/test_icephys.py
+++ b/tests/unit_tests/test_icephys.py
@@ -1,9 +1,9 @@
 import pytest
 from packaging.version import Version
-from pynwb.icephys import IntracellularElectrode
 from pynwb.device import Device
+from pynwb.icephys import IntracellularElectrode
 
-from nwbinspector import InspectorMessage, Importance
+from nwbinspector import Importance, InspectorMessage
 from nwbinspector.checks import check_intracellular_electrode_cell_id_exists
 from nwbinspector.utils import get_package_version
 

--- a/tests/unit_tests/test_image_series.py
+++ b/tests/unit_tests/test_image_series.py
@@ -1,20 +1,20 @@
 import unittest
 from pathlib import Path
-from tempfile import mkdtemp
 from shutil import rmtree
+from tempfile import mkdtemp
 
 import numpy as np
 from pynwb import NWBHDF5IO, H5DataIO
 from pynwb.image import ImageSeries
 
-from nwbinspector import InspectorMessage, Importance
+from nwbinspector import Importance, InspectorMessage
 from nwbinspector.checks import (
-    check_image_series_external_file_valid,
-    check_image_series_external_file_relative,
     check_image_series_data_size,
+    check_image_series_external_file_relative,
+    check_image_series_external_file_valid,
     check_timestamps_match_first_dimension,
 )
-from nwbinspector.testing import make_minimal_nwbfile, load_testing_config
+from nwbinspector.testing import load_testing_config, make_minimal_nwbfile
 
 try:
     testing_config = load_testing_config()

--- a/tests/unit_tests/test_images.py
+++ b/tests/unit_tests/test_images.py
@@ -1,22 +1,21 @@
-import pytest
-
 import numpy as np
+import pytest
+from packaging.version import Version
 from pynwb import TimeSeries
 from pynwb.image import GrayscaleImage, IndexSeries
-from packaging.version import Version
 
-from nwbinspector import InspectorMessage, Importance
+from nwbinspector import Importance, InspectorMessage
 from nwbinspector.checks import (
-    check_order_of_images_unique,
-    check_order_of_images_len,
     check_index_series_points_to_image,
+    check_order_of_images_len,
+    check_order_of_images_unique,
 )
 from nwbinspector.utils import get_package_version
 
 HAVE_IMAGES = get_package_version(name="pynwb") >= Version("2.1.0")
 skip_reason = "You must have PyNWB>=v2.1.0 to run these tests!"
 if HAVE_IMAGES:
-    from pynwb.base import Images, ImageReferences
+    from pynwb.base import ImageReferences, Images
 
 
 @pytest.mark.skipif(not HAVE_IMAGES, reason=skip_reason)

--- a/tests/unit_tests/test_nwb_containers.py
+++ b/tests/unit_tests/test_nwb_containers.py
@@ -1,21 +1,21 @@
-from pathlib import Path
-from tempfile import mkdtemp
-from shutil import rmtree
-from unittest import TestCase
 from datetime import datetime
+from pathlib import Path
+from shutil import rmtree
+from tempfile import mkdtemp
+from unittest import TestCase
 
 import h5py
 import numpy as np
 from pynwb import NWBContainer, NWBFile
 from pynwb.image import ImageSeries
 
-from nwbinspector import InspectorMessage, Importance
-from nwbinspector.checks import (
-    check_small_dataset_compression,
-    check_large_dataset_compression,
-    check_empty_string_for_optional_attribute,
-)
+from nwbinspector import Importance, InspectorMessage
 from nwbinspector._registration import Severity
+from nwbinspector.checks import (
+    check_empty_string_for_optional_attribute,
+    check_large_dataset_compression,
+    check_small_dataset_compression,
+)
 
 
 class TestNWBContainers(TestCase):

--- a/tests/unit_tests/test_nwbfile_metadata.py
+++ b/tests/unit_tests/test_nwbfile_metadata.py
@@ -1,31 +1,30 @@
-from uuid import uuid4
 from datetime import datetime, timezone
+from uuid import uuid4
 
 from pynwb import NWBFile, ProcessingModule
 from pynwb.file import Subject
 
-from nwbinspector import InspectorMessage, Importance
+from nwbinspector import Importance, InspectorMessage
 from nwbinspector.checks import (
+    check_doi_publications,
+    check_experiment_description,
     check_experimenter_exists,
     check_experimenter_form,
-    check_experiment_description,
     check_institution,
     check_keywords,
-    check_doi_publications,
+    check_processing_module_name,
+    check_session_start_time_future_date,
+    check_session_start_time_old_date,
+    check_subject_age,
     check_subject_exists,
     check_subject_id_exists,
-    check_subject_sex,
-    check_subject_age,
     check_subject_proper_age_range,
+    check_subject_sex,
     check_subject_species_exists,
     check_subject_species_form,
-    check_processing_module_name,
-    check_session_start_time_old_date,
-    check_session_start_time_future_date,
 )
-from nwbinspector.testing import make_minimal_nwbfile
 from nwbinspector.checks._nwbfile_metadata import PROCESSING_MODULE_CONFIG
-
+from nwbinspector.testing import make_minimal_nwbfile
 
 minimal_nwbfile = make_minimal_nwbfile()
 

--- a/tests/unit_tests/test_ogen.py
+++ b/tests/unit_tests/test_ogen.py
@@ -1,9 +1,9 @@
-from unittest import TestCase
 from datetime import datetime
+from unittest import TestCase
 
-from pynwb.ogen import OptogeneticSeries
 from pynwb.device import Device
 from pynwb.file import NWBFile
+from pynwb.ogen import OptogeneticSeries
 
 from nwbinspector.checks import check_optogenetic_stimulus_site_has_optogenetic_series
 

--- a/tests/unit_tests/test_ophys.py
+++ b/tests/unit_tests/test_ophys.py
@@ -3,26 +3,26 @@ from unittest import TestCase
 from uuid import uuid4
 
 import numpy as np
+from hdmf.common.table import DynamicTable, DynamicTableRegion
 from pynwb import NWBFile
 from pynwb.device import Device
 from pynwb.ophys import (
-    OpticalChannel,
     ImageSegmentation,
-    RoiResponseSeries,
     ImagingPlane,
+    OpticalChannel,
     PlaneSegmentation,
+    RoiResponseSeries,
     TwoPhotonSeries,
 )
-from hdmf.common.table import DynamicTableRegion, DynamicTable
 
-from nwbinspector import InspectorMessage, Importance
+from nwbinspector import Importance, InspectorMessage
 from nwbinspector.checks import (
+    check_emission_lambda_in_nm,
+    check_excitation_lambda_in_nm,
+    check_image_series_data_size,  # Technically an ImageSeries check, but test is more convenient here
+    check_plane_segmentation_image_mask_shape_against_ref_images,
     check_roi_response_series_dims,
     check_roi_response_series_link_to_plane_segmentation,
-    check_excitation_lambda_in_nm,
-    check_emission_lambda_in_nm,
-    check_plane_segmentation_image_mask_shape_against_ref_images,
-    check_image_series_data_size,  # Technically an ImageSeries check, but test is more convenient here
 )
 
 

--- a/tests/unit_tests/test_tables.py
+++ b/tests/unit_tests/test_tables.py
@@ -1,24 +1,24 @@
-import platform
 import json
+import platform
 from unittest import TestCase
-from packaging import version
 
 import numpy as np
 from hdmf.common import DynamicTable, DynamicTableRegion
-from pynwb.file import TimeIntervals, Units, ElectrodeTable, ElectrodeGroup, Device
+from packaging import version
+from pynwb.file import Device, ElectrodeGroup, ElectrodeTable, TimeIntervals, Units
 
-from nwbinspector import InspectorMessage, Importance
+from nwbinspector import Importance, InspectorMessage
 from nwbinspector.checks import (
+    check_col_not_nan,
+    check_column_binary_capability,
+    check_dynamic_table_region_data_validity,
     check_empty_table,
+    check_ids_unique,
+    check_single_row,
+    check_table_time_columns_are_not_negative,
+    check_table_values_for_dict,
     check_time_interval_time_columns,
     check_time_intervals_stop_after_start,
-    check_dynamic_table_region_data_validity,
-    check_column_binary_capability,
-    check_single_row,
-    check_table_values_for_dict,
-    check_col_not_nan,
-    check_ids_unique,
-    check_table_time_columns_are_not_negative,
 )
 from nwbinspector.utils import get_package_version
 

--- a/tests/unit_tests/test_time_series.py
+++ b/tests/unit_tests/test_time_series.py
@@ -1,23 +1,22 @@
 import h5py
+import numpy as np
 import pynwb
 import pytest
-import numpy as np
 from packaging import version
 
-
-from nwbinspector import InspectorMessage, Importance
+from nwbinspector import Importance, InspectorMessage
 from nwbinspector.checks import (
-    check_regular_timestamps,
     check_data_orientation,
-    check_timestamps_match_first_dimension,
-    check_timestamps_ascending,
-    check_timestamps_without_nans,
     check_missing_unit,
+    check_rate_is_not_zero,
+    check_regular_timestamps,
     check_resolution,
     check_timestamp_of_the_first_sample_is_not_negative,
-    check_rate_is_not_zero,
+    check_timestamps_ascending,
+    check_timestamps_match_first_dimension,
+    check_timestamps_without_nans,
 )
-from nwbinspector.testing import make_minimal_nwbfile, check_streaming_tests_enabled
+from nwbinspector.testing import check_streaming_tests_enabled, make_minimal_nwbfile
 from nwbinspector.utils import get_package_version, robust_s3_read
 
 STREAMING_TESTS_ENABLED, DISABLED_STREAMING_TESTS_REASON = check_streaming_tests_enabled()


### PR DESCRIPTION
## Motivation

Enabling the remaining isort checks (there's only `I001` and `I002`, which we already activated)
