### PR TITLE
Add dandi config documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.6.6 (Upcoming)
+
+### Improvements
+* Added documentation to API and CLI docs on how to use the dandi config option. [#624](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/624)
+
 # v0.6.5 (July 25, 2025)
 
 ### Fixes

--- a/docs/user_guide/using_the_command_line_interface.rst
+++ b/docs/user_guide/using_the_command_line_interface.rst
@@ -26,8 +26,8 @@ Using the DANDI Configuration
 ------------------------------
 
 The NWBInspector includes a built-in DANDI configuration that adjusts the importance levels of certain checks to match
-DANDI archive requirements. This is useful when preparing files for upload to DANDI, as it ensures that critical
-checks required for DANDI validation are properly prioritized.
+:dandi-archive:`DANDI Archive <>` requirements. This is useful when preparing files for upload to DANDI, as it
+ensures that critical checks required for DANDI validation are properly prioritized.
 
 To use the DANDI configuration from the command line, use the ``--config`` flag with the keyword ``dandi``:
 

--- a/docs/user_guide/using_the_command_line_interface.rst
+++ b/docs/user_guide/using_the_command_line_interface.rst
@@ -25,7 +25,8 @@ the most useful of these options.
 Using the DANDI Configuration
 ------------------------------
 
-The NWBInspector includes a built-in DANDI configuration that adjusts the importance levels of certain checks to match
+The NWBInspector includes a built-in DANDI `configuration file <https://github.com/NeurodataWithoutBorders/nwbinspector/blob/dev/src/nwbinspector/_internal_configs/dandi.inspector_config.yaml>`_
+that adjusts the importance levels of certain checks to match
 :dandi-archive:`DANDI Archive <>` requirements. This is useful when preparing files for upload to DANDI, as it
 ensures that critical checks required for DANDI validation are properly prioritized.
 
@@ -37,7 +38,8 @@ To use the DANDI configuration from the command line, use the ``--config`` flag 
 
 
 The DANDI configuration elevates certain checks (e.g. ``check_subject_exists``, ``check_subject_species_exists``, etc.)
-to ``CRITICAL`` importance, meaning they must pass for DANDI validation to succeed.
+to ``CRITICAL`` importance, meaning they must pass for DANDI validation to succeed. A full list of the additional DANDI requirements
+can be found in the `DANDI documentation <https://docs.dandiarchive.org/user-guide-sharing/validating-files/#missing-dandi-metadata>`_.
 
 
 

--- a/docs/user_guide/using_the_command_line_interface.rst
+++ b/docs/user_guide/using_the_command_line_interface.rst
@@ -22,6 +22,25 @@ the most useful of these options.
 
 
 
+Using the DANDI Configuration
+------------------------------
+
+The NWBInspector includes a built-in DANDI configuration that adjusts the importance levels of certain checks to match
+DANDI archive requirements. This is useful when preparing files for upload to DANDI, as it ensures that critical
+checks required for DANDI validation are properly prioritized.
+
+To use the DANDI configuration from the command line, use the ``--config`` flag with the keyword ``dandi``:
+
+::
+
+    nwbinspector path/to/my/data.nwb --config dandi
+
+
+The DANDI configuration elevates certain checks (e.g. ``check_subject_exists``, ``check_subject_species_exists``, etc.)
+to ``CRITICAL`` importance, meaning they must pass for DANDI validation to succeed.
+
+
+
 Streaming
 ---------
 

--- a/docs/user_guide/using_the_library.rst
+++ b/docs/user_guide/using_the_library.rst
@@ -74,6 +74,33 @@ This has the same return structure as :py:class:`~nwbinspector.nwbinspector.insp
 
 
 
+Using the DANDI Configuration
+------------------------------
+
+The NWBInspector includes a built-in DANDI configuration that adjusts the importance levels of certain checks to match
+DANDI archive requirements. This is useful when preparing files for upload to DANDI, as it ensures that critical
+checks required for DANDI validation are properly prioritized.
+
+To use the DANDI configuration with the library functions, use the :py:class:`~nwbinspector._configuration.load_config`
+function:
+
+.. code-block:: python
+
+    from nwbinspector import inspect_nwbfile, load_config
+
+    dandi_config = load_config("dandi")
+    results = list(inspect_nwbfile(nwbfile_path="path_to_single_nwbfile", config=dandi_config))
+
+The DANDI configuration elevates certain checks (e.g. ``check_subject_exists``, ``check_subject_species_exists``, etc.)
+to ``CRITICAL`` importance, meaning they must pass for DANDI validation to succeed.
+
+.. note::
+
+    The DANDI configuration can also be used as a keyword argument with other inspection functions
+    (e.g. ``inspect_all`` and ``inspect_nwbfile_object``)
+
+
+
 .. _simple_streaming_api:
 
 Inspect a Dandiset

--- a/docs/user_guide/using_the_library.rst
+++ b/docs/user_guide/using_the_library.rst
@@ -77,9 +77,11 @@ This has the same return structure as :py:class:`~nwbinspector.nwbinspector.insp
 Using the DANDI Configuration
 ------------------------------
 
-The NWBInspector includes a built-in DANDI configuration that adjusts the importance levels of certain checks to match
-:dandi-archive:`DANDI Archive <>` requirements. This is useful when preparing files for upload to DANDI, as it ensures
-that critical checks required for DANDI validation are properly prioritized.
+The NWBInspector includes a built-in DANDI
+`configuration file <https://github.com/NeurodataWithoutBorders/nwbinspector/blob/dev/src/nwbinspector/_internal_configs/dandi.inspector_config.yaml>`_
+that adjusts the importance levels of certain checks to match :dandi-archive:`DANDI Archive <>` requirements.
+This is useful when preparing files for upload to DANDI, as it ensures that critical checks required for DANDI
+validation are properly prioritized.
 
 To use the DANDI configuration with the library functions, use the :py:class:`~nwbinspector._configuration.load_config`
 function:
@@ -92,7 +94,9 @@ function:
     results = list(inspect_nwbfile(nwbfile_path="path_to_single_nwbfile", config=dandi_config))
 
 The DANDI configuration elevates certain checks (e.g. ``check_subject_exists``, ``check_subject_species_exists``, etc.)
-to ``CRITICAL`` importance, meaning they must pass for DANDI validation to succeed.
+to ``CRITICAL`` importance, meaning they must pass for DANDI validation to succeed. A full list of the additional DANDI
+requirements can be found in the
+`DANDI documentation <https://docs.dandiarchive.org/user-guide-sharing/validating-files/#missing-dandi-metadata>`_.
 
 .. note::
 

--- a/docs/user_guide/using_the_library.rst
+++ b/docs/user_guide/using_the_library.rst
@@ -78,8 +78,8 @@ Using the DANDI Configuration
 ------------------------------
 
 The NWBInspector includes a built-in DANDI configuration that adjusts the importance levels of certain checks to match
-DANDI archive requirements. This is useful when preparing files for upload to DANDI, as it ensures that critical
-checks required for DANDI validation are properly prioritized.
+:dandi-archive:`DANDI Archive <>` requirements. This is useful when preparing files for upload to DANDI, as it ensures
+that critical checks required for DANDI validation are properly prioritized.
 
 To use the DANDI configuration with the library functions, use the :py:class:`~nwbinspector._configuration.load_config`
 function:


### PR DESCRIPTION
## Motivation

Fix #554, #360.

Adds documentation to the user guide on using the dandi configuration when running the inspector. With help from Claude.