### PR TITLE
Remove numpy and h5py restrictions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Upcoming
 
+### Improvements
+* Added support for Numpy 2 and h5py 3.12. [#536](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/536)
+
+
 # v0.6.0
 
 ### Deprecation
@@ -17,7 +21,6 @@
 * Cleaned old references to non-recent PyNWB and HDMF versions. Current policy is that latest NWB Inspector releases should only support compatibility with latest PyNWB and HDMF. [#510](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/510)
 * Swapped setup approach to the modern `pyproject.toml` standard. [#507](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/507)
 * Added complete annotation typing and integrated Mypy into pre-commit. [#520](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/520)
-* Added support for Numpy 2 and h5py 3.12. [#536](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/536)
 
 ### Fixes
 * Fixed incorrect error message for OptogeneticStimulusSite. [#524](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/524)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Upcoming
 
 ### Improvements
-* Added support for Numpy 2 and h5py 3.12. [#536](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/536)
+* Added support for Numpy 2 and h5py 3.12, and pinned PyNWB to <3.0 temporarily. [#536](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/536)
 
 
 # v0.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Cleaned old references to non-recent PyNWB and HDMF versions. Current policy is that latest NWB Inspector releases should only support compatibility with latest PyNWB and HDMF. [#510](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/510)
 * Swapped setup approach to the modern `pyproject.toml` standard. [#507](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/507)
 * Added complete annotation typing and integrated Mypy into pre-commit. [#520](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/520)
+* Added support for Numpy 2 and h5py 3.12. [#536](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/536)
 
 ### Fixes
 * Fixed incorrect error message for OptogeneticStimulusSite. [#524](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/524)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "pynwb>=2.8",   # NWB Inspector should always be used with most recent minor versions of PyNWB
+    "pynwb>=2.8,<3",   # NWB Inspector should always be used with most recent minor versions of PyNWB
     "hdmf-zarr",
     "fsspec",
     "s3fs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,6 @@ dependencies = [
     "click",
     "tqdm",
     "isodate",
-    "numpy>=1.22.0,<2.0.0", # TODO: add compatibility for 2.0 - HDMF Zarr and others also still have some troubles
-    "h5py<3.12.0", # TODO: remove pin when https://github.com/h5py/h5py/issues/2505 is fixed and released
 ]
 
 [project.optional-dependencies]

--- a/src/nwbinspector/checks/_tables.py
+++ b/src/nwbinspector/checks/_tables.py
@@ -155,7 +155,7 @@ def check_column_binary_capability(
                 ["hit", "miss"],
             ]
             if any([set(parsed_unique_values) == set(pair) for pair in pairs_to_check]):  # type: ignore
-                saved_bytes = (unique_values.dtype.itemsize - 1) * np.product(
+                saved_bytes = (unique_values.dtype.itemsize - 1) * np.prod(
                     get_data_shape(data=column.data, strict_no_data_load=True)
                 )
                 if unique_values.dtype == "float":

--- a/tests/unit_tests/test_tables.py
+++ b/tests/unit_tests/test_tables.py
@@ -3,8 +3,8 @@ import platform
 from unittest import TestCase
 
 import numpy as np
-from numpy.lib import NumpyVersion
 from hdmf.common import DynamicTable, DynamicTableRegion
+from numpy.lib import NumpyVersion
 from pynwb.file import Device, ElectrodeGroup, ElectrodeTable, TimeIntervals, Units
 
 from nwbinspector import Importance, InspectorMessage
@@ -189,7 +189,7 @@ class TestCheckBinaryColumns(TestCase):
         for x in [1, 0, 1, 0, 1]:
             self.table.add_row(test_col=x)
         # the default numpy int in Windows with NumPy < 2 is int32. otherwise it is int64.
-        if platform.system() == "Windows" and NumpyVersion(np.__version__) < '2.0.0':
+        if platform.system() == "Windows" and NumpyVersion(np.__version__) < "2.0.0":
             platform_saved_bytes = "15.00B"
         else:
             platform_saved_bytes = "35.00B"

--- a/tests/unit_tests/test_tables.py
+++ b/tests/unit_tests/test_tables.py
@@ -3,6 +3,7 @@ import platform
 from unittest import TestCase
 
 import numpy as np
+from numpy.lib import NumpyVersion
 from hdmf.common import DynamicTable, DynamicTableRegion
 from pynwb.file import Device, ElectrodeGroup, ElectrodeTable, TimeIntervals, Units
 
@@ -187,7 +188,8 @@ class TestCheckBinaryColumns(TestCase):
         self.table.add_column(name="test_col", description="")
         for x in [1, 0, 1, 0, 1]:
             self.table.add_row(test_col=x)
-        if platform.system() == "Windows":
+        # the default numpy int in Windows with NumPy < 2 is int32. otherwise it is int64.
+        if platform.system() == "Windows" and NumpyVersion(np.__version__) < '2.0.0':
             platform_saved_bytes = "15.00B"
         else:
             platform_saved_bytes = "35.00B"


### PR DESCRIPTION
## Motivation

numpy was pinned to <2.0 due to incompatibilities in pynwb and hdmf-zarr and maybe other tools. Those should be resolved now.

h5py was pinned to <3.12.0 due to an issue with windows that has been fixed and released.