### PR TITLE
Update inspector report summary for PyNWB read errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * Fixed incorrect data orientation check for SpikeEventSeries [#592](https://github.com/NeurodataWithoutBorders/nwbinspector/issues/592)
 * Fix dimensionality check for SpikeEventSeries validation [#581](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/581)
 
+### Improvements
+* Updated InspectorMessage reporting for PyNWB read errors to improve readability [#603](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/603)
+
 # v0.6.3 (March 13, 2025)
 
 ### Improvements

--- a/src/nwbinspector/_nwb_inspection.py
+++ b/src/nwbinspector/_nwb_inspection.py
@@ -148,12 +148,7 @@ def inspect_all(
             nwbfile = read_nwbfile(nwbfile_path=nwbfile_path)
             identifiers[nwbfile.identifier].append(nwbfile_path)
         except Exception as exception:
-            yield InspectorMessage(
-                message=traceback.format_exc(),
-                importance=Importance.ERROR,
-                check_function_name=f"During io.read() - {type(exception)}: {str(exception)}",
-                file_path=str(nwbfile_path),
-            )
+            continue  # read failure errors will be returned as part of inspect_nwbfile
 
     if len(identifiers) != len(nwbfiles):
         for identifier, nwbfiles_with_identifier in identifiers.items():
@@ -304,10 +299,15 @@ def inspect_nwbfile(
             inspector_message.file_path = nwbfile_path  # type: ignore
             yield inspector_message
     except Exception as exception:
+        exception_name = f"{type(exception).__module__}.{type(exception).__name__}"
         yield InspectorMessage(
             message=traceback.format_exc(),
             importance=Importance.ERROR,
-            check_function_name=f"During io.read() - {type(exception)}: {str(exception)}",
+            check_function_name=(
+                f"During io.read(), an error occurred: {exception_name}. "
+                f"This indicates that PyNWB was unable to read the file. "
+                f"See the traceback message for more details."
+            ),
             file_path=nwbfile_path,
         )
 


### PR DESCRIPTION
## Motivation

Fix #594. 

When running NWBInspector on a file that is unable to be opened by PyNWB, io.read() error message outputs are long and sections are repeated multiple times as part of the inspector report.

These updates attempt to improve the readability of the report by removing the duplicated read error outputs when searching for non-unique file identifiers and condensing the inspector message returned by `inspect_nwbfile`.

## Code to reproduce

Create the file in python and remove a required argument
```python
from h5py import File
from pynwb import NWBHDF5IO
from pynwb.testing.mock.file import mock_NWBFile
from pynwb.validation import validate
from nwbinspector import inspect_nwbfile


# create mock NWBFile
path = "test_construct_error.nwb"
nwbfile = mock_NWBFile()
with NWBHDF5IO(path=path, mode="w") as io:
    io.write(nwbfile)

# remove required argument
with File(name=path, mode="r+") as file:
    del file["session_description"]
```

Run the inspector CLI:
```bash
nwbinspector "test_construct_error.nwb"
```

New inspector report:
```
**************************************************
NWBInspector Report Summary

Timestamp: 2025-07-23 16:52:08.679265-07:00
Platform: macOS-14.2.1-arm64-arm-64bit
NWBInspector version: 0.6.3

Found 1 issues over 1 files:
       1 - ERROR
**************************************************


0  ERROR
========

0.0  test_construct_error.nwb: During io.read(), an error occurred: hdmf.build.errors.ConstructError. This indicates that PyNWB was unable to read the file. See the traceback message for more details. - 'None' object with name 'None'
       Message: Traceback (most recent call last):
  File "/Users/smprince/Documents/code/nwbinspector/.venv/lib/python3.11/site-packages/hdmf/build/objectmapper.py", line 1368, in construct
    obj = self.__new_container__(cls, builder.source, parent, builder.attributes.get(self.__spec.id_key()),
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/Documents/code/nwbinspector/.venv/lib/python3.11/site-packages/hdmf/build/objectmapper.py", line 1381, in __new_container__
    obj.__init__(**kwargs)
  File "/Users/smprince/Documents/code/nwbinspector/.venv/lib/python3.11/site-packages/hdmf/utils.py", line 577, in func_call
    pargs = _check_args(args, kwargs)
            ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/Documents/code/nwbinspector/.venv/lib/python3.11/site-packages/hdmf/utils.py", line 570, in _check_args
    raise ExceptionType(msg)
TypeError: NWBFile.__init__: missing argument 'session_description'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/smprince/Documents/code/nwbinspector/src/nwbinspector/_nwb_inspection.py", line 272, in inspect_nwbfile
    in_memory_nwbfile = read_nwbfile(nwbfile_path=nwbfile_path)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/Documents/code/nwbinspector/src/nwbinspector/tools/_read_nwbfile.py", line 95, in read_nwbfile
    nwbfile, _ = _read_nwbfile_helper(nwbfile_path=nwbfile_path, method=method, backend=backend)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/Documents/code/nwbinspector/src/nwbinspector/tools/_read_nwbfile.py", line 180, in _read_nwbfile_helper
    nwbfile = io.read()
              ^^^^^^^^^
  File "/Users/smprince/Documents/code/nwbinspector/.venv/lib/python3.11/site-packages/hdmf/utils.py", line 578, in func_call
    return func(args[0], **pargs)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/Documents/code/nwbinspector/.venv/lib/python3.11/site-packages/pynwb/__init__.py", line 479, in read
    file = super().read(**kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/Documents/code/nwbinspector/.venv/lib/python3.11/site-packages/hdmf/backends/hdf5/h5tools.py", line 458, in read
    return super().read(**kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/Documents/code/nwbinspector/.venv/lib/python3.11/site-packages/hdmf/utils.py", line 578, in func_call
    return func(args[0], **pargs)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/Documents/code/nwbinspector/.venv/lib/python3.11/site-packages/hdmf/backends/io.py", line 60, in read
    container = self.__manager.construct(f_builder)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/Documents/code/nwbinspector/.venv/lib/python3.11/site-packages/hdmf/utils.py", line 578, in func_call
    return func(args[0], **pargs)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/Documents/code/nwbinspector/.venv/lib/python3.11/site-packages/hdmf/build/manager.py", line 286, in construct
    result = self.__type_map.construct(builder, self, None)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/Documents/code/nwbinspector/.venv/lib/python3.11/site-packages/hdmf/utils.py", line 578, in func_call
    return func(args[0], **pargs)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/Documents/code/nwbinspector/.venv/lib/python3.11/site-packages/hdmf/build/manager.py", line 813, in construct
    return obj_mapper.construct(builder, build_manager, parent)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/Documents/code/nwbinspector/.venv/lib/python3.11/site-packages/hdmf/utils.py", line 578, in func_call
    return func(args[0], **pargs)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/Documents/code/nwbinspector/.venv/lib/python3.11/site-packages/pynwb/io/file.py", line 161, in construct
    return super().construct(**kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/Documents/code/nwbinspector/.venv/lib/python3.11/site-packages/hdmf/utils.py", line 578, in func_call
    return func(args[0], **pargs)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/Documents/code/nwbinspector/.venv/lib/python3.11/site-packages/hdmf/build/objectmapper.py", line 1372, in construct
    raise ConstructError(builder, msg) from ex
hdmf.build.errors.ConstructError: (root GroupBuilder {'attributes': {'namespace': 'core', 'neurodata_type': 'NWBFile', 'nwb_version': '2.8.0', 'object_id': 'a49b2093-a78f-4954-899b-74f7eaf5d2b9'}, 'groups': {'acquisition': root/acquisition GroupBuilder {'attributes': {}, 'groups': {}, 'datasets': {}, 'links': {}}, 'analysis': root/analysis GroupBuilder {'attributes': {}, 'groups': {}, 'datasets': {}, 'links': {}}, 'general': root/general GroupBuilder {'attributes': {}, 'groups': {}, 'datasets': {}, 'links': {}}, 'processing': root/processing GroupBuilder {'attributes': {}, 'groups': {}, 'datasets': {}, 'links': {}}, 'stimulus': root/stimulus GroupBuilder {'attributes': {}, 'groups': {'presentation': root/stimulus/presentation GroupBuilder {'attributes': {}, 'groups': {}, 'datasets': {}, 'links': {}}, 'templates': root/stimulus/templates GroupBuilder {'attributes': {}, 'groups': {}, 'datasets': {}, 'links': {}}}, 'datasets': {}, 'links': {}}}, 'datasets': {'file_create_date': root/file_create_date DatasetBuilder {'attributes': {}, 'data': <HDF5 dataset "file_create_date": shape (1,), type "|O">}, 'identifier': root/identifier DatasetBuilder {'attributes': {}, 'data': '766a7f4e-08a6-44d7-83df-b54753758d47'}, 'session_start_time': root/session_start_time DatasetBuilder {'attributes': {}, 'data': '1970-01-01T00:00:00+00:00'}, 'timestamps_reference_time': root/timestamps_reference_time DatasetBuilder {'attributes': {}, 'data': '1970-01-01T00:00:00+00:00'}}, 'links': {}}, "Could not construct NWBFile object due to: NWBFile.__init__: missing argument 'session_description'")
```

Old inspector report:
```
**************************************************
NWBInspector Report Summary

Timestamp: 2025-07-23 16:47:08.514507-07:00
Platform: macOS-14.2.1-arm64-arm-64bit
NWBInspector version: 0.6.3

Found 2 issues over 1 files:
       2 - ERROR
**************************************************


0  ERROR
========

0.0  /Users/smprince/Documents/code/nwbinspector/test_construct_error.nwb: During io.read() - <class 'hdmf.build.errors.ConstructError'>: (root GroupBuilder {'attributes': {'namespace': 'core', 'neurodata_type': 'NWBFile', 'nwb_version': '2.8.0', 'object_id': '9ca053ce-bd47-443e-90cd-776cfe8b0d90'}, 'groups': {'acquisition': root/acquisition GroupBuilder {'attributes': {}, 'groups': {}, 'datasets': {}, 'links': {}}, 'analysis': root/analysis GroupBuilder {'attributes': {}, 'groups': {}, 'datasets': {}, 'links': {}}, 'general': root/general GroupBuilder {'attributes': {}, 'groups': {}, 'datasets': {}, 'links': {}}, 'processing': root/processing GroupBuilder {'attributes': {}, 'groups': {}, 'datasets': {}, 'links': {}}, 'stimulus': root/stimulus GroupBuilder {'attributes': {}, 'groups': {'presentation': root/stimulus/presentation GroupBuilder {'attributes': {}, 'groups': {}, 'datasets': {}, 'links': {}}, 'templates': root/stimulus/templates GroupBuilder {'attributes': {}, 'groups': {}, 'datasets': {}, 'links': {}}}, 'datasets': {}, 'links': {}}}, 'datasets': {'file_create_date': root/file_create_date DatasetBuilder {'attributes': {}, 'data': <HDF5 dataset "file_create_date": shape (1,), type "|O">}, 'identifier': root/identifier DatasetBuilder {'attributes': {}, 'data': '1d2dcabe-3a30-48ad-bd43-ffedc3c0ed5b'}, 'session_start_time': root/session_start_time DatasetBuilder {'attributes': {}, 'data': '1970-01-01T00:00:00+00:00'}, 'timestamps_reference_time': root/timestamps_reference_time DatasetBuilder {'attributes': {}, 'data': '1970-01-01T00:00:00+00:00'}}, 'links': {}}, "Could not construct NWBFile object due to: NWBFile.__init__: missing argument 'session_description'") - 'None' object with name 'None'
       Message: Traceback (most recent call last):
  File "/Users/smprince/anaconda3/envs/test/lib/python3.12/site-packages/hdmf/build/objectmapper.py", line 1368, in construct
    obj = self.__new_container__(cls, builder.source, parent, builder.attributes.get(self.__spec.id_key()),
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/anaconda3/envs/test/lib/python3.12/site-packages/hdmf/build/objectmapper.py", line 1381, in __new_container__
    obj.__init__(**kwargs)
  File "/Users/smprince/anaconda3/envs/test/lib/python3.12/site-packages/hdmf/utils.py", line 577, in func_call
    pargs = _check_args(args, kwargs)
            ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/anaconda3/envs/test/lib/python3.12/site-packages/hdmf/utils.py", line 570, in _check_args
    raise ExceptionType(msg)
TypeError: NWBFile.__init__: missing argument 'session_description'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/smprince/anaconda3/envs/test/lib/python3.12/site-packages/nwbinspector/_nwb_inspection.py", line 148, in inspect_all
    nwbfile = read_nwbfile(nwbfile_path=nwbfile_path)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/anaconda3/envs/test/lib/python3.12/site-packages/nwbinspector/tools/_read_nwbfile.py", line 95, in read_nwbfile
    nwbfile, _ = _read_nwbfile_helper(nwbfile_path=nwbfile_path, method=method, backend=backend)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/anaconda3/envs/test/lib/python3.12/site-packages/nwbinspector/tools/_read_nwbfile.py", line 180, in _read_nwbfile_helper
    nwbfile = io.read()
              ^^^^^^^^^
  File "/Users/smprince/anaconda3/envs/test/lib/python3.12/site-packages/hdmf/utils.py", line 578, in func_call
    return func(args[0], **pargs)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/anaconda3/envs/test/lib/python3.12/site-packages/pynwb/__init__.py", line 479, in read
    file = super().read(**kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/anaconda3/envs/test/lib/python3.12/site-packages/hdmf/backends/hdf5/h5tools.py", line 458, in read
    return super().read(**kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/anaconda3/envs/test/lib/python3.12/site-packages/hdmf/utils.py", line 578, in func_call
    return func(args[0], **pargs)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/anaconda3/envs/test/lib/python3.12/site-packages/hdmf/backends/io.py", line 60, in read
    container = self.__manager.construct(f_builder)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/anaconda3/envs/test/lib/python3.12/site-packages/hdmf/utils.py", line 578, in func_call
    return func(args[0], **pargs)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/anaconda3/envs/test/lib/python3.12/site-packages/hdmf/build/manager.py", line 286, in construct
    result = self.__type_map.construct(builder, self, None)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/anaconda3/envs/test/lib/python3.12/site-packages/hdmf/utils.py", line 578, in func_call
    return func(args[0], **pargs)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/anaconda3/envs/test/lib/python3.12/site-packages/hdmf/build/manager.py", line 813, in construct
    return obj_mapper.construct(builder, build_manager, parent)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/anaconda3/envs/test/lib/python3.12/site-packages/hdmf/utils.py", line 578, in func_call
    return func(args[0], **pargs)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/anaconda3/envs/test/lib/python3.12/site-packages/pynwb/io/file.py", line 161, in construct
    return super().construct(**kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/anaconda3/envs/test/lib/python3.12/site-packages/hdmf/utils.py", line 578, in func_call
    return func(args[0], **pargs)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/anaconda3/envs/test/lib/python3.12/site-packages/hdmf/build/objectmapper.py", line 1372, in construct
    raise ConstructError(builder, msg) from ex
hdmf.build.errors.ConstructError: (root GroupBuilder {'attributes': {'namespace': 'core', 'neurodata_type': 'NWBFile', 'nwb_version': '2.8.0', 'object_id': '9ca053ce-bd47-443e-90cd-776cfe8b0d90'}, 'groups': {'acquisition': root/acquisition GroupBuilder {'attributes': {}, 'groups': {}, 'datasets': {}, 'links': {}}, 'analysis': root/analysis GroupBuilder {'attributes': {}, 'groups': {}, 'datasets': {}, 'links': {}}, 'general': root/general GroupBuilder {'attributes': {}, 'groups': {}, 'datasets': {}, 'links': {}}, 'processing': root/processing GroupBuilder {'attributes': {}, 'groups': {}, 'datasets': {}, 'links': {}}, 'stimulus': root/stimulus GroupBuilder {'attributes': {}, 'groups': {'presentation': root/stimulus/presentation GroupBuilder {'attributes': {}, 'groups': {}, 'datasets': {}, 'links': {}}, 'templates': root/stimulus/templates GroupBuilder {'attributes': {}, 'groups': {}, 'datasets': {}, 'links': {}}}, 'datasets': {}, 'links': {}}}, 'datasets': {'file_create_date': root/file_create_date DatasetBuilder {'attributes': {}, 'data': <HDF5 dataset "file_create_date": shape (1,), type "|O">}, 'identifier': root/identifier DatasetBuilder {'attributes': {}, 'data': '1d2dcabe-3a30-48ad-bd43-ffedc3c0ed5b'}, 'session_start_time': root/session_start_time DatasetBuilder {'attributes': {}, 'data': '1970-01-01T00:00:00+00:00'}, 'timestamps_reference_time': root/timestamps_reference_time DatasetBuilder {'attributes': {}, 'data': '1970-01-01T00:00:00+00:00'}}, 'links': {}}, "Could not construct NWBFile object due to: NWBFile.__init__: missing argument 'session_description'")


0.1  /Users/smprince/Documents/code/nwbinspector/test_construct_error.nwb: During io.read() - <class 'hdmf.build.errors.ConstructError'>: (root GroupBuilder {'attributes': {'namespace': 'core', 'neurodata_type': 'NWBFile', 'nwb_version': '2.8.0', 'object_id': '9ca053ce-bd47-443e-90cd-776cfe8b0d90'}, 'groups': {'acquisition': root/acquisition GroupBuilder {'attributes': {}, 'groups': {}, 'datasets': {}, 'links': {}}, 'analysis': root/analysis GroupBuilder {'attributes': {}, 'groups': {}, 'datasets': {}, 'links': {}}, 'general': root/general GroupBuilder {'attributes': {}, 'groups': {}, 'datasets': {}, 'links': {}}, 'processing': root/processing GroupBuilder {'attributes': {}, 'groups': {}, 'datasets': {}, 'links': {}}, 'stimulus': root/stimulus GroupBuilder {'attributes': {}, 'groups': {'presentation': root/stimulus/presentation GroupBuilder {'attributes': {}, 'groups': {}, 'datasets': {}, 'links': {}}, 'templates': root/stimulus/templates GroupBuilder {'attributes': {}, 'groups': {}, 'datasets': {}, 'links': {}}}, 'datasets': {}, 'links': {}}}, 'datasets': {'file_create_date': root/file_create_date DatasetBuilder {'attributes': {}, 'data': <HDF5 dataset "file_create_date": shape (1,), type "|O">}, 'identifier': root/identifier DatasetBuilder {'attributes': {}, 'data': '1d2dcabe-3a30-48ad-bd43-ffedc3c0ed5b'}, 'session_start_time': root/session_start_time DatasetBuilder {'attributes': {}, 'data': '1970-01-01T00:00:00+00:00'}, 'timestamps_reference_time': root/timestamps_reference_time DatasetBuilder {'attributes': {}, 'data': '1970-01-01T00:00:00+00:00'}}, 'links': {}}, "Could not construct NWBFile object due to: NWBFile.__init__: missing argument 'session_description'") - 'None' object with name 'None'
       Message: Traceback (most recent call last):
  File "/Users/smprince/anaconda3/envs/test/lib/python3.12/site-packages/hdmf/build/objectmapper.py", line 1368, in construct
    obj = self.__new_container__(cls, builder.source, parent, builder.attributes.get(self.__spec.id_key()),
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/anaconda3/envs/test/lib/python3.12/site-packages/hdmf/build/objectmapper.py", line 1381, in __new_container__
    obj.__init__(**kwargs)
  File "/Users/smprince/anaconda3/envs/test/lib/python3.12/site-packages/hdmf/utils.py", line 577, in func_call
    pargs = _check_args(args, kwargs)
            ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/anaconda3/envs/test/lib/python3.12/site-packages/hdmf/utils.py", line 570, in _check_args
    raise ExceptionType(msg)
TypeError: NWBFile.__init__: missing argument 'session_description'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/smprince/anaconda3/envs/test/lib/python3.12/site-packages/nwbinspector/_nwb_inspection.py", line 277, in inspect_nwbfile
    in_memory_nwbfile = read_nwbfile(nwbfile_path=nwbfile_path)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/anaconda3/envs/test/lib/python3.12/site-packages/nwbinspector/tools/_read_nwbfile.py", line 95, in read_nwbfile
    nwbfile, _ = _read_nwbfile_helper(nwbfile_path=nwbfile_path, method=method, backend=backend)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/anaconda3/envs/test/lib/python3.12/site-packages/nwbinspector/tools/_read_nwbfile.py", line 180, in _read_nwbfile_helper
    nwbfile = io.read()
              ^^^^^^^^^
  File "/Users/smprince/anaconda3/envs/test/lib/python3.12/site-packages/hdmf/utils.py", line 578, in func_call
    return func(args[0], **pargs)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/anaconda3/envs/test/lib/python3.12/site-packages/pynwb/__init__.py", line 479, in read
    file = super().read(**kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/anaconda3/envs/test/lib/python3.12/site-packages/hdmf/backends/hdf5/h5tools.py", line 458, in read
    return super().read(**kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/anaconda3/envs/test/lib/python3.12/site-packages/hdmf/utils.py", line 578, in func_call
    return func(args[0], **pargs)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/anaconda3/envs/test/lib/python3.12/site-packages/hdmf/backends/io.py", line 60, in read
    container = self.__manager.construct(f_builder)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/anaconda3/envs/test/lib/python3.12/site-packages/hdmf/utils.py", line 578, in func_call
    return func(args[0], **pargs)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/anaconda3/envs/test/lib/python3.12/site-packages/hdmf/build/manager.py", line 286, in construct
    result = self.__type_map.construct(builder, self, None)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/anaconda3/envs/test/lib/python3.12/site-packages/hdmf/utils.py", line 578, in func_call
    return func(args[0], **pargs)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/anaconda3/envs/test/lib/python3.12/site-packages/hdmf/build/manager.py", line 813, in construct
    return obj_mapper.construct(builder, build_manager, parent)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/anaconda3/envs/test/lib/python3.12/site-packages/hdmf/utils.py", line 578, in func_call
    return func(args[0], **pargs)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/anaconda3/envs/test/lib/python3.12/site-packages/pynwb/io/file.py", line 161, in construct
    return super().construct(**kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/anaconda3/envs/test/lib/python3.12/site-packages/hdmf/utils.py", line 578, in func_call
    return func(args[0], **pargs)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/smprince/anaconda3/envs/test/lib/python3.12/site-packages/hdmf/build/objectmapper.py", line 1372, in construct
    raise ConstructError(builder, msg) from ex
hdmf.build.errors.ConstructError: (root GroupBuilder {'attributes': {'namespace': 'core', 'neurodata_type': 'NWBFile', 'nwb_version': '2.8.0', 'object_id': '9ca053ce-bd47-443e-90cd-776cfe8b0d90'}, 'groups': {'acquisition': root/acquisition GroupBuilder {'attributes': {}, 'groups': {}, 'datasets': {}, 'links': {}}, 'analysis': root/analysis GroupBuilder {'attributes': {}, 'groups': {}, 'datasets': {}, 'links': {}}, 'general': root/general GroupBuilder {'attributes': {}, 'groups': {}, 'datasets': {}, 'links': {}}, 'processing': root/processing GroupBuilder {'attributes': {}, 'groups': {}, 'datasets': {}, 'links': {}}, 'stimulus': root/stimulus GroupBuilder {'attributes': {}, 'groups': {'presentation': root/stimulus/presentation GroupBuilder {'attributes': {}, 'groups': {}, 'datasets': {}, 'links': {}}, 'templates': root/stimulus/templates GroupBuilder {'attributes': {}, 'groups': {}, 'datasets': {}, 'links': {}}}, 'datasets': {}, 'links': {}}}, 'datasets': {'file_create_date': root/file_create_date DatasetBuilder {'attributes': {}, 'data': <HDF5 dataset "file_create_date": shape (1,), type "|O">}, 'identifier': root/identifier DatasetBuilder {'attributes': {}, 'data': '1d2dcabe-3a30-48ad-bd43-ffedc3c0ed5b'}, 'session_start_time': root/session_start_time DatasetBuilder {'attributes': {}, 'data': '1970-01-01T00:00:00+00:00'}, 'timestamps_reference_time': root/timestamps_reference_time DatasetBuilder {'attributes': {}, 'data': '1970-01-01T00:00:00+00:00'}}, 'links': {}}, "Could not construct NWBFile object due to: NWBFile.__init__: missing argument 'session_description'")
```