### PR TITLE
feat: add check for starting_frame without external_file in ImageSeries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added `check_units_table_duration` to detect if the duration of spike times in a Units table exceeds a threshold (default: 1 year), which may indicate spike_times are in the wrong units or there is a data quality issue.
 * Added `check_time_intervals_duration`, which makes sure that `TimeInterval` objects do not have a duration greater than 1 year.
 [#635](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/635)
+* Added `check_image_series_starting_frame_without_external_file` to verify that `starting_frame` is not set when `external_file` is not used in an `ImageSeries`. [#235](https://github.com/NeurodataWithoutBorders/nwbinspector/issues/235)
 
 ### Improvements
 * Added documentation to API and CLI docs on how to use the dandi config option. [#624](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/624)

--- a/docs/best_practices/image_series.rst
+++ b/docs/best_practices/image_series.rst
@@ -33,3 +33,15 @@ Use relative path for external mode
 When using ``external_file`` the paths passed in the ``external_file`` option should be relative to the location of the nwb file.
 
 Check function: :py:meth:`~nwbinspector.checks._image_series.check_image_series_external_file_relative`
+
+
+.. _best_practice_starting_frame_only_with_external_file:
+
+Starting frame only with external file
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``starting_frame`` attribute of an :ref:`nwb-schema:sec-ImageSeries` is only relevant when using external files.
+If there is no external file, there should be no starting frame set. This is a legacy issue that was possible in
+older versions of PyNWB (< 2.2.0).
+
+Check function: :py:meth:`~nwbinspector.checks._image_series.check_image_series_starting_frame_without_external_file`

--- a/src/nwbinspector/checks/__init__.py
+++ b/src/nwbinspector/checks/__init__.py
@@ -24,6 +24,7 @@ from ._image_series import (
     check_image_series_data_size,
     check_image_series_external_file_relative,
     check_image_series_external_file_valid,
+    check_image_series_starting_frame_without_external_file,
 )
 from ._images import (
     check_index_series_points_to_image,
@@ -103,6 +104,7 @@ __all__ = [
     "check_image_series_data_size",
     "check_image_series_external_file_relative",
     "check_image_series_external_file_valid",
+    "check_image_series_starting_frame_without_external_file",
     "check_order_of_images_unique",
     "check_order_of_images_len",
     "check_index_series_points_to_image",

--- a/src/nwbinspector/checks/_image_series.py
+++ b/src/nwbinspector/checks/_image_series.py
@@ -78,3 +78,22 @@ def check_image_series_data_size(image_series: ImageSeries, gb_lower_bound: floa
         return InspectorMessage(message="ImageSeries is very large. Consider using external mode for better storage.")
 
     return None
+
+
+@register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=ImageSeries)
+def check_image_series_starting_frame_without_external_file(image_series: ImageSeries) -> Optional[InspectorMessage]:
+    """
+    Check if starting_frame is set when external_file is not used.
+
+    The starting_frame attribute is only relevant when using external files.
+    If there is no external file, there should be no starting_frame.
+
+    Best Practice: :ref:`best_practice_starting_frame_only_with_external_file`
+    """
+    if image_series.external_file is None and image_series.starting_frame is not None and len(image_series.starting_frame) > 0:
+        return InspectorMessage(
+            message="ImageSeries has starting_frame set but no external_file. "
+            "starting_frame is only relevant when using external files."
+        )
+
+    return None

--- a/src/nwbinspector/checks/_image_series.py
+++ b/src/nwbinspector/checks/_image_series.py
@@ -90,7 +90,11 @@ def check_image_series_starting_frame_without_external_file(image_series: ImageS
 
     Best Practice: :ref:`best_practice_starting_frame_only_with_external_file`
     """
-    if image_series.external_file is None and image_series.starting_frame is not None and len(image_series.starting_frame) > 0:
+    if (
+        image_series.external_file is None
+        and image_series.starting_frame is not None
+        and len(image_series.starting_frame) > 0
+    ):
         return InspectorMessage(
             message="ImageSeries has starting_frame set but no external_file. "
             "starting_frame is only relevant when using external files."

--- a/tests/unit_tests/test_image_series.py
+++ b/tests/unit_tests/test_image_series.py
@@ -13,6 +13,7 @@ from nwbinspector.checks import (
     check_image_series_data_size,
     check_image_series_external_file_relative,
     check_image_series_external_file_valid,
+    check_image_series_starting_frame_without_external_file,
     check_timestamps_match_first_dimension,
 )
 from nwbinspector.testing import make_minimal_nwbfile
@@ -152,6 +153,50 @@ def test_check_large_image_series_stored_internally():
     )
 
     assert inspector_message == expected_message
+
+
+def test_check_image_series_starting_frame_without_external_file_pass_no_external_no_starting():
+    """Test that an ImageSeries without external_file and without starting_frame passes."""
+    image_series = ImageSeries(name="TestImageSeries", rate=1.0, data=np.zeros(shape=(3, 3, 3, 3)), unit="TestUnit")
+    assert check_image_series_starting_frame_without_external_file(image_series=image_series) is None
+
+
+def test_check_image_series_starting_frame_without_external_file_pass_with_external():
+    """Test that an ImageSeries with external_file passes regardless of starting_frame."""
+    image_series = ImageSeries(
+        name="TestImageSeries",
+        external_file=["test.mp4"],
+        format="external",
+        starting_frame=[0],
+        rate=1.0,
+        unit="TestUnit",
+    )
+    assert check_image_series_starting_frame_without_external_file(image_series=image_series) is None
+
+
+def test_check_image_series_starting_frame_without_external_file_trigger():
+    """Test that an ImageSeries with starting_frame but no external_file triggers."""
+    # Create ImageSeries with external_file first, then modify
+    image_series = ImageSeries(
+        name="TestImageSeries",
+        rate=1.0,
+        data=np.zeros(shape=(3, 3, 3, 3)),
+        unit="TestUnit",
+    )
+    # Manually set starting_frame to simulate a legacy file
+    image_series.starting_frame = [0]
+
+    result = check_image_series_starting_frame_without_external_file(image_series=image_series)
+    expected_message = InspectorMessage(
+        importance=Importance.BEST_PRACTICE_VIOLATION,
+        message="ImageSeries has starting_frame set but no external_file. "
+        "starting_frame is only relevant when using external files.",
+        check_function_name="check_image_series_starting_frame_without_external_file",
+        object_type="ImageSeries",
+        object_name="TestImageSeries",
+        location="/",
+    )
+    assert result == expected_message
 
 
 class TestCheckImageSeriesStoredInternally(unittest.TestCase):


### PR DESCRIPTION
Add check_image_series_starting_frame_without_external_file to detect when starting_frame is set on an ImageSeries without external_file. The starting_frame attribute is only relevant when using external files, and setting it otherwise indicates a legacy issue from older PyNWB versions.

Includes documentation, unit tests, and changelog entry.

Closes #235