### PR TITLE
Update v0.6.2 release date, copyright year, authors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Upcoming
+# v0.6.2
 
 ### Deprecation
 * Remove s3fs dependency, which was causing dependency management issues [#549](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/549)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,8 +11,8 @@ from conf_extlinks import extlinks, intersphinx_mapping
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 project = "NWBInspector"
-copyright = "2022-2024, CatalystNeuro"
-author = "Cody Baker, Ryan Ly, and Ben Dichter"
+copyright = "2022-2025, CatalystNeuro"
+author = "Cody Baker, Steph Prince, Szonja Weigl, Heberto Mayorquin, Paul Adkisson, Luiz Tauffer, Ryan Ly, and Ben Dichter"
 
 extensions = [
     "sphinx.ext.doctest",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 project = "NWBInspector"
 copyright = "2022-2025, CatalystNeuro"
-author = "Cody Baker, Steph Prince, Szonja Weigl, Heberto Mayorquin, Paul Adkisson, Luiz Tauffer, Ryan Ly, and Ben Dichter"
+author = (
+    "Cody Baker, Steph Prince, Szonja Weigl, Heberto Mayorquin, Paul Adkisson, Luiz Tauffer, Ryan Ly, and Ben Dichter"
+)
 
 extensions = [
     "sphinx.ext.doctest",

--- a/license.txt
+++ b/license.txt
@@ -1,4 +1,4 @@
-“nwbinspector” Copyright (c) 2022-2024, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Dept. of Energy).  All rights reserved.
+“nwbinspector” Copyright (c) 2022-2025, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Dept. of Energy).  All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nwbinspector"
-version = "0.6.1"
+version = "0.6.2"
 description = "Tool to inspect NWB files for best practices compliance."
 readme = "README.md"
 authors = [
@@ -14,6 +14,7 @@ authors = [
     {name = "Heberto Mayorquin"},
     {name = "Paul Adkisson"},
     {name = "Luiz Tauffer"},
+    {name = "Ryan Ly"},
     {name = "Ben Dichter",  email = "ben.dichter@catalystneuro.com"}
 ]
 urls = { "Homepage" = "https://github.com/NeurodataWithoutBorders/nwbinspector" }


### PR DESCRIPTION
Preparing for v0.6.2 release. 
- updated release date in changelog
- updated version in `pyproject.toml`
- bumped latest copyright year
- made authors list consistent