### PR TITLE
Fix RuntimeWarning for all-NaN time columns in check_time_intervals_duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Upgraded `check_ascending_spike_times` from `BEST_PRACTICE_VIOLATION` to `CRITICAL` and made it flag both descending and equal consecutive spike times. Setting the `resolution` field on the Units table suppresses the equal-timestamps check for recordings with limited temporal precision. [#684](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/684)
 
 ### Fixes
+* Fixed `RuntimeWarning: All-NaN slice encountered` in `check_time_intervals_duration` when custom time columns contain all-NaN values. [#682](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/682)
 
 # v0.7.0 (Feb 23, 2026)
 

--- a/src/nwbinspector/checks/_tables.py
+++ b/src/nwbinspector/checks/_tables.py
@@ -333,10 +333,14 @@ def check_time_intervals_duration(
             data = time_intervals[column_name]
             head = data[:NELEMS]
             tail = data[-NELEMS:]
-            if np.all(np.isnan(head)) or np.all(np.isnan(tail)):
+            head_all_nan = np.all(np.isnan(head))
+            tail_all_nan = np.all(np.isnan(tail))
+            if head_all_nan and tail_all_nan:
                 continue
-            start_times.append(float(np.nanmin(head)))
-            stop_times.append(float(np.nanmax(tail)))
+            if not head_all_nan:
+                start_times.append(float(np.nanmin(head)))
+            if not tail_all_nan:
+                stop_times.append(float(np.nanmax(tail)))
 
     if start_times and stop_times:
         duration = np.nanmax(stop_times) - np.nanmin(start_times)

--- a/src/nwbinspector/checks/_tables.py
+++ b/src/nwbinspector/checks/_tables.py
@@ -331,8 +331,12 @@ def check_time_intervals_duration(
             and len(time_intervals[column_name]) > 0
         ):
             data = time_intervals[column_name]
-            start_times.append(float(np.nanmin(data[:NELEMS])))
-            stop_times.append(float(np.nanmax(data[-NELEMS:])))
+            head = data[:NELEMS]
+            tail = data[-NELEMS:]
+            if np.all(np.isnan(head)) or np.all(np.isnan(tail)):
+                continue
+            start_times.append(float(np.nanmin(head)))
+            stop_times.append(float(np.nanmax(tail)))
 
     if start_times and stop_times:
         duration = np.nanmax(stop_times) - np.nanmin(start_times)


### PR DESCRIPTION
The `check_time_intervals_duration` function (introduced in PR #627) iterates over all columns ending in `_time` and calls `np.nanmin`/`np.nanmax` to determine the time span. When a `_time` column contains entirely NaN values, numpy emits a `RuntimeWarning: All-NaN slice encountered`, which surfaces repeatedly during dandi validation on real datasets. This is noise and makes the output less useful.

This fix adds a guard that skips columns where the sampled head or tail slice is all-NaN before calling the aggregation functions. This does not interfere with the original intent of PR #627 because an all-NaN column carries no timing information. The duration calculation falls back to the other columns that do have real values (`start_time`, `stop_time`, and any non-NaN custom `_time` columns), so suspicious time spans are still caught.
