### PR TITLE
Remove unused setuptools reference on pyproject.toml.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,8 +54,8 @@ dandi = [
     "remfile",
 ]
 
-[tool.setuptools.packages.find]
-where = ["src"]
+[tool.hatch.build]
+packages = ["src/nwbinspector"]
 
 [project.scripts]
 nwbinspector = "nwbinspector._nwbinspector_cli:_nwbinspector_cli"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "pynwb>=2.8",   # NWB Inspector should always be used with most recent minor versions of PyNWB
+    "pynwb>=3.0",   # NWB Inspector should always be used with most recent minor versions of PyNWB
     "hdmf-zarr",
     "fsspec",
     "requests",
@@ -54,8 +54,15 @@ dandi = [
     "remfile",
 ]
 
-[tool.hatch.build]
+[tool.hatch.build.targets.sdist]
 packages = ["src/nwbinspector"]
+[tool.hatch.build.targets.sdist.force-include]
+"license.txt" = "license.txt"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/nwbinspector"]
+
+
 
 [project.scripts]
 nwbinspector = "nwbinspector._nwbinspector_cli:_nwbinspector_cli"


### PR DESCRIPTION
While debugging a build issue with this package, I discovered that the library uses `setuptools` directives even though the build system is `hatchling`.

I'm interpreting the original intent and translating the `setuptools` configuration directly to `hatchling`. @rly 

I'm also updating the `pynwb` version as mentioned in the comment.
