### PR TITLE
add format input to ImageSeries

### DIFF
--- a/tests/unit_tests/test_image_series.py
+++ b/tests/unit_tests/test_image_series.py
@@ -56,6 +56,7 @@ class TestExternalFileValid(unittest.TestCase):
             name="TestImageSeries",
             rate=1.0,
             external_file=[bytes("/".join([".", good_external_path.name]), "utf-8")],
+            format="external",
         )
         assert check_image_series_external_file_relative(image_series=image_series) is None
 


### PR DESCRIPTION
## Motivation

The daily workflows are failing because pynwb will throw an error if an ImageSeries is initialized with an `external_file` but the format argument not specified.