### PR TITLE
Update assess file changes GH action

### DIFF
--- a/.github/workflows/assess-file-changes.yml
+++ b/.github/workflows/assess-file-changes.yml
@@ -5,15 +5,19 @@ on:
     # Map the workflow outputs to job outputs
     outputs:
       SOURCE_CHANGED:
-        description: "Whether or not the files under /src/ were changed."
+        description: "Whether the files under /src/ were changed."
         value: ${{ jobs.build.outputs.SOURCE_CHANGED }}
+      CHANGELOG_UPDATED:
+        description: "Whether or the CHANGELOG.md file was updated."
+        value: ${{ jobs.build.outputs.CHANGELOG_UPDATED }}
 
 jobs:
   build:
     runs-on: ubuntu-latest
     # Map the job outputs to step outputs
     outputs:
-      SOURCE_CHANGED: ${{ steps.flagged-changes.outputs.SOURCE_CHANGED }}
+      SOURCE_CHANGED: ${{ steps.assess-changes.outputs.SOURCE_CHANGED }}
+      CHANGELOG_UPDATED: ${{ steps.assess-changes.outputs.CHANGELOG_UPDATED }}
 
     name: Test changed-files
     steps:
@@ -23,19 +27,26 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v41.0.0
-
+        uses: tj-actions/changed-files@v46.0.1
       - name: Assess Source Code Changes
-        id: flagged-changes
+        id: assess-changes
         run: |
-          echo "::set-output name=SOURCE_CHANGED::false"
+          echo "SOURCE_CHANGED=false" >> $GITHUB_OUTPUT
+          echo "CHANGELOG_UPDATED=false" >> $GITHUB_OUTPUT
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
             echo $file
-            if [[ $file == "src/nwbinspector/"* || $file == "requirements.txt" || $file == "setup.py" || $file == "tests/"* ]]
+            if [[ $file == "src/"* || $file == "tests/"* || $file == "pyproject.toml"   || $file == "setup.py" || $file == ".github/"* ]]
             then
               echo "Source changed"
-              echo "::set-output name=SOURCE_CHANGED::true"
+              echo "SOURCE_CHANGED=true" >> $GITHUB_OUTPUT
             else
               echo "Source not changed"
+            fi
+            if [[ $file == "CHANGELOG.md" ]]
+            then
+              echo "Changelog updated"
+              echo "CHANGELOG_UPDATED=true" >> $GITHUB_OUTPUT
+            else
+              echo "Changelog not updated"
             fi
           done

--- a/.github/workflows/deploy-tests.yml
+++ b/.github/workflows/deploy-tests.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   assess-file-changes:
-    uses: catalystneuro/neuroconv/.github/workflows/assess-file-changes.yml@main
+    uses: ./.github/workflows/assess-file-changes.yml
 
   detect-changelog-updates:
     needs: assess-file-changes


### PR DESCRIPTION
## Motivation

The [tj-actions/changed-files](https://github.com/tj-actions/changed-files) GitHub Action used by the `assess-file-changes.yml` workflow was compromised last week and since then has been fixed. This repo should not have been affected since there were no secrets in that specific workflow file, and @rly and I reviewed the logs to see if we used the compromised version or if any secrets were leaked. The developers recommend updating to the latest version (We could also pin the dependency to specific commit SHAs).

While looking through these files, it brought up that we are pointing to the neuroconv version, so this PR also updates `deploy-tests` to use our local version that has been updated to match the latest neuroconv version.
