### PR TITLE
remove hdmf pin from workflows

### DIFF
--- a/.github/workflows/dandi-dev-live-services.yml
+++ b/.github/workflows/dandi-dev-live-services.yml
@@ -28,5 +28,4 @@ jobs:
           git clone https://github.com/dandi/dandi-cli
           cd dandi-cli
           pip install -e .[test]
-          pip install hdmf==3.14.3  # temporary: https://github.com/dandi/dandi-cli/issues/1494
           pytest -vv

--- a/.github/workflows/dandi-dev.yml
+++ b/.github/workflows/dandi-dev.yml
@@ -31,5 +31,4 @@ jobs:
           git clone https://github.com/dandi/dandi-cli
           cd dandi-cli
           pip install -e .[test]
-          pip install hdmf==3.14.3  # temporary: https://github.com/dandi/dandi-cli/issues/1494
           pytest -rsx

--- a/.github/workflows/dandi-release.yml
+++ b/.github/workflows/dandi-release.yml
@@ -45,7 +45,6 @@ jobs:
     - name: Install this branch of NWB Inspector
       run: |
         pip install -e .
-        pip install hdmf==3.14.3  # temporary: https://github.com/dandi/dandi-cli/issues/1494
 
     - name: Run all NWB Inspector tests
       run: pytest -rsx


### PR DESCRIPTION
## Motivation

There was previously a regression in hdmf 3.14.4 that required temporarily pinning to hdmf==3.14.3 in the dandi test workflows. This issue was addressed in the subsequent hdmf release.  

Removing this pin should fix one of the daily workflows that requires a newer version of hdmf for the best practice checks for colons in container names (https://github.com/NeurodataWithoutBorders/nwbinspector/pull/532)
