### PR TITLE
Allow "/" as valid subject age for unspecified age range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Added `nwb_schema_version_lt` and `nwb_schema_version_gt` parameters to `register_check` to conditionally run checks based on the NWB schema version of the file being inspected. [#661](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/661)
 
 ### Fixes
+* Fixed `check_subject_age` to allow `"/"` and `"/P3D"` style age ranges where the lower bound is unspecified. [#673](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/673)
 * Fixed `check_timestamp_of_the_first_sample_is_not_negative` to handle empty timestamps arrays instead of throwing an `IndexError`. [#582](https://github.com/NeurodataWithoutBorders/nwbinspector/issues/582)
 * Fixed file count error when checking for non-unique identifiers in a folder [#629](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/629)
 * Improved `check_data_orientation` error message to include the TimeSeries name, current shape, and a suggestion for transposing the data. [#1430](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/1430)

--- a/src/nwbinspector/checks/_nwbfile_metadata.py
+++ b/src/nwbinspector/checks/_nwbfile_metadata.py
@@ -180,8 +180,12 @@ def check_subject_age(subject: Subject) -> Optional[InspectorMessage]:
     if "/" in subject.age:
         subject_lower_age_bound, subject_upper_age_bound = subject.age.split("/")
 
-        lower_valid = re.fullmatch(pattern=duration_regex, string=subject_lower_age_bound) or subject_lower_age_bound == ""
-        upper_valid = re.fullmatch(pattern=duration_regex, string=subject_upper_age_bound) or subject_upper_age_bound == ""
+        lower_valid = (
+            re.fullmatch(pattern=duration_regex, string=subject_lower_age_bound) or subject_lower_age_bound == ""
+        )
+        upper_valid = (
+            re.fullmatch(pattern=duration_regex, string=subject_upper_age_bound) or subject_upper_age_bound == ""
+        )
         if lower_valid and upper_valid:
             return None
 

--- a/src/nwbinspector/checks/_nwbfile_metadata.py
+++ b/src/nwbinspector/checks/_nwbfile_metadata.py
@@ -180,9 +180,9 @@ def check_subject_age(subject: Subject) -> Optional[InspectorMessage]:
     if "/" in subject.age:
         subject_lower_age_bound, subject_upper_age_bound = subject.age.split("/")
 
-        if re.fullmatch(pattern=duration_regex, string=subject_lower_age_bound) and (
-            re.fullmatch(pattern=duration_regex, string=subject_upper_age_bound) or subject_upper_age_bound == ""
-        ):
+        lower_valid = re.fullmatch(pattern=duration_regex, string=subject_lower_age_bound) or subject_lower_age_bound == ""
+        upper_valid = re.fullmatch(pattern=duration_regex, string=subject_upper_age_bound) or subject_upper_age_bound == ""
+        if lower_valid and upper_valid:
             return None
 
     return InspectorMessage(

--- a/tests/unit_tests/test_nwbfile_metadata.py
+++ b/tests/unit_tests/test_nwbfile_metadata.py
@@ -383,6 +383,16 @@ def test_check_subject_age_iso8601_range_pass_2():
     assert check_subject_age(subject) is None
 
 
+def test_check_subject_age_iso8601_range_pass_3():
+    subject = Subject(subject_id="001", age="/P3D")
+    assert check_subject_age(subject) is None
+
+
+def test_check_subject_age_iso8601_range_pass_4():
+    subject = Subject(subject_id="001", age="/")
+    assert check_subject_age(subject) is None
+
+
 def test_check_subject_age_iso8601_range_fail_1():
     subject = Subject(subject_id="001", age="9 months/12 months")
     assert check_subject_age(subject) == InspectorMessage(


### PR DESCRIPTION
## Summary
- `check_subject_age` required the lower bound of an age range to be a valid ISO 8601 duration, but allowed the upper bound to be empty. Now both sides are treated symmetrically, so `"/"`, `"/P3D"`, and `"P1D/"` are all valid.
- Added two new tests for the newly accepted formats (`"/P3D"` and `"/"`).

## Test plan
- [x] All existing `check_subject_age` and `check_subject_proper_age_range` tests pass
- [x] New tests for `age="/P3D"` and `age="/"` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)