### PR TITLE
Ensure IO object is closed after inspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 
 ### Fixes
 * Fixed incorrect data orientation check for SpikeEventSeries [#592](https://github.com/NeurodataWithoutBorders/nwbinspector/issues/592)
-* Fix dimensionality check for SpikeEventSeries validation [#581](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/581)
+* Fixed dimensionality check for SpikeEventSeries validation [#581](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/581)
+* Fixed issue where the io object remained open after inspection was completed. [#601](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/601)
 
 # v0.6.3 (March 13, 2025)
 

--- a/src/nwbinspector/_nwb_inspection.py
+++ b/src/nwbinspector/_nwb_inspection.py
@@ -15,7 +15,7 @@ from tqdm import tqdm
 
 from ._configuration import configure_checks
 from ._registration import Importance, InspectorMessage, available_checks
-from .tools._read_nwbfile import read_nwbfile
+from .tools._read_nwbfile import read_nwbfile, read_nwbfile_and_io
 from .utils import (
     OptionalListOfStrings,
     PathType,
@@ -273,8 +273,9 @@ def inspect_nwbfile(
     filterwarnings(action="ignore", message="No cached namespaces found in .*")
     filterwarnings(action="ignore", message="Ignoring cached namespace .*")
 
+    io = None
     try:
-        in_memory_nwbfile = read_nwbfile(nwbfile_path=nwbfile_path)
+        in_memory_nwbfile, io = read_nwbfile_and_io(nwbfile_path=nwbfile_path)
 
         if not skip_validate:
             # TODO - update validation call when pynwb 3.0 is the minimal
@@ -310,6 +311,9 @@ def inspect_nwbfile(
             check_function_name=f"During io.read() - {type(exception)}: {str(exception)}",
             file_path=nwbfile_path,
         )
+    finally:
+        if io is not None:
+            io.close()  # close the io object in case of exceptions or when inspection is complete
 
 
 # TODO: deprecate once subject types and dandi schemas have been extended

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -664,6 +664,27 @@ class TestInspectorAPIAndCLIHDF5(TestInspectorOnBackend):
         ]
         self.assertCountEqual(first=test_results, second=true_results)
 
+    def test_inspect_nwbfile_io_closed_after_inspection(self):
+        """Test that the IO object is properly closed after inspection by verifying the file can be opened."""
+        # Create new minimal NWBFile to ensure file is not open by other tests
+        nwbfile = make_minimal_nwbfile()
+        add_regular_timestamps(nwbfile)
+        nwbfile_path = self.tempdir / f"testing_io_closed{self.get_extension()}"
+        with self.BackendIOClass(path=nwbfile_path, mode="w") as io:
+            io.write(nwbfile)
+
+        # Run inspection and consume the entire generator
+        test_results = list(
+            inspect_nwbfile(nwbfile_path=nwbfile_path, checks=self.checks, skip_validate=self.skip_validate)
+        )
+        self.assertGreater(len(test_results), 0)
+
+        # If the IO object was properly closed, we should be able to open the file in append mode
+        # This will fail if the file handle is still open
+        with self.BackendIOClass(path=nwbfile_path, mode="a") as io:
+            nwbfile = io.read()
+            self.assertIsNotNone(nwbfile)
+
 
 class TestInspectorAPIAndCLIZarr(TestInspectorAPIAndCLIHDF5):
     BackendIOClass = BACKEND_IO_CLASSES["zarr"]


### PR DESCRIPTION
## Motivation

Fix #599. 

Explicitly close the IO object after inspection to prevent file access issues. 