### PR TITLE
Nwb schema in register checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * Added documentation to API and CLI docs on how to use the dandi config option. [#624](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/624)
 * Updated report summary to include number of files detected and indicate when no issues are found. [#629](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/629)
 * Made subject information checks (`check_subject_exists`, `check_subject_id_exists`, `check_subject_sex`, `check_subject_age`) CRITICAL by default to be consistent with DANDI requirements. [#648](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/648)
-* Added `nwb_schema_version_lt` and `nwb_schema_version_gt` parameters to `register_check` to conditionally run checks based on the NWB schema version of the file being inspected.
+* Added `nwb_schema_version_lt` and `nwb_schema_version_gt` parameters to `register_check` to conditionally run checks based on the NWB schema version of the file being inspected. [#661](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/661)
 
 ### Fixes
 * Fixed `check_timestamp_of_the_first_sample_is_not_negative` to handle empty timestamps arrays instead of throwing an `IndexError`. [#582](https://github.com/NeurodataWithoutBorders/nwbinspector/issues/582)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Added documentation to API and CLI docs on how to use the dandi config option. [#624](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/624)
 * Updated report summary to include number of files detected and indicate when no issues are found. [#629](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/629)
 * Made subject information checks (`check_subject_exists`, `check_subject_id_exists`, `check_subject_sex`, `check_subject_age`) CRITICAL by default to be consistent with DANDI requirements. [#648](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/648)
+* Added `nwb_schema_version_lt` and `nwb_schema_version_gt` parameters to `register_check` to conditionally run checks based on the NWB schema version of the file being inspected.
 
 ### Fixes
 * Fixed `check_timestamp_of_the_first_sample_is_not_negative` to handle empty timestamps arrays instead of throwing an `IndexError`. [#582](https://github.com/NeurodataWithoutBorders/nwbinspector/issues/582)

--- a/src/nwbinspector/_nwb_inspection.py
+++ b/src/nwbinspector/_nwb_inspection.py
@@ -15,6 +15,8 @@ from tqdm import tqdm
 from ._configuration import configure_checks
 from ._registration import Importance, InspectorMessage, available_checks
 from .tools._read_nwbfile import read_nwbfile, read_nwbfile_and_io
+from packaging import version
+
 from .utils import (
     OptionalListOfStrings,
     PathType,
@@ -401,6 +403,7 @@ def run_checks(
     checks: list,
     progress_bar_class: Optional[Type[tqdm]] = None,
     progress_bar_options: Optional[dict] = None,
+    nwb_schema_version: Optional[version.Version] = None,
 ) -> Iterable[Union[InspectorMessage, None]]:
     """
     Run checks on an open NWBFile object.
@@ -416,6 +419,9 @@ def run_checks(
         Defaults to not displaying progress per set of checks over an individual file.
     progress_bar_options : dict, optional
         Dictionary of keyword arguments to pass directly to the `progress_bar_class`.
+    nwb_schema_version : packaging.version.Version, optional
+        The NWB schema version of the file being inspected.
+        If not provided, will be read from nwbfile.read_io.nwb_version if available.
 
     Yields
     ------
@@ -428,7 +434,21 @@ def run_checks(
     else:
         check_progress = checks
 
+    # Get NWB schema version from the nwbfile's read_io if not provided
+    if nwb_schema_version is None:
+        nwb_version_info = getattr(getattr(nwbfile, "read_io", None), "nwb_version", None)
+        nwb_schema_version = version.parse(nwb_version_info[0]) if nwb_version_info else None
+
     for check_function in check_progress:
+        # Skip check if schema version constraints are not met
+        if nwb_schema_version is not None:
+            version_lt = getattr(check_function, "nwb_schema_version_lt", None)
+            version_gt = getattr(check_function, "nwb_schema_version_gt", None)
+            if version_lt is not None and nwb_schema_version >= version.parse(version_lt):
+                continue
+            if version_gt is not None and nwb_schema_version <= version.parse(version_gt):
+                continue
+
         for nwbfile_object in nwbfile.objects.values():
             if check_function.neurodata_type is not None and not issubclass(
                 type(nwbfile_object), check_function.neurodata_type

--- a/src/nwbinspector/_nwb_inspection.py
+++ b/src/nwbinspector/_nwb_inspection.py
@@ -421,6 +421,7 @@ def run_checks(
     nwb_schema_version : packaging.version.Version, optional
         The NWB schema version of the file being inspected.
         If not provided, will be read from nwbfile.read_io.nwb_version if available.
+        This arg is mostly used for tests. Usually it is best to leave as None.
 
     Yields
     ------

--- a/src/nwbinspector/_nwb_inspection.py
+++ b/src/nwbinspector/_nwb_inspection.py
@@ -10,13 +10,12 @@ from warnings import filterwarnings, warn
 
 import pynwb
 from natsort import natsorted
+from packaging import version
 from tqdm import tqdm
 
 from ._configuration import configure_checks
 from ._registration import Importance, InspectorMessage, available_checks
 from .tools._read_nwbfile import read_nwbfile, read_nwbfile_and_io
-from packaging import version
-
 from .utils import (
     OptionalListOfStrings,
     PathType,

--- a/src/nwbinspector/_registration.py
+++ b/src/nwbinspector/_registration.py
@@ -17,7 +17,12 @@ available_checks = list()
 
 # TODO: neurodata_type could have annotation hdmf.utils.ExtenderMeta, which seems to apply to all currently checked
 # objects. We can wait and see how well that holds up before adding it in officially.
-def register_check(importance: Importance, neurodata_type: object) -> Callable:
+def register_check(
+    importance: Importance,
+    neurodata_type: object,
+    nwb_schema_version_lt: Optional[str] = None,
+    nwb_schema_version_gt: Optional[str] = None,
+) -> Callable:
     """
     Wrap a check function with this decorator to add it to the check registry and automatically parse some output.
 
@@ -35,6 +40,12 @@ def register_check(importance: Importance, neurodata_type: object) -> Callable:
         The most generic HDMF/PyNWB class the check function applies to.
         Should generally match the type annotation of the check.
         If this check is intended to apply to any general NWBFile object, set neurodata_type to None.
+    nwb_schema_version_lt : str, optional
+        Only run this check on NWB files with schema version less than this value.
+        Useful for checks that only apply to older schema versions.
+    nwb_schema_version_gt : str, optional
+        Only run this check on NWB files with schema version greater than this value.
+        Useful for checks that only apply to newer schema versions.
     """
 
     def register_check_and_auto_parse(check_function: Callable) -> Callable:
@@ -50,6 +61,8 @@ def register_check(importance: Importance, neurodata_type: object) -> Callable:
             )
         check_function.importance = importance  # type: ignore
         check_function.neurodata_type = neurodata_type  # type: ignore
+        check_function.nwb_schema_version_lt = nwb_schema_version_lt  # type: ignore
+        check_function.nwb_schema_version_gt = nwb_schema_version_gt  # type: ignore
 
         @wraps(check_function)
         def auto_parse_some_output(

--- a/src/nwbinspector/checks/_ecephys.py
+++ b/src/nwbinspector/checks/_ecephys.py
@@ -183,7 +183,7 @@ def check_units_table_duration(
     # Build indices for first and last spike of each unit
     # First spike indices: 0 for first unit, then idxs[:-1] for subsequent units
     # Last spike indices: idxs - 1 for each unit
-    first_spike_idxs = np.concatenate([[0], idxs[idxs != idxs[-1]]])
+    first_spike_idxs = np.concatenate([[np.uint64(0)], idxs[idxs != idxs[-1]]])
     last_spike_idxs = idxs[idxs != 0] - 1
 
     # Combine into single array of indices to read, then read all at once

--- a/tests/test_register_check.py
+++ b/tests/test_register_check.py
@@ -1,10 +1,14 @@
+from datetime import datetime
 from enum import Enum
 
 from hdmf.common import DynamicTable
 from hdmf.testing import TestCase
+from packaging import version
+import pynwb
 from pynwb import TimeSeries
 
 from nwbinspector import Importance, InspectorMessage, Severity, register_check
+from nwbinspector._nwb_inspection import run_checks
 
 
 class TestRegisterClass(TestCase):
@@ -179,3 +183,227 @@ class TestRegisterClass(TestCase):
             pass
 
         assert good_check_function_2 in available_checks
+
+    def test_register_schema_version_lt(self):
+        """Test that nwb_schema_version_lt is stored on the check function."""
+
+        @register_check(
+            importance=Importance.BEST_PRACTICE_SUGGESTION,
+            neurodata_type=TimeSeries,
+            nwb_schema_version_lt="2.5.0",
+        )
+        def check_with_version_lt(time_series: TimeSeries):
+            return InspectorMessage(message="test")
+
+        self.assertEqual(check_with_version_lt.nwb_schema_version_lt, "2.5.0")
+        self.assertIsNone(check_with_version_lt.nwb_schema_version_gt)
+
+    def test_register_schema_version_gt(self):
+        """Test that nwb_schema_version_gt is stored on the check function."""
+
+        @register_check(
+            importance=Importance.BEST_PRACTICE_SUGGESTION,
+            neurodata_type=TimeSeries,
+            nwb_schema_version_gt="2.3.0",
+        )
+        def check_with_version_gt(time_series: TimeSeries):
+            return InspectorMessage(message="test")
+
+        self.assertIsNone(check_with_version_gt.nwb_schema_version_lt)
+        self.assertEqual(check_with_version_gt.nwb_schema_version_gt, "2.3.0")
+
+    def test_register_schema_version_both(self):
+        """Test that both version constraints can be set."""
+
+        @register_check(
+            importance=Importance.BEST_PRACTICE_SUGGESTION,
+            neurodata_type=TimeSeries,
+            nwb_schema_version_lt="2.5.0",
+            nwb_schema_version_gt="2.3.0",
+        )
+        def check_with_both_versions(time_series: TimeSeries):
+            return InspectorMessage(message="test")
+
+        self.assertEqual(check_with_both_versions.nwb_schema_version_lt, "2.5.0")
+        self.assertEqual(check_with_both_versions.nwb_schema_version_gt, "2.3.0")
+
+
+class TestSchemaVersionFiltering(TestCase):
+    """Test that run_checks properly filters checks based on schema version."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.nwbfile = pynwb.NWBFile(
+            session_description="test",
+            identifier="test",
+            session_start_time=datetime.now(),
+        )
+
+    def test_run_checks_skips_check_when_version_lt_not_met(self):
+        """Test that a check with nwb_schema_version_lt is skipped when file version is >= threshold."""
+
+        @register_check(
+            importance=Importance.BEST_PRACTICE_SUGGESTION,
+            neurodata_type=None,
+            nwb_schema_version_lt="2.5.0",
+        )
+        def check_for_old_files_only(nwbfile: pynwb.NWBFile):
+            return InspectorMessage(message="This should be skipped for newer files")
+
+        # File version 2.6.0 is >= 2.5.0, so check should be skipped
+        results = list(
+            run_checks(
+                nwbfile=self.nwbfile,
+                checks=[check_for_old_files_only],
+                nwb_schema_version=version.parse("2.6.0"),
+            )
+        )
+        self.assertEqual(len(results), 0)
+
+    def test_run_checks_runs_check_when_version_lt_is_met(self):
+        """Test that a check with nwb_schema_version_lt is run when file version is < threshold."""
+
+        @register_check(
+            importance=Importance.BEST_PRACTICE_SUGGESTION,
+            neurodata_type=None,
+            nwb_schema_version_lt="2.5.0",
+        )
+        def check_for_old_files_lt(nwbfile: pynwb.NWBFile):
+            return InspectorMessage(message="This should run for older files")
+
+        # File version 2.4.0 is < 2.5.0, so check should run
+        results = list(
+            run_checks(
+                nwbfile=self.nwbfile,
+                checks=[check_for_old_files_lt],
+                nwb_schema_version=version.parse("2.4.0"),
+            )
+        )
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].message, "This should run for older files")
+
+    def test_run_checks_skips_check_when_version_gt_not_met(self):
+        """Test that a check with nwb_schema_version_gt is skipped when file version is <= threshold."""
+
+        @register_check(
+            importance=Importance.BEST_PRACTICE_SUGGESTION,
+            neurodata_type=None,
+            nwb_schema_version_gt="2.5.0",
+        )
+        def check_for_new_files_only(nwbfile: pynwb.NWBFile):
+            return InspectorMessage(message="This should be skipped for older files")
+
+        # File version 2.4.0 is <= 2.5.0, so check should be skipped
+        results = list(
+            run_checks(
+                nwbfile=self.nwbfile,
+                checks=[check_for_new_files_only],
+                nwb_schema_version=version.parse("2.4.0"),
+            )
+        )
+        self.assertEqual(len(results), 0)
+
+    def test_run_checks_runs_check_when_version_gt_is_met(self):
+        """Test that a check with nwb_schema_version_gt is run when file version is > threshold."""
+
+        @register_check(
+            importance=Importance.BEST_PRACTICE_SUGGESTION,
+            neurodata_type=None,
+            nwb_schema_version_gt="2.5.0",
+        )
+        def check_for_new_files_gt(nwbfile: pynwb.NWBFile):
+            return InspectorMessage(message="This should run for newer files")
+
+        # File version 2.6.0 is > 2.5.0, so check should run
+        results = list(
+            run_checks(
+                nwbfile=self.nwbfile,
+                checks=[check_for_new_files_gt],
+                nwb_schema_version=version.parse("2.6.0"),
+            )
+        )
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].message, "This should run for newer files")
+
+    def test_run_checks_with_both_version_constraints(self):
+        """Test that a check with both version constraints works correctly."""
+
+        @register_check(
+            importance=Importance.BEST_PRACTICE_SUGGESTION,
+            neurodata_type=None,
+            nwb_schema_version_lt="2.7.0",
+            nwb_schema_version_gt="2.3.0",
+        )
+        def check_for_version_range(nwbfile: pynwb.NWBFile):
+            return InspectorMessage(message="This should run for versions in range")
+
+        # File version 2.5.0 is > 2.3.0 and < 2.7.0, so check should run
+        results = list(
+            run_checks(
+                nwbfile=self.nwbfile,
+                checks=[check_for_version_range],
+                nwb_schema_version=version.parse("2.5.0"),
+            )
+        )
+        self.assertEqual(len(results), 1)
+
+        # File version 2.2.0 is <= 2.3.0, so check should be skipped
+        @register_check(
+            importance=Importance.BEST_PRACTICE_SUGGESTION,
+            neurodata_type=None,
+            nwb_schema_version_lt="2.7.0",
+            nwb_schema_version_gt="2.3.0",
+        )
+        def check_for_version_range_2(nwbfile: pynwb.NWBFile):
+            return InspectorMessage(message="This should be skipped")
+
+        results = list(
+            run_checks(
+                nwbfile=self.nwbfile,
+                checks=[check_for_version_range_2],
+                nwb_schema_version=version.parse("2.2.0"),
+            )
+        )
+        self.assertEqual(len(results), 0)
+
+    def test_run_checks_without_version_constraints_always_runs(self):
+        """Test that a check without version constraints always runs regardless of file version."""
+
+        @register_check(
+            importance=Importance.BEST_PRACTICE_SUGGESTION,
+            neurodata_type=None,
+        )
+        def check_without_version_constraints(nwbfile: pynwb.NWBFile):
+            return InspectorMessage(message="This should always run")
+
+        # Should run with any version
+        for ver in ["2.0.0", "2.5.0", "3.0.0"]:
+            results = list(
+                run_checks(
+                    nwbfile=self.nwbfile,
+                    checks=[check_without_version_constraints],
+                    nwb_schema_version=version.parse(ver),
+                )
+            )
+            self.assertEqual(len(results), 1)
+
+    def test_run_checks_without_schema_version_runs_all_checks(self):
+        """Test that when no schema version is provided, all checks run regardless of constraints."""
+
+        @register_check(
+            importance=Importance.BEST_PRACTICE_SUGGESTION,
+            neurodata_type=None,
+            nwb_schema_version_lt="2.0.0",  # Very restrictive constraint
+        )
+        def check_with_restrictive_lt(nwbfile: pynwb.NWBFile):
+            return InspectorMessage(message="Should run when no version provided")
+
+        # When nwb_schema_version is None, checks should run regardless of constraints
+        results = list(
+            run_checks(
+                nwbfile=self.nwbfile,
+                checks=[check_with_restrictive_lt],
+                nwb_schema_version=None,
+            )
+        )
+        self.assertEqual(len(results), 1)

--- a/tests/test_register_check.py
+++ b/tests/test_register_check.py
@@ -1,10 +1,10 @@
 from datetime import datetime
 from enum import Enum
 
+import pynwb
 from hdmf.common import DynamicTable
 from hdmf.testing import TestCase
 from packaging import version
-import pynwb
 from pynwb import TimeSeries
 
 from nwbinspector import Importance, InspectorMessage, Severity, register_check


### PR DESCRIPTION
Add args to `register_check` so the checks can be filtered by what version of the NWB schema they apply to