### PR TITLE
clean up imports a bit

### DIFF
--- a/src/nwbinspector/_configuration.py
+++ b/src/nwbinspector/_configuration.py
@@ -8,9 +8,7 @@ from typing import List, Optional
 import jsonschema
 import yaml
 
-from nwbinspector.utils._utils import (
-    PathType,
-)
+from nwbinspector.utils import PathType
 
 from . import available_checks
 from ._registration import Importance

--- a/src/nwbinspector/_formatting.py
+++ b/src/nwbinspector/_formatting.py
@@ -106,7 +106,8 @@ class MessageFormatter:
         self.message_counter = 0
         self.formatted_messages = []
 
-    def _count_messages_by_importance(self, messages: List[InspectorMessage]) -> Dict[str, int]:
+    @staticmethod
+    def _count_messages_by_importance(messages: List[InspectorMessage]) -> Dict[str, int]:
         message_count_by_importance = {importance_level.name: 0 for importance_level in Importance}
         for message in messages:
             message_count_by_importance[message.importance.name] += 1
@@ -114,7 +115,8 @@ class MessageFormatter:
             message_count_by_importance.pop(key)
         return message_count_by_importance
 
-    def _get_name(self, obj) -> str:
+    @staticmethod
+    def _get_name(obj) -> str:
         if isinstance(obj, Enum):
             return obj.name
         if isinstance(obj, str):

--- a/src/nwbinspector/_inspection.py
+++ b/src/nwbinspector/_inspection.py
@@ -6,7 +6,7 @@ import traceback
 from collections import defaultdict
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from pathlib import Path
-from typing import Iterable, List, Optional, Union
+from typing import Iterable, List, Optional, Union, Type
 from warnings import filterwarnings, warn
 
 import pynwb
@@ -37,7 +37,7 @@ def inspect_all(
     n_jobs: int = 1,
     skip_validate: bool = False,
     progress_bar: bool = True,
-    progress_bar_class: tqdm = tqdm,
+    progress_bar_class: Type[tqdm] = tqdm,
     progress_bar_options: Optional[dict] = None,
     stream: bool = False,
     version_id: Optional[str] = None,
@@ -421,7 +421,7 @@ def inspect_nwbfile_object(
 def run_checks(
     nwbfile: pynwb.NWBFile,
     checks: list,
-    progress_bar_class: Optional[tqdm] = None,
+    progress_bar_class: Optional[Type[tqdm]] = None,
     progress_bar_options: Optional[dict] = None,
 ) -> Iterable[InspectorMessage]:
     """
@@ -435,7 +435,7 @@ def run_checks(
         The list of check functions that will be run on the in-memory pynwb.NWBFile object.
     progress_bar_class : type of tqdm.tqdm, optional
         The specific child class of tqdm.tqdm to use to make progress bars.
-        Defaults to not displaying progress per set of checks over an invidiual file.
+        Defaults to not displaying progress per set of checks over an individual file.
     progress_bar_options : dict, optional
         Dictionary of keyword arguments to pass directly to the `progress_bar_class`.
 

--- a/src/nwbinspector/_inspection.py
+++ b/src/nwbinspector/_inspection.py
@@ -6,7 +6,7 @@ import traceback
 from collections import defaultdict
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from pathlib import Path
-from typing import Iterable, List, Optional, Union, Type
+from typing import Iterable, List, Optional, Type, Union
 from warnings import filterwarnings, warn
 
 import pynwb

--- a/tests/streaming_tests.py
+++ b/tests/streaming_tests.py
@@ -64,7 +64,8 @@ class TestStreamingCLI(TestCase):
     def tearDownClass(cls):
         rmtree(cls.tempdir)
 
-    def assertFileExists(self, path: FilePathType):
+    @staticmethod
+    def assertFileExists(path: FilePathType):
         path = Path(path)
         assert path.exists()
 

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -88,7 +88,8 @@ def add_simple_table(nwbfile: NWBFile):
 class TestInspector(TestCase):
     """A common helper class for testing the NWBInspector."""
 
-    def assertFileExists(self, path: FilePathType):
+    @staticmethod
+    def assertFileExists(path: FilePathType):
         path = Path(path)
         assert path.exists()
 

--- a/tests/unit_tests/test_nwb_containers.py
+++ b/tests/unit_tests/test_nwb_containers.py
@@ -9,8 +9,7 @@ import numpy as np
 from pynwb import NWBContainer, NWBFile
 from pynwb.image import ImageSeries
 
-from nwbinspector import Importance, InspectorMessage
-from nwbinspector._registration import Severity
+from nwbinspector import Importance, InspectorMessage, Severity
 from nwbinspector.checks import (
     check_empty_string_for_optional_attribute,
     check_large_dataset_compression,


### PR DESCRIPTION
* stay away from private modules
* use Type when indicating that an arg should be a class

## Motivation

What was the reasoning behind this change? Please explain the changes briefly.
