### PR TITLE
Update requirements to HDMF 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 
 ### Improvements
+* Updated HDMF dependency to version 5+. [#675](https://github.com/NeurodataWithoutBorders/nwbinspector/issues/675)
 
 ### Fixes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "pynwb>=3.1",   # NWB Inspector should always be used with most recent minor versions of PyNWB
+    "hdmf>=5",
     "hdmf-zarr",
     "fsspec",
     "requests",

--- a/tests/unit_tests/test_tables.py
+++ b/tests/unit_tests/test_tables.py
@@ -31,7 +31,9 @@ class TestCheckDynamicTableRegion(TestCase):
             self.table.add_row(test_column=1)
 
     def test_check_dynamic_table_region_data_validity_lt_zero(self):
-        dynamic_table_region = DynamicTableRegion(name="dyn_tab", description="desc", data=[-1, 0], table=self.table)
+        dynamic_table_region = DynamicTableRegion(
+            name="dyn_tab", description="desc", data=[-1, 0], table=self.table, validate_data=False
+        )
 
         assert check_dynamic_table_region_data_validity(dynamic_table_region) == InspectorMessage(
             message="Some elements of dyn_tab are out of range because they are less than 0.",
@@ -43,7 +45,9 @@ class TestCheckDynamicTableRegion(TestCase):
         )
 
     def test_check_dynamic_table_region_data_validity_gt_len(self):
-        dynamic_table_region = DynamicTableRegion(name="dyn_tab", description="desc", data=[0, 20], table=self.table)
+        dynamic_table_region = DynamicTableRegion(
+            name="dyn_tab", description="desc", data=[0, 20], table=self.table, validate_data=False
+        )
 
         assert check_dynamic_table_region_data_validity(dynamic_table_region) == InspectorMessage(
             message=(


### PR DESCRIPTION
HDMF 5 added constructor-time validation for `DynamicTableRegion` that raises `IndexError` for out-of-bounds indices. Pass `validate_data=False` in tests that intentionally create invalid `DynamicTableRegion` objects to test the inspector's own validation checks.

Closes #675

Note that pynwb does not yet support HDMF 5 so the dependencies cannot yet be resolved except in local installations where tests pass. This is a WIP until the next pynwb release.
