### PR TITLE
Update tests to use in_construct_mode=True for invalid timeseries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Improvements
 * Added a section for describing the issues with negative timestamps in `TimeSeries` [#545](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/545)
+* Use alternate way of generating `TimeSeries` objects to avoid new pynwb error when the shape of the first dimension of
+  data does not match the length of timestamps [#556](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/556)
 
 # v0.6.1
 

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -95,7 +95,9 @@ def add_flipped_data_orientation_to_processing(nwbfile: NWBFile):
 def add_non_matching_timestamps_dimension(nwbfile: NWBFile):
     timestamps = [1.0, 2.1, 3.0]
     timestamps_length = len(timestamps)
-    time_series = TimeSeries(
+    # Use __new__ and in_construct_mode=True to bypass the check in pynwb for data.shape[0] == len(timestamps)
+    time_series = TimeSeries.__new__(TimeSeries, in_construct_mode=True)
+    time_series.__init__(
         name="test_time_series_3",
         data=np.zeros(shape=(timestamps_length + 1, timestamps_length)),
         timestamps=timestamps,

--- a/tests/unit_tests/test_time_series.py
+++ b/tests/unit_tests/test_time_series.py
@@ -124,9 +124,12 @@ def test_check_timestamps_match_first_dimension_special_skip(tmp_path):
     image_height = 15
     num_channels = 3
     dtype = "uint8"
-    image_series = pynwb.image.ImageSeries(
+
+    # Use __new__ and in_construct_mode=True to bypass the check in pynwb for data.shape[0] == len(timestamps)
+    image_series = pynwb.image.ImageSeries.__new__(pynwb.image.ImageSeries, in_construct_mode=True)
+    image_series.__init__(
         name="ImageSeries",
-        unit="n.a.",
+        unit="N/A",
         data=np.empty(shape=(num_images, image_width, image_height, num_channels), dtype=dtype),
         timestamps=[],
     )
@@ -134,7 +137,7 @@ def test_check_timestamps_match_first_dimension_special_skip(tmp_path):
     nwbfile.add_acquisition(
         pynwb.image.IndexSeries(
             name="IndexSeries",
-            unit="n.a.",
+            unit="N/A",
             data=[0, 1],
             indexed_timeseries=image_series,
             timestamps=[0.5, 0.6],
@@ -152,14 +155,15 @@ def test_check_timestamps_match_first_dimension_special_skip(tmp_path):
 
 
 def test_check_timestamps_match_first_dimension_bad():
-    assert check_timestamps_match_first_dimension(
-        time_series=pynwb.TimeSeries(
-            name="test_time_series",
-            unit="test_units",
-            data=np.empty(shape=4),
-            timestamps=[1.0, 2.0, 3.0],
-        )
-    ) == InspectorMessage(
+    # Use __new__ and in_construct_mode=True to bypass the check in pynwb for data.shape[0] == len(timestamps)
+    time_series = pynwb.TimeSeries.__new__(pynwb.TimeSeries, in_construct_mode=True)
+    time_series.__init__(
+        name="test_time_series",
+        unit="test_units",
+        data=np.empty(shape=4),
+        timestamps=[1.0, 2.0, 3.0],
+    )
+    assert check_timestamps_match_first_dimension(time_series=time_series) == InspectorMessage(
         message="The length of the first dimension of data (4) does not match the length of timestamps (3).",
         importance=Importance.CRITICAL,
         check_function_name="check_timestamps_match_first_dimension",
@@ -170,9 +174,15 @@ def test_check_timestamps_match_first_dimension_bad():
 
 
 def test_check_timestamps_empty_data():
-    assert check_timestamps_match_first_dimension(
-        time_series=pynwb.TimeSeries(name="test_time_series", unit="test_units", data=[], timestamps=[1.0, 2.0, 3.0])
-    ) == InspectorMessage(
+    # Use __new__ and in_construct_mode=True to bypass the check in pynwb for data.shape[0] == len(timestamps)
+    time_series = pynwb.TimeSeries.__new__(pynwb.TimeSeries, in_construct_mode=True)
+    time_series.__init__(
+        name="test_time_series",
+        unit="test_units",
+        data=[],
+        timestamps=[1.0, 2.0, 3.0],
+    )
+    assert check_timestamps_match_first_dimension(time_series=time_series) == InspectorMessage(
         message="The length of the first dimension of data (0) does not match the length of timestamps (3).",
         importance=Importance.CRITICAL,
         check_function_name="check_timestamps_match_first_dimension",
@@ -183,9 +193,15 @@ def test_check_timestamps_empty_data():
 
 
 def test_check_timestamps_empty_timestamps():
-    assert check_timestamps_match_first_dimension(
-        time_series=pynwb.TimeSeries(name="test_time_series", unit="test_units", data=np.empty(shape=4), timestamps=[])
-    ) == InspectorMessage(
+    # Use __new__ and in_construct_mode=True to bypass the check in pynwb for data.shape[0] == len(timestamps)
+    time_series = pynwb.TimeSeries.__new__(pynwb.TimeSeries, in_construct_mode=True)
+    time_series.__init__(
+        name="test_time_series",
+        unit="test_units",
+        data=np.empty(shape=4),
+        timestamps=[],
+    )
+    assert check_timestamps_match_first_dimension(time_series=time_series) == InspectorMessage(
         message="The length of the first dimension of data (4) does not match the length of timestamps (0).",
         importance=Importance.CRITICAL,
         check_function_name="check_timestamps_match_first_dimension",


### PR DESCRIPTION
## Motivation

Fix #556 in preparation of https://github.com/NeurodataWithoutBorders/pynwb/pull/1538