### PR TITLE
Update dandi gui-staging url to sandbox

### DIFF
--- a/.github/workflows/dev-gallery.yml
+++ b/.github/workflows/dev-gallery.yml
@@ -30,7 +30,7 @@ jobs:
           pip install git+https://github.com/neurodatawithoutborders/pynwb@dev
 
       - name: Download testing data and set config path
-        run: dandi download "https://sandbox.dandiarchive.org/dandiset/204919"
+        run: dandi download "https://sandbox.dandiarchive.org/#/dandiset/204919"
 
       - name: Run pytest
         run: pytest -rsx

--- a/.github/workflows/dev-gallery.yml
+++ b/.github/workflows/dev-gallery.yml
@@ -30,7 +30,7 @@ jobs:
           pip install git+https://github.com/neurodatawithoutborders/pynwb@dev
 
       - name: Download testing data and set config path
-        run: dandi download "https://gui-staging.dandiarchive.org/#/dandiset/204919"
+        run: dandi download "https://sandbox.dandiarchive.org/dandiset/204919"
 
       - name: Run pytest
         run: pytest -rsx

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install package
         run: pip install ".[dandi]"
       - name: Download testing data and set config path
-        run: dandi download "https://sandbox.dandiarchive.org/dandiset/204919"
+        run: dandi download "https://sandbox.dandiarchive.org/#/dandiset/204919"
 
       - name: Run pytest with coverage
         run: pytest -rsx --cov=nwbinspector --cov-report xml:./coverage.xml

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install package
         run: pip install ".[dandi]"
       - name: Download testing data and set config path
-        run: dandi download "https://gui-staging.dandiarchive.org/#/dandiset/204919"
+        run: dandi download "https://sandbox.dandiarchive.org/dandiset/204919"
 
       - name: Run pytest with coverage
         run: pytest -rsx --cov=nwbinspector --cov-report xml:./coverage.xml


### PR DESCRIPTION
## Motivation
One of the daily windows workflows was failing due to a connection timeout error when downloading the test dandi dataset. This may have been a temporary issue and I believe the old `gui-staging.dandiarchive.org` URL should automatically redirect to `sandbox.dandiarchive.org`, but we can update the workflows to point to the new URL.