### PR TITLE
Use cached namespaces during validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Fixes
 * Fixed incorrect error message for OptogeneticStimulusSite. [#524](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/524)
+* Fixed detection of Zarr directories for inspection. [#531](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/531)
 
 
 # v0.5.2

--- a/src/nwbinspector/_nwb_inspection.py
+++ b/src/nwbinspector/_nwb_inspection.py
@@ -126,7 +126,9 @@ def inspect_all(
     if progress_bar_options is None:
         progress_bar_options = dict(position=0, leave=False)
 
-    if in_path.is_dir():
+    if in_path.is_dir() and (in_path.match("*.nwb*")) and (in_path / ".zgroup").exists():
+        nwbfiles = [in_path]  # if it is a zarr directory
+    elif in_path.is_dir():
         nwbfiles = list(in_path.rglob("*.nwb*"))
 
         # Remove any macOS sidecar files

--- a/src/nwbinspector/_nwb_inspection.py
+++ b/src/nwbinspector/_nwb_inspection.py
@@ -14,7 +14,7 @@ from tqdm import tqdm
 
 from ._configuration import configure_checks
 from ._registration import Importance, InspectorMessage, available_checks
-from .tools._read_nwbfile import read_nwbfile, read_nwbfile_and_io
+from .tools._read_nwbfile import read_nwbfile
 from .utils import (
     OptionalListOfStrings,
     PathType,
@@ -271,10 +271,10 @@ def inspect_nwbfile(
     filterwarnings(action="ignore", message="Ignoring cached namespace .*")
 
     try:
-        in_memory_nwbfile, io = read_nwbfile_and_io(nwbfile_path=nwbfile_path)
+        in_memory_nwbfile = read_nwbfile(nwbfile_path=nwbfile_path)
 
         if not skip_validate:
-            validation_errors = pynwb.validate(io=io)
+            validation_errors, _ = pynwb.validate(paths=[nwbfile_path])
             for validation_error in validation_errors:
                 yield InspectorMessage(
                     message=validation_error.reason,

--- a/src/nwbinspector/_nwb_inspection.py
+++ b/src/nwbinspector/_nwb_inspection.py
@@ -9,6 +9,7 @@ from typing import Iterable, Optional, Type, Union
 from warnings import filterwarnings, warn
 
 import pynwb
+from hdmf_zarr import ZarrIO
 from natsort import natsorted
 from tqdm import tqdm
 
@@ -126,7 +127,7 @@ def inspect_all(
     if progress_bar_options is None:
         progress_bar_options = dict(position=0, leave=False)
 
-    if in_path.is_dir() and (in_path.match("*.nwb*")) and (in_path / ".zgroup").exists():
+    if in_path.is_dir() and (in_path.match("*.nwb*")) and ZarrIO.can_read(in_path):
         nwbfiles = [in_path]  # if it is a zarr directory
     elif in_path.is_dir():
         nwbfiles = list(in_path.rglob("*.nwb*"))


### PR DESCRIPTION
## Motivation

Fix #528. 

Recent Zarr-related updates switched the inspector from using `pynwb.validate(paths=paths)` to `pynwb.validate(io=io)`,  resulting in the inspector not using cached namespaces during validation. We will temporarily revert this change, since pynwb validation of Zarr NWB files is not yet fully supported anyway due to pending issues that need to be addressed in hdmf/pynwb.

Since this is more of a bug on the pynwb side that using the `io` argument ignores the `use_cached_namespaces=True` setting in the validator (and will be updated in the next major pynwb release), I'm not sure if there are really any specific tests to add here.

While addressing this issue, I added a couple of other small updates to the Zarr support here:
1. Passing the path of an NWB file Zarr folder to the CLI (instead of the parent folder) would result in 0 files being inspected, due to some conditionals in `inspect_all` that detected whether the path provided was a directory of NWB files or an NWB file.
2. The `test_inspect_all_parallel` tests had been indented and were not running