### PR TITLE
Allow nwbinspector CLI to accept URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Fixes
 * Fix wrongly triggered compression check [#552](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/552)
+* Fixed URL inspection using the CLI [#559](https://github.com/NeurodataWithoutBorders/nwbinspector/issues/559)
 
 ## Improvements
 * Added a section for describing the issues with negative timestamps in `TimeSeries` [#545](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/545)

--- a/src/nwbinspector/_nwbinspector_cli.py
+++ b/src/nwbinspector/_nwbinspector_cli.py
@@ -160,7 +160,7 @@ def _nwbinspector_cli(
             show_progress_bar=show_progress_bar,
         )
     # Scan a single NWB file in a Dandiset
-    elif stream and ":" in path:
+    elif stream and ":" in path and not path_is_url:
         dandiset_id, dandi_file_path = path.split(":")
         dandiset_version = version_id
 

--- a/tests/streaming_cli_tests.py
+++ b/tests/streaming_cli_tests.py
@@ -120,3 +120,17 @@ def test_dandiset_streaming_cli_with_version_saved_report(tmpdir: py.path.local)
     expected_report_length = 38
     report_end = report_start + expected_report_length
     assert test_report[report_start:report_end] == expected_report[14:]
+
+
+@pytest.mark.skipif(not STREAMING_TESTS_ENABLED, reason=DISABLED_STREAMING_TESTS_REASON or "")
+def test_inspect_url_cli(tmp_path):
+    """Test that the CLI correctly handles inspecting a URL."""
+    url = "https://dandiarchive.s3.amazonaws.com/blobs/11e/c89/11ec8933-1456-4942-922b-94e5878bb991"
+    console_output_file = tmp_path / "url_console_output.txt"
+
+    os.system(f"nwbinspector {url} " "--skip-validate " f"> {console_output_file}")
+
+    # Read and check the contents of the console output file
+    with open(console_output_file, "r") as file:
+        output = file.read()
+        assert "Subject species is missing." in output

--- a/tests/streaming_tests.py
+++ b/tests/streaming_tests.py
@@ -1,5 +1,7 @@
 """Test the API functions related to streaming."""
 
+import os
+
 import pytest
 
 from nwbinspector import (
@@ -104,3 +106,17 @@ def test_inspect_url():
     )
 
     assert test_message == expected_message
+
+
+@pytest.mark.skipif(not STREAMING_TESTS_ENABLED, reason=DISABLED_STREAMING_TESTS_REASON or "")
+def test_inspect_url_cli(tmp_path):
+    """Test that the CLI correctly handles inspecting a URL."""
+    url = "https://dandiarchive.s3.amazonaws.com/blobs/11e/c89/11ec8933-1456-4942-922b-94e5878bb991"
+    console_output_file = tmp_path / "url_console_output.txt"
+
+    os.system(f"nwbinspector {url} " "--skip-validate " f"> {console_output_file}")
+
+    # Read and check the contents of the console output file
+    with open(console_output_file, "r") as file:
+        output = file.read()
+        assert "Subject species is missing." in output

--- a/tests/streaming_tests.py
+++ b/tests/streaming_tests.py
@@ -1,7 +1,5 @@
 """Test the API functions related to streaming."""
 
-import os
-
 import pytest
 
 from nwbinspector import (
@@ -106,17 +104,3 @@ def test_inspect_url():
     )
 
     assert test_message == expected_message
-
-
-@pytest.mark.skipif(not STREAMING_TESTS_ENABLED, reason=DISABLED_STREAMING_TESTS_REASON or "")
-def test_inspect_url_cli(tmp_path):
-    """Test that the CLI correctly handles inspecting a URL."""
-    url = "https://dandiarchive.s3.amazonaws.com/blobs/11e/c89/11ec8933-1456-4942-922b-94e5878bb991"
-    console_output_file = tmp_path / "url_console_output.txt"
-
-    os.system(f"nwbinspector {url} " "--skip-validate " f"> {console_output_file}")
-
-    # Read and check the contents of the console output file
-    with open(console_output_file, "r") as file:
-        output = file.read()
-        assert "Subject species is missing." in output


### PR DESCRIPTION
## Motivation

Fix https://github.com/NeurodataWithoutBorders/nwbinspector/issues/558.

Add a condition to distinguish dandiset file paths and URLs, and add a test for using a URL with the CLI