### PR TITLE
Follow up to dependabot pypa/gh-action-pypi-publish bump

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -27,7 +27,7 @@ jobs:
           python -m pip install dist/*.whl
           python -c "import nwbinspector"
       - name: pypi-publish
-        uses: pypa/gh-action-pypi-publish@v1.4.2
+        uses: pypa/gh-action-pypi-publish@v1.13.0
         with:
           verbose: true
           user: __token__

--- a/.github/workflows/read-nwbfile-tests.yml
+++ b/.github/workflows/read-nwbfile-tests.yml
@@ -47,5 +47,5 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+          fail_ci_if_error: ${{ github.actor != 'dependabot[bot]' }}
           file: ./coverage.xml

--- a/.github/workflows/streaming-tests.yml
+++ b/.github/workflows/streaming-tests.yml
@@ -49,7 +49,7 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+          fail_ci_if_error: ${{ github.actor != 'dependabot[bot]' }}
           file: ./cli_coverage.xml
 
   build-and-test-no-dandi:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -43,7 +43,7 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+          fail_ci_if_error: ${{ github.actor != 'dependabot[bot]' }}
           file: ./coverage.xml
 
   build-and-test-no-dandi:


### PR DESCRIPTION
## Motivation

This PR supersedes https://github.com/NeurodataWithoutBorders/nwbinspector/pull/616, which has a failing required CI check. 

`codecov/codecov-action@v4` stopped permitting tokenless coverage uploading and dependabot PRs do not have access to GitHub Actions secrets, including our `CODECOV_TOKEN`.

This will update the actions to allow coverage upload failures to pass for dependabot PRs (see suggestions outlined in https://docs.github.com/en/code-security/dependabot/troubleshooting-dependabot/troubleshooting-dependabot-on-github-actions)