### PR TITLE
feat(checks): add check_subject_weight to validate weight format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Added `check_units_table_duration` to detect if the duration of spike times in a Units table exceeds a threshold (default: 1 year), which may indicate spike_times are in the wrong units or there is a data quality issue.
 * Added `check_time_intervals_duration`, which makes sure that `TimeInterval` objects do not have a duration greater than 1 year.
 [#635](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/635)
-* Added `check_subject_weight` to ensure subject weight follows the form '[numeric] [unit]' (e.g., '2.3 kg' or '25kg'). [#647](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/647)
+* Added `check_subject_weight` to ensure subject weight follows the form '[numeric] [unit]' (e.g., '2.3 kg' or '10 g'). [#647](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/647)
 
 ### Improvements
 * Added documentation to API and CLI docs on how to use the dandi config option. [#624](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/624)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Added `check_file_extension` for NWB file extension best practice recommendations (`.nwb`, `.nwb.h5`, or `.nwb.zarr`) [#625](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/625)
 * Added `check_time_intervals_duration`, which makes sure that `TimeInterval` objects do not have a duration greater than 1 year.
 [#635](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/635)
-* Added `check_subject_weight` to ensure subject weight follows the form '[numeric] [unit]' (e.g., '2.3 kg' or '25kg'). [#370](https://github.com/NeurodataWithoutBorders/nwbinspector/issues/370)
+* Added `check_subject_weight` to ensure subject weight follows the form '[numeric] [unit]' (e.g., '2.3 kg' or '25kg'). [#647](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/647)
 
 ### Improvements
 * Added documentation to API and CLI docs on how to use the dandi config option. [#624](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/624)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Added `check_file_extension` for NWB file extension best practice recommendations (`.nwb`, `.nwb.h5`, or `.nwb.zarr`) [#625](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/625)
 * Added `check_time_intervals_duration`, which makes sure that `TimeInterval` objects do not have a duration greater than 1 year.
 [#635](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/635)
+* Added `check_subject_weight` to ensure subject weight follows the form '[numeric] [unit]' (e.g., '2.3 kg' or '25kg'). [#370](https://github.com/NeurodataWithoutBorders/nwbinspector/issues/370)
 
 ### Improvements
 * Added documentation to API and CLI docs on how to use the dandi config option. [#624](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/624)

--- a/docs/best_practices/nwbfile_metadata.rst
+++ b/docs/best_practices/nwbfile_metadata.rst
@@ -249,6 +249,19 @@ The ``strain`` of a :ref:`nwb-schema:sec-Subject` should be set to further indic
 
 
 
+.. _best_practice_subject_weight:
+
+Subject Weight
+~~~~~~~~~~~~~~
+
+The ``weight`` of a :ref:`nwb-schema:sec-Subject` should follow the form '[numeric] [unit]', e.g. '2.3 kg'.
+The weight should include a numeric value followed by a space and a unit string. Without a unit, the weight
+is ambiguous.
+
+Check function: :py:meth:`~nwbinspector.checks._nwbfile_metadata.check_subject_weight`
+
+
+
 .. _best_practice_subject_age:
 
 Subject Age

--- a/docs/best_practices/nwbfile_metadata.rst
+++ b/docs/best_practices/nwbfile_metadata.rst
@@ -255,8 +255,10 @@ Subject Weight
 ~~~~~~~~~~~~~~
 
 The ``weight`` of a :ref:`nwb-schema:sec-Subject` should follow the form '[numeric] [unit]', e.g. '2.3 kg'.
-The weight should include a numeric value followed by a space and a unit string. Without a unit, the weight
-is ambiguous.
+The weight should include a numeric value followed by a space and a unit string. Without a unit, the weight is ambiguous.
+The unit should follow standard SI unit conventions (see `The International System of Units, 9th edition <https://doi.org/10.59161/AUEZ1291>`_),
+e.g. 'kg' for kilograms, 'g' for grams, 'mg' for milligrams, etc.
+The unit should be one of: 'kg', 'g', 'mg', 'ug', 'μg', 'ng', 'pg'.
 
 Check function: :py:meth:`~nwbinspector.checks._nwbfile_metadata.check_subject_weight`
 

--- a/src/nwbinspector/checks/__init__.py
+++ b/src/nwbinspector/checks/__init__.py
@@ -54,6 +54,7 @@ from ._nwbfile_metadata import (
     check_subject_sex,
     check_subject_species_exists,
     check_subject_species_form,
+    check_subject_weight,
 )
 from ._ogen import (
     check_optogenetic_stimulus_site_has_optogenetic_series,
@@ -121,6 +122,7 @@ __all__ = [
     "check_subject_id_no_slashes",
     "check_subject_species_exists",
     "check_subject_species_form",
+    "check_subject_weight",
     "check_subject_proper_age_range",
     "check_file_extension",
     "check_session_id_no_slashes",

--- a/src/nwbinspector/checks/_nwbfile_metadata.py
+++ b/src/nwbinspector/checks/_nwbfile_metadata.py
@@ -19,7 +19,7 @@ duration_regex = (
     r"?M)?(\d+(?:\.\d+)?S)?)?$"
 )
 species_form_regex = r"([A-Z][a-z]* [a-z]+)|(http://purl.obolibrary.org/obo/NCBITaxon_\d+)"
-weight_form_regex = r"^\d+(\.\d+)?\s*[A-Za-z]+$"
+weight_form_regex = r"(?i)^\d+(\.\d+)? (kg|g|mg|ug|μg|ng|pg)$"
 
 PROCESSING_MODULE_CONFIG = ["ophys", "ecephys", "icephys", "behavior", "misc", "ogen", "retinotopy"]
 

--- a/src/nwbinspector/checks/_nwbfile_metadata.py
+++ b/src/nwbinspector/checks/_nwbfile_metadata.py
@@ -257,7 +257,8 @@ def check_subject_weight(subject: Subject) -> Optional[InspectorMessage]:
         return InspectorMessage(
             message=(
                 f"Subject weight '{subject.weight}' does not follow the expected form '[numeric] [unit]'. "
-                "For example, '2.3 kg'. Without a unit, the weight is ambiguous."
+                "For example, '2.3 kg'. Without a unit, the weight is ambiguous. "
+                "Valid units are: 'kg', 'g', 'mg', 'ug', 'μg', 'ng', 'pg'."
             )
         )
 

--- a/src/nwbinspector/checks/_nwbfile_metadata.py
+++ b/src/nwbinspector/checks/_nwbfile_metadata.py
@@ -19,6 +19,7 @@ duration_regex = (
     r"?M)?(\d+(?:\.\d+)?S)?)?$"
 )
 species_form_regex = r"([A-Z][a-z]* [a-z]+)|(http://purl.obolibrary.org/obo/NCBITaxon_\d+)"
+weight_form_regex = r"^\d+(\.\d+)?\s*[A-Za-z]+$"
 
 PROCESSING_MODULE_CONFIG = ["ophys", "ecephys", "icephys", "behavior", "misc", "ogen", "retinotopy"]
 
@@ -235,6 +236,30 @@ def check_subject_id_exists(subject: Subject) -> Optional[InspectorMessage]:
     """
     if subject.subject_id is None:
         return InspectorMessage(message="subject_id is missing.")
+
+    return None
+
+
+@register_check(importance=Importance.CRITICAL, neurodata_type=Subject)
+def check_subject_weight(subject: Subject) -> Optional[InspectorMessage]:
+    """
+    Check if subject weight follows the form '[numeric] [unit]', e.g. '2.3 kg'.
+
+    The weight should include a numeric value followed by a space and a unit string.
+    Without a unit, the weight is ambiguous.
+
+    Best Practice: :ref:`best_practice_subject_weight`
+    """
+    if subject.weight is None:
+        return None
+
+    if not re.fullmatch(weight_form_regex, subject.weight):
+        return InspectorMessage(
+            message=(
+                f"Subject weight '{subject.weight}' does not follow the expected form '[numeric] [unit]'. "
+                "For example, '2.3 kg'. Without a unit, the weight is ambiguous."
+            )
+        )
 
     return None
 

--- a/tests/unit_tests/test_nwbfile_metadata.py
+++ b/tests/unit_tests/test_nwbfile_metadata.py
@@ -685,7 +685,8 @@ def test_check_subject_weight_fail_no_unit():
     assert check_subject_weight(subject) == InspectorMessage(
         message=(
             "Subject weight '25' does not follow the expected form '[numeric] [unit]'. "
-            "For example, '2.3 kg'. Without a unit, the weight is ambiguous."
+            "For example, '2.3 kg'. Without a unit, the weight is ambiguous. "
+            "Valid units are: 'kg', 'g', 'mg', 'ug', 'μg', 'ng', 'pg'."
         ),
         importance=Importance.CRITICAL,
         check_function_name="check_subject_weight",
@@ -701,7 +702,8 @@ def test_check_subject_weight_fail_multiple_decimals():
     assert check_subject_weight(subject) == InspectorMessage(
         message=(
             "Subject weight '2.3.4 kg' does not follow the expected form '[numeric] [unit]'. "
-            "For example, '2.3 kg'. Without a unit, the weight is ambiguous."
+            "For example, '2.3 kg'. Without a unit, the weight is ambiguous. "
+            "Valid units are: 'kg', 'g', 'mg', 'ug', 'μg', 'ng', 'pg'."
         ),
         importance=Importance.CRITICAL,
         check_function_name="check_subject_weight",
@@ -717,7 +719,8 @@ def test_check_subject_weight_fail_text_only():
     assert check_subject_weight(subject) == InspectorMessage(
         message=(
             "Subject weight 'heavy' does not follow the expected form '[numeric] [unit]'. "
-            "For example, '2.3 kg'. Without a unit, the weight is ambiguous."
+            "For example, '2.3 kg'. Without a unit, the weight is ambiguous. "
+            "Valid units are: 'kg', 'g', 'mg', 'ug', 'μg', 'ng', 'pg'."
         ),
         importance=Importance.CRITICAL,
         check_function_name="check_subject_weight",

--- a/tests/unit_tests/test_nwbfile_metadata.py
+++ b/tests/unit_tests/test_nwbfile_metadata.py
@@ -667,7 +667,7 @@ def test_check_file_extension_fail():
 
 def test_check_subject_weight_pass():
     """Test that valid weight formats pass the check."""
-    valid_weights = ["2.3 kg", "25 kg", "2.5kg", "100g", "1.5 lbs", "0.5 kg"]
+    valid_weights = ["2.3 kg", "25 kg", "0.5 kg", "100 g"]
     for weight in valid_weights:
         subject = Subject(subject_id="001", weight=weight)
         assert check_subject_weight(subject) is None, f"Weight '{weight}' should pass the check"

--- a/tests/unit_tests/test_nwbfile_metadata.py
+++ b/tests/unit_tests/test_nwbfile_metadata.py
@@ -27,6 +27,7 @@ from nwbinspector.checks import (
     check_subject_sex,
     check_subject_species_exists,
     check_subject_species_form,
+    check_subject_weight,
 )
 from nwbinspector.checks._nwbfile_metadata import PROCESSING_MODULE_CONFIG
 from nwbinspector.testing import make_minimal_nwbfile
@@ -662,3 +663,65 @@ def test_check_file_extension_fail():
             result = check_file_extension(read_nwbfile)
             msg = f"The file extension '{ext}' does not follow the recommended naming convention."
             assert msg in result.message
+
+
+def test_check_subject_weight_pass():
+    """Test that valid weight formats pass the check."""
+    valid_weights = ["2.3 kg", "25 kg", "2.5kg", "100g", "1.5 lbs", "0.5 kg"]
+    for weight in valid_weights:
+        subject = Subject(subject_id="001", weight=weight)
+        assert check_subject_weight(subject) is None, f"Weight '{weight}' should pass the check"
+
+
+def test_check_subject_weight_none():
+    """Test that None weight passes the check (weight is optional)."""
+    subject = Subject(subject_id="001")
+    assert check_subject_weight(subject) is None
+
+
+def test_check_subject_weight_fail_no_unit():
+    """Test that weight without unit fails the check."""
+    subject = Subject(subject_id="001", weight="25")
+    assert check_subject_weight(subject) == InspectorMessage(
+        message=(
+            "Subject weight '25' does not follow the expected form '[numeric] [unit]'. "
+            "For example, '2.3 kg'. Without a unit, the weight is ambiguous."
+        ),
+        importance=Importance.CRITICAL,
+        check_function_name="check_subject_weight",
+        object_type="Subject",
+        object_name="subject",
+        location="/general/subject",
+    )
+
+
+def test_check_subject_weight_fail_multiple_decimals():
+    """Test that weight with multiple decimal points fails the check."""
+    subject = Subject(subject_id="001", weight="2.3.4 kg")
+    assert check_subject_weight(subject) == InspectorMessage(
+        message=(
+            "Subject weight '2.3.4 kg' does not follow the expected form '[numeric] [unit]'. "
+            "For example, '2.3 kg'. Without a unit, the weight is ambiguous."
+        ),
+        importance=Importance.CRITICAL,
+        check_function_name="check_subject_weight",
+        object_type="Subject",
+        object_name="subject",
+        location="/general/subject",
+    )
+
+
+def test_check_subject_weight_fail_text_only():
+    """Test that weight with only text fails the check."""
+    subject = Subject(subject_id="001", weight="heavy")
+    assert check_subject_weight(subject) == InspectorMessage(
+        message=(
+            "Subject weight 'heavy' does not follow the expected form '[numeric] [unit]'. "
+            "For example, '2.3 kg'. Without a unit, the weight is ambiguous."
+        ),
+        importance=Importance.CRITICAL,
+        check_function_name="check_subject_weight",
+        object_type="Subject",
+        object_name="subject",
+        location="/general/subject",
+    )

--- a/tests/unit_tests/test_nwbfile_metadata.py
+++ b/tests/unit_tests/test_nwbfile_metadata.py
@@ -728,3 +728,20 @@ def test_check_subject_weight_fail_text_only():
         object_name="subject",
         location="/general/subject",
     )
+
+
+def test_check_subject_weight_fail_no_space():
+    """Test that weight without space between number and unit fails the check."""
+    subject = Subject(subject_id="001", weight="25kg")
+    assert check_subject_weight(subject) == InspectorMessage(
+        message=(
+            "Subject weight '25kg' does not follow the expected form '[numeric] [unit]'. "
+            "For example, '2.3 kg'. Without a unit, the weight is ambiguous. "
+            "Valid units are: 'kg', 'g', 'mg', 'ug', 'μg', 'ng', 'pg'."
+        ),
+        importance=Importance.CRITICAL,
+        check_function_name="check_subject_weight",
+        object_type="Subject",
+        object_name="subject",
+        location="/general/subject",
+    )


### PR DESCRIPTION
Add new check that ensures subject weight follows the form '[numeric] [unit]' (e.g., '2.3 kg' or '25kg'). Without a unit, the weight is ambiguous.

- Add weight_form_regex pattern for validation
- Register check with CRITICAL importance
- Add unit tests for valid/invalid weight formats

Closes #370