### PR TITLE
 Upgrade check_ascending_spike_times to CRITICAL with resolution escape hatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 
 ### Improvements
+* Upgraded `check_ascending_spike_times` from `BEST_PRACTICE_VIOLATION` to `CRITICAL` and made it flag both descending and equal consecutive spike times. Setting the `resolution` field on the Units table suppresses the equal-timestamps check for recordings with limited temporal precision. [#684](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/684)
 
 ### Fixes
 

--- a/docs/best_practices/ecephys.rst
+++ b/docs/best_practices/ecephys.rst
@@ -109,10 +109,15 @@ Check function: :py:meth:`~nwbinspector.checks._ecephys.check_spike_times_not_in
 Ascending Spike Times
 ~~~~~~~~~~~~~~~~~~~~~
 
-The spike times within each unit of the :ref:`nwb-schema:sec-units-src` table should be sorted in ascending order.
-Non-ascending spike times can indicate errors in the spike sorting process or in the temporal alignment of the data.
-Properly ordered spike times are essential for analyzing temporal patterns of neural activity and for calculating
-intervals between spikes (inter-spike intervals).
+The spike times within each unit of the :ref:`nwb-schema:sec-units-src` table must be strictly ascending.
+Descending spike times always indicate a data error, such as trial-concatenated times, a spike sorting bug,
+or a conversion error. Equal consecutive spike times violate the neural refractory period for single-unit data
+and are also flagged.
+
+If your recording hardware has limited temporal resolution (e.g., low sampling rate or binned spike sorting output),
+equal consecutive spike times may be expected. In this case, set the ``resolution`` field on the Units table to
+the smallest resolvable difference between spike times in seconds (e.g., ``Units(resolution=1/30000)`` for a
+30 kHz sampling rate). When ``resolution`` is set, equal consecutive spike times are allowed.
 
 Check function: :py:meth:`~nwbinspector.checks._ecephys.check_ascending_spike_times`
 

--- a/src/nwbinspector/checks/_ecephys.py
+++ b/src/nwbinspector/checks/_ecephys.py
@@ -123,27 +123,48 @@ def check_spike_times_not_in_unobserved_interval(units_table: Units, nunits: int
     return None
 
 
-@register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=Units)
+@register_check(importance=Importance.CRITICAL, neurodata_type=Units)
 def check_ascending_spike_times(units_table: Units, nelems: Optional[int] = NELEMS) -> Optional[InspectorMessage]:
     """
-    Check that the values in the timestamps array are strictly increasing.
+    Check that spike times are strictly ascending for each unit.
+
+    Descending spike times always indicate a data error (trial-concatenated times, spike sorting bug,
+    or conversion error). Equal consecutive spike times violate the neural refractory period for
+    single-unit data. If the ``resolution`` field on the Units table is set, equal consecutive spike
+    times are allowed because they may reflect hardware timing precision limits.
 
     Best Practice :ref:`best_practice_ascending_spike_times`
     """
     if "spike_times" not in units_table:
         return None
 
+    resolution_is_set = units_table.resolution is not None
+
     for unit_id in range(len(units_table)):
         spike_times = units_table["spike_times"][unit_id]
         if nelems is not None:
             spike_times = spike_times[:nelems]
-        if not np.all(np.diff(spike_times) >= 0):
+
+        diffs = np.diff(spike_times)
+
+        if np.any(diffs < 0):
             return InspectorMessage(
                 message=(
-                    f"Unit {unit_id} contains non-ascending spike times. "
-                    "Spike times should be sorted in ascending order."
+                    f"Unit {unit_id} contains descending spike times, which is always a data error. "
+                    "Spike times should be sorted in strictly ascending order."
                 )
             )
+
+        if not resolution_is_set and np.any(diffs == 0):
+            return InspectorMessage(
+                message=(
+                    f"Unit {unit_id} contains equal consecutive spike times. "
+                    "This violates the neural refractory period for single-unit data. "
+                    "If your recording resolution does not allow distinguishing these spikes, "
+                    "set the `resolution` field on the Units table to suppress this check."
+                )
+            )
+
     return None
 
 

--- a/tests/unit_tests/test_ecephys.py
+++ b/tests/unit_tests/test_ecephys.py
@@ -299,16 +299,40 @@ class TestCheckAscendingSpikeTimes(TestCase):
         self.units_table.add_unit(spike_times=[1.0, 1.1, 1.2])
         assert check_ascending_spike_times(units_table=self.units_table) is None
 
-    def test_ascending_spike_times_invalid(self):
-        self.units_table.add_unit(spike_times=[0.2, 0.1, 0.3])  # Non-ascending
+    def test_descending_spike_times(self):
+        self.units_table.add_unit(spike_times=[0.2, 0.1, 0.3])
         assert check_ascending_spike_times(units_table=self.units_table) == InspectorMessage(
-            message="Unit 0 contains non-ascending spike times. Spike times should be sorted in ascending order.",
-            importance=Importance.BEST_PRACTICE_VIOLATION,
+            message=(
+                "Unit 0 contains descending spike times, which is always a data error. "
+                "Spike times should be sorted in strictly ascending order."
+            ),
+            importance=Importance.CRITICAL,
             check_function_name="check_ascending_spike_times",
             object_type="Units",
             object_name="Units",
             location="/",
         )
+
+    def test_equal_consecutive_spike_times_no_resolution(self):
+        self.units_table.add_unit(spike_times=[0.0, 0.1, 0.1, 0.2])
+        assert check_ascending_spike_times(units_table=self.units_table) == InspectorMessage(
+            message=(
+                "Unit 0 contains equal consecutive spike times. "
+                "This violates the neural refractory period for single-unit data. "
+                "If your recording resolution does not allow distinguishing these spikes, "
+                "set the `resolution` field on the Units table to suppress this check."
+            ),
+            importance=Importance.CRITICAL,
+            check_function_name="check_ascending_spike_times",
+            object_type="Units",
+            object_name="Units",
+            location="/",
+        )
+
+    def test_equal_consecutive_spike_times_with_resolution(self):
+        units_table = Units(resolution=0.001)
+        units_table.add_unit(spike_times=[0.0, 0.1, 0.1, 0.2])
+        assert check_ascending_spike_times(units_table=units_table) is None
 
     def test_ascending_spike_times_empty(self):
         assert check_ascending_spike_times(units_table=self.units_table) is None


### PR DESCRIPTION
`check_ascending_spike_times` was `BEST_PRACTICE_VIOLATION` and only flagged descending spike times (using `np.diff >= 0`). This meant DANDI validation did not block uploads with non-ascending spike times, which allowed datasets like Dandiset 1610 (trial-concatenated spike times going from +7.0 back to -7.0 at each trial boundary) to pass validation.

This PR upgrades the check to `CRITICAL` and makes it flag both descending and equal consecutive spike times using `np.diff > 0`. Descending spike times always indicate a data error. Equal consecutive spike times violate the neural refractory period for single-unit data.

For recordings with limited temporal resolution (low sampling rate, binned spike sorting output), equal consecutive spike times can be legitimate. Setting the `resolution` field on the Units table suppresses the equal-timestamps portion of the check, following the same escape-hatch pattern established in #683 for `check_spike_times_not_in_samples`.

Relates to #676
