### PR TITLE
Fix build configuration in pyproject.toml

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -22,6 +22,10 @@ jobs:
           python -m pip install --upgrade build
       - name: Build package
         run: python -m build
+      - name: Test wheel installation
+        run: |
+          python -m pip install dist/*.whl
+          python -c "import nwbinspector"
       - name: pypi-publish
         uses: pypa/gh-action-pypi-publish@v1.4.2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v0.6.5
+# v0.6.5 (July 25, 2025)
 * Fixed build configuration error in pyproject.toml [#605](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/605)
 
 # v0.6.4 (July 24, 2025)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v0.6.5
+* Fixed build configuration error in pyproject.toml [#605](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/605)
+
 # v0.6.4 (July 24, 2025)
 
 ### New Checks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # v0.6.5 (July 25, 2025)
+
+### Fixes
 * Fixed build configuration error in pyproject.toml [#605](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/605)
 
 # v0.6.4 (July 24, 2025)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nwbinspector"
-version = "0.6.4"
+version = "0.6.5"
 description = "Tool to inspect NWB files for best practices compliance."
 readme = "README.md"
 authors = [
@@ -54,13 +54,9 @@ dandi = [
     "remfile",
 ]
 
-[tool.hatch.build.targets.sdist]
-packages = ["src/nwbinspector"]
-[tool.hatch.build.targets.sdist.force-include]
-"license.txt" = "license.txt"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/nwbinspector"]
+sources = ["src"]
 
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,9 +54,15 @@ dandi = [
     "remfile",
 ]
 
+[tool.hatch.build.targets.sdist]
+exclude = [
+    ".git*",
+    "codecov.yml",
+    ".pre-commit-config.yaml",
+]
 
 [tool.hatch.build.targets.wheel]
-sources = ["src"]
+packages = ["src/nwbinspector"]
 
 
 


### PR DESCRIPTION
## Motivation

I believe the latest version of the inspector has an error in the build configuration resulting in a ModuleNotFound error on import. These changes update the configuration and add a test of the wheel installation before publishing.