### PR TITLE
fix: cast initial index to uint64 in units table check

### DIFF
--- a/src/nwbinspector/checks/_ecephys.py
+++ b/src/nwbinspector/checks/_ecephys.py
@@ -183,7 +183,7 @@ def check_units_table_duration(
     # Build indices for first and last spike of each unit
     # First spike indices: 0 for first unit, then idxs[:-1] for subsequent units
     # Last spike indices: idxs - 1 for each unit
-    first_spike_idxs = np.concatenate([[0], idxs[idxs != idxs[-1]]])
+    first_spike_idxs = np.concatenate([[np.uint64(0)], idxs[idxs != idxs[-1]]])
     last_spike_idxs = idxs[idxs != 0] - 1
 
     # Combine into single array of indices to read, then read all at once


### PR DESCRIPTION
Explicitly cast the starting index 0 to `np.uint64` when calculating `first_spike_idxs`. This ensures type consistency with the existing `idxs` array during concatenation, preventing potential type mismatch or implicit casting issues.

## Motivation

fix #658 
