### PR TITLE
feat: add check for unscaled ElectricalSeries data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added `check_units_table_duration` to detect if the duration of spike times in a Units table exceeds a threshold (default: 1 year), which may indicate spike_times are in the wrong units or there is a data quality issue.
 * Added `check_time_intervals_duration`, which makes sure that `TimeInterval` objects do not have a duration greater than 1 year.
 [#635](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/635)
+* Added `check_electrical_series_unscaled_data` to warn when ElectricalSeries has integer data type with default conversion (1.0) and offset (0.0), which suggests raw acquisition units are not properly scaled to Volts. Also considers `channel_conversion` for per-channel scaling. [#408](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/408)
 
 ### Improvements
 * Added documentation to API and CLI docs on how to use the dandi config option. [#624](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/624)

--- a/docs/best_practices/ecephys.rst
+++ b/docs/best_practices/ecephys.rst
@@ -113,3 +113,26 @@ Properly ordered spike times are essential for analyzing temporal patterns of ne
 intervals between spikes (inter-spike intervals).
 
 Check function: :py:meth:`~nwbinspector.checks._ecephys.check_ascending_spike_times`
+
+
+ElectricalSeries
+----------------
+
+.. _best_practice_electrical_series_unscaled_data:
+
+Data Type and Conversion
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+When storing raw electrophysiology data in an :ref:`nwb-schema:sec-ElectricalSeries`, it is common to use integer
+data types (e.g., ``int16``, ``uint16``) to save storage space. However, if using integer data types, you must set
+the ``conversion`` and/or ``offset`` fields to convert the raw data to Volts.
+
+If the data is stored as an integer type with default values of ``conversion=1.0`` and ``offset=0.0``, this likely
+indicates that the raw acquisition units are being stored without proper scaling to Volts. This is problematic
+because the NWB specification expects electrophysiology data to be in Volts (or to have conversion factors that
+convert to Volts).
+
+For per-channel conversion factors, use the ``channel_conversion`` field, which allows specifying different scaling
+factors for each channel. This is particularly useful when different channels have different gain settings.
+
+Check function: :py:meth:`~nwbinspector.checks._ecephys.check_electrical_series_unscaled_data`

--- a/src/nwbinspector/checks/__init__.py
+++ b/src/nwbinspector/checks/__init__.py
@@ -8,6 +8,7 @@ from ._ecephys import (
     check_ascending_spike_times,
     check_electrical_series_dims,
     check_electrical_series_reference_electrodes_table,
+    check_electrical_series_unscaled_data,
     check_negative_spike_times,
     check_spike_times_not_in_unobserved_interval,
     check_units_table_duration,
@@ -161,5 +162,6 @@ __all__ = [
     "check_spatial_series_dims",
     "check_spatial_series_degrees_magnitude",
     "check_ascending_spike_times",
+    "check_electrical_series_unscaled_data",
     "check_rate_is_positive",
 ]

--- a/src/nwbinspector/checks/_ecephys.py
+++ b/src/nwbinspector/checks/_ecephys.py
@@ -144,6 +144,65 @@ def check_ascending_spike_times(units_table: Units, nelems: Optional[int] = NELE
     return None
 
 
+@register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=ElectricalSeries)
+def check_electrical_series_unscaled_data(electrical_series: ElectricalSeries) -> Optional[InspectorMessage]:
+    """
+    Check if an ElectricalSeries has integer data with default conversion and offset values.
+
+    If the data type is an integer (int16, uint16, etc.) and both conversion and offset
+    are set to their default values (1.0 and 0.0 respectively), this is likely a mistake
+    because the raw integer values are probably not in Volts.
+
+    However, if channel_conversion is set with non-default values (not all 1.0),
+    then the conversion factors are properly specified and no warning is needed.
+
+    Best Practice: :ref:`best_practice_electrical_series_unscaled_data`
+    """
+    data = electrical_series.data
+    if data is None or len(data) == 0:
+        return None
+
+    # Get dtype - handle both numpy arrays and HDF5 datasets
+    if hasattr(data, "dtype"):
+        dtype = data.dtype
+    else:
+        dtype = np.asarray(data[:1]).dtype
+
+    # Only check integer types
+    if not np.issubdtype(dtype, np.integer):
+        return None
+
+    # Check if using default conversion and offset
+    # These are inherited from TimeSeries
+    conversion = getattr(electrical_series, "conversion", 1.0)
+    offset = getattr(electrical_series, "offset", 0.0)
+
+    # Default values
+    default_conversion = 1.0
+    default_offset = 0.0
+
+    # If conversion or offset is not default, data scaling is specified
+    if conversion != default_conversion or offset != default_offset:
+        return None
+
+    # Check channel_conversion - if it exists and has non-default values, that's fine
+    channel_conversion = getattr(electrical_series, "channel_conversion", None)
+    if channel_conversion is not None:
+        channel_conversion_array = np.asarray(channel_conversion)
+        # If any channel conversion is not 1.0, the scaling is properly specified
+        if not np.allclose(channel_conversion_array, 1.0):
+            return None
+
+    return InspectorMessage(
+        message=(
+            f"ElectricalSeries '{electrical_series.name}' has data with dtype '{dtype}' and "
+            f"conversion={conversion} and offset={offset}. This suggests the data is in raw acquisition units "
+            "which is not in Volts. Please set the 'conversion' and/or 'offset' fields to convert "
+            "the data to Volts, or use 'channel_conversion' for per-channel conversion factors."
+        )
+    )
+
+
 @register_check(importance=Importance.CRITICAL, neurodata_type=Units)
 def check_units_table_duration(
     units_table: Units, duration_threshold: float = DURATION_THRESHOLD

--- a/tests/unit_tests/test_ecephys.py
+++ b/tests/unit_tests/test_ecephys.py
@@ -523,8 +523,19 @@ class TestCheckElectricalSeriesUnscaledData(TestCase):
             rate=30.0,
         )
         result = check_electrical_series_unscaled_data(electrical_series)
-        assert result is not None
-        assert "uint16" in result.message
+        assert result == InspectorMessage(
+            message=(
+                "ElectricalSeries 'elec_series' has data with dtype 'uint16' and "
+                "conversion=1.0 and offset=0.0. This suggests the data is in raw acquisition units "
+                "which is not in Volts. Please set the 'conversion' and/or 'offset' fields to convert "
+                "the data to Volts, or use 'channel_conversion' for per-channel conversion factors."
+            ),
+            importance=Importance.BEST_PRACTICE_VIOLATION,
+            check_function_name="check_electrical_series_unscaled_data",
+            object_type="ElectricalSeries",
+            object_name="elec_series",
+            location="/",
+        )
 
     def test_fail_with_channel_conversion_all_ones(self):
         """Test that int data with channel_conversion all 1.0 triggers a warning."""
@@ -537,8 +548,19 @@ class TestCheckElectricalSeriesUnscaledData(TestCase):
             channel_conversion=[1.0, 1.0, 1.0],  # All default values
         )
         result = check_electrical_series_unscaled_data(electrical_series)
-        assert result is not None
-        assert "int16" in result.message
+        assert result == InspectorMessage(
+            message=(
+                "ElectricalSeries 'elec_series' has data with dtype 'int16' and "
+                "conversion=1.0 and offset=0.0. This suggests the data is in raw acquisition units "
+                "which is not in Volts. Please set the 'conversion' and/or 'offset' fields to convert "
+                "the data to Volts, or use 'channel_conversion' for per-channel conversion factors."
+            ),
+            importance=Importance.BEST_PRACTICE_VIOLATION,
+            check_function_name="check_electrical_series_unscaled_data",
+            object_type="ElectricalSeries",
+            object_name="elec_series",
+            location="/",
+        )
 
     def test_pass_with_empty_data(self):
         """Test that empty data does not trigger a warning."""

--- a/tests/unit_tests/test_ecephys.py
+++ b/tests/unit_tests/test_ecephys.py
@@ -14,6 +14,7 @@ from nwbinspector.checks import (
     check_data_orientation,
     check_electrical_series_dims,
     check_electrical_series_reference_electrodes_table,
+    check_electrical_series_unscaled_data,
     check_negative_spike_times,
     check_spike_times_not_in_unobserved_interval,
     check_units_table_duration,
@@ -422,3 +423,130 @@ def test_check_units_table_duration_second_unit_no_spikes():
 
     # Should pass - duration is only 2 seconds
     assert check_units_table_duration(units) is None
+
+
+class TestCheckElectricalSeriesUnscaledData(TestCase):
+    """Tests for check_electrical_series_unscaled_data."""
+
+    def setUp(self):
+        nwbfile = NWBFile(
+            session_description="", identifier=str(uuid4()), session_start_time=datetime.now().astimezone()
+        )
+        device = nwbfile.create_device(name="dev")
+        group = nwbfile.create_electrode_group(
+            name="electrode_group", description="desc", location="loc", device=device
+        )
+        for _ in range(3):
+            nwbfile.add_electrode(location="unknown", group=group)
+        self.nwbfile = nwbfile
+        self.electrodes = self.nwbfile.create_electrode_table_region(region=[0, 1, 2], description="three elecs")
+
+    def test_pass_with_float_data(self):
+        """Test that float data does not trigger a warning."""
+        electrical_series = ElectricalSeries(
+            name="elec_series",
+            description="desc",
+            data=np.zeros((100, 3), dtype=np.float64),
+            electrodes=self.electrodes,
+            rate=30.0,
+        )
+        assert check_electrical_series_unscaled_data(electrical_series) is None
+
+    def test_pass_with_int_data_and_non_default_conversion(self):
+        """Test that int data with non-default conversion does not trigger a warning."""
+        electrical_series = ElectricalSeries(
+            name="elec_series",
+            description="desc",
+            data=np.zeros((100, 3), dtype=np.int16),
+            electrodes=self.electrodes,
+            rate=30.0,
+            conversion=1e-6,  # Non-default conversion
+        )
+        assert check_electrical_series_unscaled_data(electrical_series) is None
+
+    def test_pass_with_int_data_and_non_default_offset(self):
+        """Test that int data with non-default offset does not trigger a warning."""
+        electrical_series = ElectricalSeries(
+            name="elec_series",
+            description="desc",
+            data=np.zeros((100, 3), dtype=np.int16),
+            electrodes=self.electrodes,
+            rate=30.0,
+            offset=0.5,  # Non-default offset
+        )
+        assert check_electrical_series_unscaled_data(electrical_series) is None
+
+    def test_pass_with_int_data_and_channel_conversion(self):
+        """Test that int data with channel_conversion set does not trigger a warning."""
+        electrical_series = ElectricalSeries(
+            name="elec_series",
+            description="desc",
+            data=np.zeros((100, 3), dtype=np.int16),
+            electrodes=self.electrodes,
+            rate=30.0,
+            channel_conversion=[1e-6, 1e-6, 1e-6],  # Non-default channel conversion
+        )
+        assert check_electrical_series_unscaled_data(electrical_series) is None
+
+    def test_fail_with_int16_data_and_default_conversion(self):
+        """Test that int16 data with default conversion triggers a warning."""
+        electrical_series = ElectricalSeries(
+            name="elec_series",
+            description="desc",
+            data=np.zeros((100, 3), dtype=np.int16),
+            electrodes=self.electrodes,
+            rate=30.0,
+        )
+        result = check_electrical_series_unscaled_data(electrical_series)
+        assert result is not None
+        assert result == InspectorMessage(
+            message=(
+                "ElectricalSeries 'elec_series' has data with dtype 'int16' and "
+                "conversion=1.0 and offset=0.0. This suggests the data is in raw acquisition units "
+                "which is not in Volts. Please set the 'conversion' and/or 'offset' fields to convert "
+                "the data to Volts, or use 'channel_conversion' for per-channel conversion factors."
+            ),
+            importance=Importance.BEST_PRACTICE_VIOLATION,
+            check_function_name="check_electrical_series_unscaled_data",
+            object_type="ElectricalSeries",
+            object_name="elec_series",
+            location="/",
+        )
+
+    def test_fail_with_uint16_data_and_default_conversion(self):
+        """Test that uint16 data with default conversion triggers a warning."""
+        electrical_series = ElectricalSeries(
+            name="elec_series",
+            description="desc",
+            data=np.zeros((100, 3), dtype=np.uint16),
+            electrodes=self.electrodes,
+            rate=30.0,
+        )
+        result = check_electrical_series_unscaled_data(electrical_series)
+        assert result is not None
+        assert "uint16" in result.message
+
+    def test_fail_with_channel_conversion_all_ones(self):
+        """Test that int data with channel_conversion all 1.0 triggers a warning."""
+        electrical_series = ElectricalSeries(
+            name="elec_series",
+            description="desc",
+            data=np.zeros((100, 3), dtype=np.int16),
+            electrodes=self.electrodes,
+            rate=30.0,
+            channel_conversion=[1.0, 1.0, 1.0],  # All default values
+        )
+        result = check_electrical_series_unscaled_data(electrical_series)
+        assert result is not None
+        assert "int16" in result.message
+
+    def test_pass_with_empty_data(self):
+        """Test that empty data does not trigger a warning."""
+        electrical_series = ElectricalSeries(
+            name="elec_series",
+            description="desc",
+            data=np.zeros((0, 3), dtype=np.int16),
+            electrodes=self.electrodes,
+            rate=30.0,
+        )
+        assert check_electrical_series_unscaled_data(electrical_series) is None

--- a/tests/unit_tests/test_ecephys.py
+++ b/tests/unit_tests/test_ecephys.py
@@ -561,4 +561,3 @@ class TestCheckElectricalSeriesUnscaledData(TestCase):
             object_name="elec_series",
             location="/",
         )
-

--- a/tests/unit_tests/test_ecephys.py
+++ b/tests/unit_tests/test_ecephys.py
@@ -562,13 +562,3 @@ class TestCheckElectricalSeriesUnscaledData(TestCase):
             location="/",
         )
 
-    def test_pass_with_empty_data(self):
-        """Test that empty data does not trigger a warning."""
-        electrical_series = ElectricalSeries(
-            name="elec_series",
-            description="desc",
-            data=np.zeros((0, 3), dtype=np.int16),
-            electrodes=self.electrodes,
-            rate=30.0,
-        )
-        assert check_electrical_series_unscaled_data(electrical_series) is None


### PR DESCRIPTION
Add `check_electrical_series_unscaled_data` to warn when ElectricalSeries has integer data type with default conversion (1.0) and offset (0.0), which suggests raw acquisition units are not properly scaled to Volts.

The check also considers `channel_conversion` for per-channel scaling to avoid false positives when proper conversion factors are specified.

Includes documentation for the best practice and changelog entry.

Closes #408
Closes #395