### PR TITLE
Adjust github actions to use setup-miniconda

### DIFF
--- a/.github/workflows/assess-file-changes.yml
+++ b/.github/workflows/assess-file-changes.yml
@@ -17,7 +17,7 @@ jobs:
 
     name: Test changed-files
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -11,9 +11,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: "3.9"
       - name: Install dependencies

--- a/.github/workflows/dev-gallery.yml
+++ b/.github/workflows/dev-gallery.yml
@@ -11,12 +11,12 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: s-weigand/setup-conda@v1
+      - uses: conda-incubator/setup-miniconda@v3
         with:
-          update-conda: true
-          python-version: 3.9
-          conda-channels: conda-forge
-      - uses: actions/checkout@v3
+          auto-update-conda: true
+          python-version: ${{ matrix.python-version }}
+          channels: conda-forge
+      - uses: actions/checkout@v4
       - run: git fetch --prune --unshallow --tags
 
       - name: Install pytest

--- a/.github/workflows/dev-gallery.yml
+++ b/.github/workflows/dev-gallery.yml
@@ -11,18 +11,19 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: conda-incubator/setup-miniconda@v3
-        with:
-          auto-update-conda: true
-          python-version: ${{ matrix.python-version }}
-          channels: conda-forge
       - uses: actions/checkout@v4
       - run: git fetch --prune --unshallow --tags
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
 
       - name: Install pytest
         run: |
           pip install pytest
           pip install pytest-cov
+          
       - name: Install package
         run: |
           pip install -e ".[dandi]"

--- a/.github/workflows/dev-gallery.yml
+++ b/.github/workflows/dev-gallery.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           pip install pytest
           pip install pytest-cov
-          
+
       - name: Install package
         run: |
           pip install -e ".[dandi]"

--- a/.github/workflows/doc-link-checks.yml
+++ b/.github/workflows/doc-link-checks.yml
@@ -9,10 +9,10 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: git fetch --prune --unshallow --tags
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
 

--- a/.github/workflows/read-nwbfile-tests.yml
+++ b/.github/workflows/read-nwbfile-tests.yml
@@ -9,6 +9,9 @@ jobs:
   build-and-test:
     name: Streaming tests using ${{ matrix.os }} with ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
+    defaults:
+     run:
+       shell: bash -l {0}  # necessary for conda
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/read-nwbfile-tests.yml
+++ b/.github/workflows/read-nwbfile-tests.yml
@@ -15,11 +15,12 @@ jobs:
         os: ["ubuntu-latest", "windows-latest"]  # TODO: update mac and streaming methods
         python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
-      - uses: s-weigand/setup-conda@v1
+      - uses: conda-incubator/setup-miniconda@v3
         with:
-          update-conda: true
+          auto-update-conda: true
           python-version: ${{ matrix.python-version }}
-      - uses: actions/checkout@v3
+          channels: conda-forge
+      - uses: actions/checkout@v4
       - run: git fetch --prune --unshallow --tags
 
       - name: Install pytest

--- a/.github/workflows/streaming-tests.yml
+++ b/.github/workflows/streaming-tests.yml
@@ -15,11 +15,12 @@ jobs:
         os: ["ubuntu-latest", "windows-latest"]  # TODO: update mac and streaming methods
         python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
-      - uses: s-weigand/setup-conda@v1
+      - uses: conda-incubator/setup-miniconda@v3
         with:
-          update-conda: true
+          auto-update-conda: true
           python-version: ${{ matrix.python-version }}
-      - uses: actions/checkout@v3
+          channels: conda-forge
+      - uses: actions/checkout@v4
       - run: git fetch --prune --unshallow --tags
 
       - name: Install pytest

--- a/.github/workflows/streaming-tests.yml
+++ b/.github/workflows/streaming-tests.yml
@@ -15,13 +15,13 @@ jobs:
         os: ["ubuntu-latest", "windows-latest"]  # TODO: update mac and streaming methods
         python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
-      - uses: conda-incubator/setup-miniconda@v3
-        with:
-          auto-update-conda: true
-          python-version: ${{ matrix.python-version }}
-          channels: conda-forge
       - uses: actions/checkout@v4
       - run: git fetch --prune --unshallow --tags
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
 
       - name: Install pytest
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -23,7 +23,7 @@ jobs:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
           channels: conda-forge
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: git fetch --prune --unshallow --tags
 
       - name: Install pytest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -18,13 +18,13 @@ jobs:
         os: ["ubuntu-latest", "macos-13", "windows-latest"]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
-      - uses: conda-incubator/setup-miniconda@v3
-        with:
-          auto-update-conda: true
-          python-version: ${{ matrix.python-version }}
-          channels: conda-forge
       - uses: actions/checkout@v4
       - run: git fetch --prune --unshallow --tags
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
 
       - name: Install pytest
         run: |


### PR DESCRIPTION
Tests that use the s-weigand/setup-conda action are failing on Windows. Replace with conda-incubator/setup-miniconda. Also update some versions of GH Actions used.