### PR TITLE
Add check for spike times stored as sample indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### New Checks
 
 * Added `check_imaging_plane_location_allen_ccf`, `check_electrodes_location_allen_ccf`, and `check_intracellular_electrode_location_allen_ccf` to validate location fields against Allen Mouse Brain CCF ontology terms when subject species is mouse. [#671](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/671)
+* Added `check_spike_times_not_in_samples` to flag when spike times appear to be stored as sample indices rather than seconds, detected by all values being integer-valued with implausibly large magnitudes.
 
 
 ### Improvements

--- a/docs/best_practices/ecephys.rst
+++ b/docs/best_practices/ecephys.rst
@@ -79,6 +79,21 @@ The spikes associated with each unit are stored in the ``spike_times`` column of
 Check function: :py:meth:`~nwbinspector.checks._ecephys.check_units_table_duration`
 
 
+.. _best_practice_spike_times_not_in_samples:
+
+Spike Times in Seconds
+~~~~~~~~~~~~~~~~~~~~~~
+
+Spike times must be stored in seconds with respect to the ``timestamps_reference_time`` of the
+:ref:`nwb-schema:sec-NWBFile` (which by default is the ``session_start_time``).
+
+A common failure is writing spike times in samples instead of seconds. To convert, divide by the sampling rate
+of the recording. Spike times in samples are integer-valued, while real spike times in seconds have fractional
+parts at any common electrophysiology sampling rate.
+
+Check function: :py:meth:`~nwbinspector.checks._ecephys.check_spike_times_not_in_samples`
+
+
 .. _best_practice_negative_spike_times:
 
 Negative Spike Times

--- a/src/nwbinspector/checks/__init__.py
+++ b/src/nwbinspector/checks/__init__.py
@@ -11,6 +11,7 @@ from ._ecephys import (
     check_electrical_series_unscaled_data,
     check_electrodes_location_allen_ccf,
     check_negative_spike_times,
+    check_spike_times_not_in_samples,
     check_spike_times_not_in_unobserved_interval,
     check_units_table_duration,
 )
@@ -104,6 +105,7 @@ from ._time_series import (
 
 __all__ = [
     "check_negative_spike_times",
+    "check_spike_times_not_in_samples",
     "check_electrical_series_dims",
     "check_electrical_series_reference_electrodes_table",
     "check_spike_times_not_in_unobserved_interval",

--- a/src/nwbinspector/checks/_ecephys.py
+++ b/src/nwbinspector/checks/_ecephys.py
@@ -34,9 +34,7 @@ def check_negative_spike_times(units_table: Units) -> Optional[InspectorMessage]
 
 
 @register_check(importance=Importance.CRITICAL, neurodata_type=Units)
-def check_spike_times_not_in_samples(
-    units_table: Units, nelems: Optional[int] = 200
-) -> Optional[InspectorMessage]:
+def check_spike_times_not_in_samples(units_table: Units, nelems: Optional[int] = 200) -> Optional[InspectorMessage]:
     """
     Check if spike times appear to be sample indices rather than seconds.
 

--- a/src/nwbinspector/checks/_ecephys.py
+++ b/src/nwbinspector/checks/_ecephys.py
@@ -33,6 +33,57 @@ def check_negative_spike_times(units_table: Units) -> Optional[InspectorMessage]
     return None
 
 
+@register_check(importance=Importance.CRITICAL, neurodata_type=Units)
+def check_spike_times_not_in_samples(
+    units_table: Units, nelems: Optional[int] = 200
+) -> Optional[InspectorMessage]:
+    """
+    Check if spike times appear to be sample indices rather than seconds.
+
+    Spike times stored as sample indices are integer-valued. Real spike times in seconds
+    have fractional parts at any common electrophysiology sampling rate. If the ``resolution``
+    field on the Units table is set to >= 1.0 second, the check is skipped. This serves as
+    an escape hatch for the unlikely case where spike time resolution is truly 1 second or
+    lower; users must explicitly set this field to suppress the check.
+
+    Best Practice :ref:`best_practice_spike_times_not_in_samples`
+    """
+    if "spike_times" not in units_table:
+        return None
+
+    if units_table.resolution is not None and units_table.resolution >= 1.0:
+        return None
+
+    spike_times_data = units_table["spike_times"].target.data
+
+    if isinstance(spike_times_data, list):
+        spike_times_data = np.array(spike_times_data)
+
+    # Sample the last nelems values
+    if nelems is not None and len(spike_times_data) > nelems:
+        sample = np.array(spike_times_data[-nelems:])
+    else:
+        sample = np.array(spike_times_data[:])
+
+    if len(sample) == 0:
+        return None
+
+    all_integer_valued = np.all(sample == np.floor(sample))
+
+    if all_integer_valued:
+        return InspectorMessage(
+            message=(
+                "Spike times appear to be in samples rather than seconds. "
+                "All sampled spike times are integer-valued. "
+                "Spike times should be in seconds (divide by the sampling rate to convert). "
+                "If your spike time resolution is truly 1 second or lower, "
+                "set Units(resolution=1.0) to suppress this check."
+            )
+        )
+
+    return None
+
+
 @register_check(importance=Importance.CRITICAL, neurodata_type=ElectricalSeries)
 def check_electrical_series_dims(electrical_series: ElectricalSeries) -> Optional[InspectorMessage]:
     """

--- a/src/nwbinspector/checks/_ecephys.py
+++ b/src/nwbinspector/checks/_ecephys.py
@@ -57,11 +57,7 @@ def check_spike_times_not_in_samples(units_table: Units, nelems: Optional[int] =
     if isinstance(spike_times_data, list):
         spike_times_data = np.array(spike_times_data)
 
-    # Sample the last nelems values
-    if nelems is not None and len(spike_times_data) > nelems:
-        sample = np.array(spike_times_data[-nelems:])
-    else:
-        sample = np.array(spike_times_data[:])
+    sample = np.array(spike_times_data[:nelems])
 
     if len(sample) == 0:
         return None

--- a/tests/unit_tests/test_ecephys.py
+++ b/tests/unit_tests/test_ecephys.py
@@ -94,21 +94,6 @@ def test_check_spike_times_not_in_samples_pass_resolution_escape_hatch():
     assert check_spike_times_not_in_samples(units_table) is None
 
 
-def test_check_spike_times_not_in_samples_fail_small_integers():
-    """Small integer-valued times without resolution set should still flag."""
-    units_table = Units()
-    units_table.add_unit(spike_times=[1.0, 2.0, 3.0, 100.0, 200.0])
-    assert check_spike_times_not_in_samples(units_table) is not None
-
-
-def test_check_spike_times_not_in_samples_pass_no_spike_times():
-    """Units table without spike_times column."""
-    units_table = Units()
-    units_table.add_column(name="custom_col", description="test")
-    units_table.add_row(custom_col=1)
-    assert check_spike_times_not_in_samples(units_table) is None
-
-
 class TestCheckElectricalSeries(TestCase):
     def setUp(self):
         nwbfile = NWBFile(

--- a/tests/unit_tests/test_ecephys.py
+++ b/tests/unit_tests/test_ecephys.py
@@ -18,6 +18,7 @@ from nwbinspector.checks import (
     check_electrical_series_unscaled_data,
     check_electrodes_location_allen_ccf,
     check_negative_spike_times,
+    check_spike_times_not_in_samples,
     check_spike_times_not_in_unobserved_interval,
     check_units_table_duration,
 )
@@ -50,6 +51,62 @@ def test_check_negative_spike_times_some_negative():
         object_name="Units",
         location="/",
     )
+
+
+def test_check_spike_times_not_in_samples_fail():
+    """Integer-valued spike times with large magnitude - likely sample indices."""
+    units_table = Units()
+    units_table.add_unit(spike_times=[30000.0, 60000.0, 90000.0])
+    units_table.add_unit(spike_times=[30001.0, 60002.0, 90003.0])
+    assert check_spike_times_not_in_samples(units_table) == InspectorMessage(
+        message=(
+            "Spike times appear to be in samples rather than seconds. "
+            "All sampled spike times are integer-valued. "
+            "Spike times should be in seconds (divide by the sampling rate to convert). "
+            "If your spike time resolution is truly 1 second or lower, "
+            "set Units(resolution=1.0) to suppress this check."
+        ),
+        importance=Importance.CRITICAL,
+        check_function_name="check_spike_times_not_in_samples",
+        object_type="Units",
+        object_name="Units",
+        location="/",
+    )
+
+
+def test_check_spike_times_not_in_samples_pass_real_times():
+    """Float spike times in seconds - normal data."""
+    units_table = Units()
+    units_table.add_unit(spike_times=[0.1234, 1.5678, 3.9012])
+    units_table.add_unit(spike_times=[10.111, 20.222, 30.333])
+    assert check_spike_times_not_in_samples(units_table) is None
+
+
+def test_check_spike_times_not_in_samples_pass_resolution_escape_hatch():
+    """Resolution set to >= 1.0 skips the check.
+
+    This is an escape hatch for the unlikely case where spike time resolution
+    is truly 1 second or lower (e.g. behavioral timestamps). Users must explicitly
+    set the resolution field on the Units table to suppress this check.
+    """
+    units_table = Units(resolution=1.0)
+    units_table.add_unit(spike_times=[1.0, 2.0, 3.0, 100.0, 200.0])
+    assert check_spike_times_not_in_samples(units_table) is None
+
+
+def test_check_spike_times_not_in_samples_fail_small_integers():
+    """Small integer-valued times without resolution set should still flag."""
+    units_table = Units()
+    units_table.add_unit(spike_times=[1.0, 2.0, 3.0, 100.0, 200.0])
+    assert check_spike_times_not_in_samples(units_table) is not None
+
+
+def test_check_spike_times_not_in_samples_pass_no_spike_times():
+    """Units table without spike_times column."""
+    units_table = Units()
+    units_table.add_column(name="custom_col", description="test")
+    units_table.add_row(custom_col=1)
+    assert check_spike_times_not_in_samples(units_table) is None
 
 
 class TestCheckElectricalSeries(TestCase):


### PR DESCRIPTION
This adds `check_spike_times_not_in_samples` (CRITICAL) to detect when spike times are stored as sample indices rather than seconds. The check flags spike times that are all integer-valued, since real spike times in seconds have fractional parts at any common electrophysiology sampling rate.

The existing `check_units_table_duration` catches this error when the apparent duration exceeds 1 year, but 15-minute recordings (common in ephys) at 30 kHz produce sample indices that look like 312 days of "seconds," slipping under that threshold. The integer-valued heuristic catches these cases regardless of recording length. The check samples the last 200 spike time values for efficiency, which is sufficient because the frames-to-seconds conversion error is all-or-nothing.

If the `resolution` field on the Units table is set to >= 1.0, the check is skipped. This serves as an escape hatch for the unlikely case where spike time resolution is truly 1 second or lower. The error message instructs users to set `Units(resolution=1.0)` if this applies to them.

Relates to #679 and #676
