### PR TITLE
Add check for dimensionality of SpikeEventSeries in electrical series validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
+# v0.6.4 (Upcoming)
+
+### Fixes
+* Fix dimensionality check for SpikeEventSeries validation [#581](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/581)
+
+
 # v0.6.3 (March 13, 2025)
 
 ### Improvements
-* Added check for negative rates in TimeSeries [#423](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/XXX)
+* Added check for negative rates in TimeSeries [#423](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/423)
 * Added check for ascending spike times in Units table [#575](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/575)
 * Added support for PyNWB 3.0 [#557](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/557)
 * Added support for Python 3.13 [#564](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/564)

--- a/src/nwbinspector/checks/_ecephys.py
+++ b/src/nwbinspector/checks/_ecephys.py
@@ -3,7 +3,7 @@
 from typing import Optional
 
 import numpy as np
-from pynwb.ecephys import ElectricalSeries
+from pynwb.ecephys import ElectricalSeries, SpikeEventSeries
 from pynwb.misc import Units
 
 from .._registration import Importance, InspectorMessage, register_check
@@ -39,6 +39,26 @@ def check_electrical_series_dims(electrical_series: ElectricalSeries) -> Optiona
     electrodes = electrical_series.electrodes
 
     data_shape = get_data_shape(data, strict_no_data_load=True)
+
+    # For SpikeEventSeries, only perform the check for 3D data
+    if isinstance(electrical_series, SpikeEventSeries):
+        if data_shape and len(data_shape) == 3 and data_shape[1] != len(electrodes.data):
+            if data_shape[0] == len(electrodes.data):
+                return InspectorMessage(
+                    message=(
+                        "The second dimension of data does not match the length of electrodes, "
+                        "but instead the first does. Data is oriented incorrectly and should be transposed."
+                    )
+                )
+            return InspectorMessage(
+                message=(
+                    "The second dimension of data does not match the length of electrodes. Your data may be transposed."
+                )
+            )
+        # Do not warn for 2D SpikeEventSeries
+        return None
+
+    # For other ElectricalSeries, keep the original logic
     if data_shape and len(data_shape) == 2 and data_shape[1] != len(electrodes.data):
         if data_shape[0] == len(electrodes.data):
             return InspectorMessage(
@@ -49,7 +69,7 @@ def check_electrical_series_dims(electrical_series: ElectricalSeries) -> Optiona
             )
         return InspectorMessage(
             message=(
-                "The second dimension of data does not match the length of electrodes. Your " "data may be transposed."
+                "The second dimension of data does not match the length of electrodes. Your data may be transposed."
             )
         )
 

--- a/tests/unit_tests/test_ecephys.py
+++ b/tests/unit_tests/test_ecephys.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 import numpy as np
 from hdmf.common.table import DynamicTable, DynamicTableRegion
 from pynwb import NWBFile
-from pynwb.ecephys import ElectricalSeries
+from pynwb.ecephys import ElectricalSeries, SpikeEventSeries
 from pynwb.misc import Units
 
 from nwbinspector import Importance, InspectorMessage
@@ -154,6 +154,47 @@ class TestCheckElectricalSeries(TestCase):
             check_electrical_series_reference_electrodes_table(electrical_series).message
             == "electrodes does not  reference an electrodes table."
         )
+
+def test_spikeeventseries_dims_check():
+    """
+    Test that 2D SpikeEventSeries does not trigger a warning,
+    but 3D SpikeEventSeries with mismatched electrodes does.
+    """
+
+    nwbfile = NWBFile(
+        session_description="",
+        identifier=str(uuid4()),
+        session_start_time=datetime.now().astimezone()
+    )
+    device = nwbfile.create_device(name="dev")
+    group = nwbfile.create_electrode_group(
+        name="electrode_group", description="desc", location="loc", device=device
+    )
+    for _ in range(3):
+        nwbfile.add_electrode(
+            x=3.0, y=3.0, z=3.0, imp=-1.0, location="unknown", filtering="unknown", group=group
+        )
+    electrodes = nwbfile.create_electrode_table_region(region=[0, 1, 2], description="three elecs")
+
+    # 2D data: [num_events, num_samples] (should NOT trigger warning)
+    ses_2d = SpikeEventSeries(
+        name="spike_events_2d",
+        data=np.zeros((10, 5)),
+        electrodes=electrodes,
+        timestamps=[0.1 * i for i in range(10)],
+    )
+    assert check_electrical_series_dims(ses_2d) is None
+
+    # 3D data: [num_events, num_channels, num_samples] with mismatched num_channels (should trigger warning)
+    ses_3d = SpikeEventSeries(
+        name="spike_events_3d",
+        data=np.zeros((10, 4, 5)),  # 4 != 3 electrodes
+        electrodes=electrodes,
+        timestamps=[0.1 * i for i in range(10)],
+    )
+    result = check_electrical_series_dims(ses_3d)
+    assert isinstance(result, InspectorMessage)
+    assert "The second dimension of data does not match the length of electrodes" in result.message
 
 
 def test_check_spike_times_not_in_unobserved_interval_pass():

--- a/tests/unit_tests/test_ecephys.py
+++ b/tests/unit_tests/test_ecephys.py
@@ -193,7 +193,7 @@ def test_spikeeventseries_dims_check():
         object_type="SpikeEventSeries",
         object_name="spike_events_3d",
         location="/",
-        )
+    )
 
 
 def test_check_spike_times_not_in_unobserved_interval_pass():

--- a/tests/unit_tests/test_ecephys.py
+++ b/tests/unit_tests/test_ecephys.py
@@ -186,8 +186,14 @@ def test_spikeeventseries_dims_check():
         timestamps=[0.1 * i for i in range(10)],
     )
     result = check_electrical_series_dims(ses_3d)
-    assert isinstance(result, InspectorMessage)
-    assert "The second dimension of data does not match the length of electrodes" in result.message
+    assert result == InspectorMessage(
+        message=("The second dimension of data does not match the length of electrodes. Your data may be transposed."),
+        importance=Importance.CRITICAL,
+        check_function_name="check_electrical_series_dims",
+        object_type="SpikeEventSeries",
+        object_name="spike_events_3d",
+        location="/",
+        )
 
 
 def test_check_spike_times_not_in_unobserved_interval_pass():

--- a/tests/unit_tests/test_ecephys.py
+++ b/tests/unit_tests/test_ecephys.py
@@ -155,25 +155,18 @@ class TestCheckElectricalSeries(TestCase):
             == "electrodes does not  reference an electrodes table."
         )
 
+
 def test_spikeeventseries_dims_check():
     """
     Test that 2D SpikeEventSeries does not trigger a warning,
     but 3D SpikeEventSeries with mismatched electrodes does.
     """
 
-    nwbfile = NWBFile(
-        session_description="",
-        identifier=str(uuid4()),
-        session_start_time=datetime.now().astimezone()
-    )
+    nwbfile = NWBFile(session_description="", identifier=str(uuid4()), session_start_time=datetime.now().astimezone())
     device = nwbfile.create_device(name="dev")
-    group = nwbfile.create_electrode_group(
-        name="electrode_group", description="desc", location="loc", device=device
-    )
+    group = nwbfile.create_electrode_group(name="electrode_group", description="desc", location="loc", device=device)
     for _ in range(3):
-        nwbfile.add_electrode(
-            x=3.0, y=3.0, z=3.0, imp=-1.0, location="unknown", filtering="unknown", group=group
-        )
+        nwbfile.add_electrode(x=3.0, y=3.0, z=3.0, imp=-1.0, location="unknown", filtering="unknown", group=group)
     electrodes = nwbfile.create_electrode_table_region(region=[0, 1, 2], description="three elecs")
 
     # 2D data: [num_events, num_samples] (should NOT trigger warning)


### PR DESCRIPTION
fix #550 

> The bug described in issue #550 has been fixed. The check for transposed data in ElectricalSeries was updated so that for SpikeEventSeries, the warning about the second dimension not matching the number of electrodes is only triggered for 3D data, not for valid 2D data. A new test was added to ensure that 2D SpikeEventSeries do not trigger a warning, while 3D SpikeEventSeries with mismatched electrodes do. All unit tests pass, confirming the fix is correct and covered by tests.

Cline-assisted (optimus-alpha)

