### PR TITLE
update publishing workflow for pyproject.toml

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -19,9 +19,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install wheel
+          python -m pip install --upgrade build
       - name: Build package
-        run: python setup.py sdist bdist_wheel
+        run: python -m build
       - name: pypi-publish
         uses: pypa/gh-action-pypi-publish@v1.4.2
         with:


### PR DESCRIPTION
## Motivation

Since we replaced the `setup.py` file with `pyproject.toml`, the release publishing workflow no longer works.
