### PR TITLE
Add check for spike times duration much shorter than recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Added `check_image_series_starting_frame_without_external_file` to verify that `starting_frame` is not set when `external_file` is not used in an `ImageSeries`. [#235](https://github.com/NeurodataWithoutBorders/nwbinspector/issues/235)
 * Added `check_sweeptable_deprecated` to detect usage of the deprecated `SweepTable` in NWB files with schema version >= 2.4.0, which should use `IntracellularRecordingsTable` instead. [#657](https://github.com/NeurodataWithoutBorders/nwbinspector/issues/657)
 * Added `check_time_series_data_is_not_empty` to detect empty `.data` fields in `TimeSeries` containers, which often indicate incomplete data entry or conversion errors. Skips `ImageSeries` with `external_file` set, where empty data is intentional. [#668](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/668)
+* Added `check_units_spike_times_short_duration` to flag when spike times duration is suspiciously short (default: less than 10 seconds), which may indicate spike times are not aligned to session start. [#680](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/680)
 
 ### Improvements
 * Added documentation to API and CLI docs on how to use the dandi config option. [#624](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/624)

--- a/src/nwbinspector/checks/__init__.py
+++ b/src/nwbinspector/checks/__init__.py
@@ -12,6 +12,7 @@ from ._ecephys import (
     check_electrodes_location_allen_ccf,
     check_negative_spike_times,
     check_spike_times_not_in_unobserved_interval,
+    check_units_spike_times_short_duration,
     check_units_table_duration,
 )
 from ._general import (
@@ -158,6 +159,7 @@ __all__ = [
     "check_time_intervals_stop_after_start",
     "check_table_values_for_dict",
     "check_table_time_columns_are_not_negative",
+    "check_units_spike_times_short_duration",
     "check_units_table_duration",
     "check_resolution",
     "check_missing_unit",

--- a/src/nwbinspector/checks/_ecephys.py
+++ b/src/nwbinspector/checks/_ecephys.py
@@ -251,6 +251,36 @@ def check_units_table_duration(
     return None
 
 
+@register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=Units)
+def check_units_spike_times_short_duration(
+    units_table: Units, duration_threshold: float = 10.0
+) -> Optional[InspectorMessage]:
+    """
+    Check if spike times duration is suspiciously short.
+
+    Parameters
+    ----------
+    units_table : Units
+        The Units table to check.
+    duration_threshold : float, optional
+        The minimum expected duration in seconds. Default is 10.0 seconds.
+    """
+    duration = units_table.get_duration()
+    if duration is None:
+        return None
+
+    if duration < duration_threshold:
+        return InspectorMessage(
+            message=(
+                f"The spike times have a duration of {duration:.2f} seconds. "
+                "This may indicate that spike times are not aligned to the session start time "
+                "or that there is a data quality issue."
+            )
+        )
+
+    return None
+
+
 @register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=NWBFile)
 def check_electrodes_location_allen_ccf(nwbfile: NWBFile) -> Optional[Iterable[InspectorMessage]]:
     """
@@ -260,7 +290,6 @@ def check_electrodes_location_allen_ccf(nwbfile: NWBFile) -> Optional[Iterable[I
 
     Best Practice: :ref:`best_practice_ecephys_ontologies`
     """
-<<<<<<< HEAD
     if nwbfile.subject is None:
         return None
     species = nwbfile.subject.species

--- a/src/nwbinspector/checks/_ecephys.py
+++ b/src/nwbinspector/checks/_ecephys.py
@@ -232,41 +232,9 @@ def check_units_table_duration(
     Optional[InspectorMessage]
         An InspectorMessage if the duration exceeds the threshold, None otherwise.
     """
-    if "spike_times" not in units_table:
+    duration = units_table.get_duration()
+    if duration is None:
         return None
-
-    # Read the index array (cumulative indices marking end of each unit's spikes)
-    # This is small - just one integer per unit
-    idxs = np.asarray(units_table["spike_times"].data[:])
-
-    if len(idxs) == 0:
-        return None
-
-    # Build indices for first and last spike of each unit
-    # First spike indices: 0 for first unit, then idxs[:-1] for subsequent units
-    # Last spike indices: idxs - 1 for each unit
-    first_spike_idxs = np.concatenate([[np.uint64(0)], idxs[idxs != idxs[-1]]])
-    last_spike_idxs = idxs[idxs != 0] - 1
-
-    # Combine into single array of indices to read, then read all at once
-    all_indices = np.concatenate([first_spike_idxs, last_spike_idxs])
-    all_indices = np.unique(all_indices)  # Remove duplicates for efficiency
-
-    # Read only the needed spike times in one operation
-    spike_times_data = units_table["spike_times"].target.data
-
-    # needed to get tests to work on example data that is a list, not an h5py dataset
-    if isinstance(spike_times_data, list):
-        spike_times_data = np.array(spike_times_data)
-
-    boundary_spike_times = spike_times_data[all_indices]
-
-    if len(boundary_spike_times) == 0:
-        return None
-
-    start = float(np.min(boundary_spike_times))
-    end = float(np.max(boundary_spike_times))
-    duration = end - start
 
     if duration > duration_threshold:
         duration_years = duration / DURATION_THRESHOLD
@@ -292,6 +260,7 @@ def check_electrodes_location_allen_ccf(nwbfile: NWBFile) -> Optional[Iterable[I
 
     Best Practice: :ref:`best_practice_ecephys_ontologies`
     """
+<<<<<<< HEAD
     if nwbfile.subject is None:
         return None
     species = nwbfile.subject.species

--- a/tests/unit_tests/test_ecephys.py
+++ b/tests/unit_tests/test_ecephys.py
@@ -572,10 +572,18 @@ def test_check_units_spike_times_short_duration_fail():
     units.add_unit(spike_times=[0.0, 1.0, 3.0])
     units.add_unit(spike_times=[2.0, 5.0, 7.32])
 
-    result = check_units_spike_times_short_duration(units)
-    assert result is not None
-    assert "7.32" in result.message
-    assert result.importance == Importance.BEST_PRACTICE_VIOLATION
+    assert check_units_spike_times_short_duration(units) == InspectorMessage(
+        message=(
+            "The spike times have a duration of 7.32 seconds. "
+            "This may indicate that spike times are not aligned to the session start time "
+            "or that there is a data quality issue."
+        ),
+        importance=Importance.BEST_PRACTICE_VIOLATION,
+        check_function_name="check_units_spike_times_short_duration",
+        object_type="Units",
+        object_name="units",
+        location="/",
+    )
 
 
 def test_check_units_spike_times_short_duration_pass():

--- a/tests/unit_tests/test_ecephys.py
+++ b/tests/unit_tests/test_ecephys.py
@@ -19,6 +19,7 @@ from nwbinspector.checks import (
     check_electrodes_location_allen_ccf,
     check_negative_spike_times,
     check_spike_times_not_in_unobserved_interval,
+    check_units_spike_times_short_duration,
     check_units_table_duration,
 )
 

--- a/tests/unit_tests/test_ecephys.py
+++ b/tests/unit_tests/test_ecephys.py
@@ -566,6 +566,34 @@ class TestCheckElectricalSeriesUnscaledData(TestCase):
         )
 
 
+def test_check_units_spike_times_short_duration_fail():
+    """Spike times span 7.32s — should flag."""
+    units = Units(name="units")
+    units.add_unit(spike_times=[0.0, 1.0, 3.0])
+    units.add_unit(spike_times=[2.0, 5.0, 7.32])
+
+    result = check_units_spike_times_short_duration(units)
+    assert result is not None
+    assert "7.32" in result.message
+    assert result.importance == Importance.BEST_PRACTICE_VIOLATION
+
+
+def test_check_units_spike_times_short_duration_pass():
+    """Spike times span more than 10s — should pass."""
+    units = Units(name="units")
+    units.add_unit(spike_times=[0.0, 5.0, 15.0])
+
+    assert check_units_spike_times_short_duration(units) is None
+
+
+def test_check_units_spike_times_short_duration_pass_no_spike_times():
+    """Units table without spike_times — should pass."""
+    units = Units(name="units")
+    units.add_column(name="custom_col", description="test")
+    units.add_row(custom_col=1)
+    assert check_units_spike_times_short_duration(units) is None
+
+
 def _make_nwbfile_with_electrodes(locations, species=None):
     """Helper to create an NWBFile with electrodes at the given locations."""
     nwbfile = NWBFile(


### PR DESCRIPTION
## Summary
- Adds `check_units_spike_times_short_duration` (BEST_PRACTICE_VIOLATION) that flags when spike times duration is less than 10 seconds, which may indicate spike times are not aligned to session start.
- Refactors `check_units_table_duration` to use the new `Units.get_duration()` method from PyNWB.

**Note:** This PR depends on the next release of PyNWB, which adds the `Units.get_duration()` method.

Closes #679

## Test plan
- [x] `test_check_units_spike_times_short_duration_fail` — spike times span 7.32s
- [x] `test_check_units_spike_times_short_duration_pass` — spike times span more than 10s
- [x] `test_check_units_spike_times_short_duration_pass_no_spike_times` — Units table without spike_times
- [x] All existing `check_units_table_duration` tests still pass after refactor to `get_duration()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)