### PR TITLE
Add check that Units resolution is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### New Checks
 
 * Added `check_imaging_plane_location_allen_ccf`, `check_electrodes_location_allen_ccf`, and `check_intracellular_electrode_location_allen_ccf` to validate location fields against Allen Mouse Brain CCF ontology terms when subject species is mouse. [#671](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/671)
+* Added `check_units_resolution_is_set` to flag when the Units table has spike_times but resolution is not set to a meaningful positive float. [#685](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/685)
 
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### New Checks
 
 * Added `check_imaging_plane_location_allen_ccf`, `check_electrodes_location_allen_ccf`, and `check_intracellular_electrode_location_allen_ccf` to validate location fields against Allen Mouse Brain CCF ontology terms when subject species is mouse. [#671](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/671)
-* Added `check_spatial_series_unit` to validate that SpatialSeries objects (outside of CompassDirection) have a recognized unit string from a curated allowlist of SI length units, angular units, and pixels. [#685](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/685)
+* Added `check_units_resolution_is_set` to flag when the Units table has spike_times but resolution is not set to a meaningful positive float. [#686](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/686)
 
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### New Checks
 
 * Added `check_imaging_plane_location_allen_ccf`, `check_electrodes_location_allen_ccf`, and `check_intracellular_electrode_location_allen_ccf` to validate location fields against Allen Mouse Brain CCF ontology terms when subject species is mouse. [#671](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/671)
-* Added `check_units_resolution_is_set` to flag when the Units table has spike_times but resolution is not set to a meaningful positive float. [#685](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/685)
+* Added `check_spatial_series_unit` to validate that SpatialSeries objects (outside of CompassDirection) have a recognized unit string from a curated allowlist of SI length units, angular units, and pixels. [#685](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/685)
 
 
 ### Improvements

--- a/docs/best_practices/ecephys.rst
+++ b/docs/best_practices/ecephys.rst
@@ -89,7 +89,11 @@ difference between two spike times, in seconds. Set this to ``1/sampling_rate`` 
 (e.g., ``resolution=1/30000`` for a 30 kHz system). This documents the precision of your spike timing
 data, which is needed by downstream users to determine whether fine-timescale analyses are appropriate.
 
-Check function: :py:meth:`~nwbinspector.checks._ecephys.check_units_resolution_is_set`
+A common mistake is to set the sampling rate (e.g., ``30000``) instead of the resolution. To avoid this,
+invert the quantity: ``resolution=1/sampling_rate``.
+
+Check functions: :py:meth:`~nwbinspector.checks._ecephys.check_units_resolution_is_set`,
+:py:meth:`~nwbinspector.checks._ecephys.check_units_resolution_is_valid`
 
 
 .. _best_practice_negative_spike_times:

--- a/docs/best_practices/ecephys.rst
+++ b/docs/best_practices/ecephys.rst
@@ -79,6 +79,19 @@ The spikes associated with each unit are stored in the ``spike_times`` column of
 Check function: :py:meth:`~nwbinspector.checks._ecephys.check_units_table_duration`
 
 
+.. _best_practice_units_resolution:
+
+Units Resolution
+~~~~~~~~~~~~~~~~
+
+The ``resolution`` field on the :ref:`nwb-schema:sec-units-src` table indicates the smallest possible
+difference between two spike times, in seconds. Set this to ``1/sampling_rate`` of the recording system
+(e.g., ``resolution=1/30000`` for a 30 kHz system). This documents the precision of your spike timing
+data, which is needed by downstream users to determine whether fine-timescale analyses are appropriate.
+
+Check function: :py:meth:`~nwbinspector.checks._ecephys.check_units_resolution_is_set`
+
+
 .. _best_practice_negative_spike_times:
 
 Negative Spike Times

--- a/src/nwbinspector/checks/__init__.py
+++ b/src/nwbinspector/checks/__init__.py
@@ -12,7 +12,7 @@ from ._ecephys import (
     check_electrodes_location_allen_ccf,
     check_negative_spike_times,
     check_spike_times_not_in_unobserved_interval,
-    check_units_resolution_in_range,
+    check_units_resolution_is_valid,
     check_units_resolution_is_set,
     check_units_table_duration,
 )
@@ -180,7 +180,7 @@ __all__ = [
     "check_spatial_series_degrees_magnitude",
     "check_ascending_spike_times",
     "check_electrical_series_unscaled_data",
-    "check_units_resolution_in_range",
+    "check_units_resolution_is_valid",
     "check_units_resolution_is_set",
     "check_rate_is_positive",
     "check_imaging_plane_location_allen_ccf",

--- a/src/nwbinspector/checks/__init__.py
+++ b/src/nwbinspector/checks/__init__.py
@@ -12,6 +12,7 @@ from ._ecephys import (
     check_electrodes_location_allen_ccf,
     check_negative_spike_times,
     check_spike_times_not_in_unobserved_interval,
+    check_units_resolution_in_range,
     check_units_resolution_is_set,
     check_units_table_duration,
 )
@@ -179,6 +180,7 @@ __all__ = [
     "check_spatial_series_degrees_magnitude",
     "check_ascending_spike_times",
     "check_electrical_series_unscaled_data",
+    "check_units_resolution_in_range",
     "check_units_resolution_is_set",
     "check_rate_is_positive",
     "check_imaging_plane_location_allen_ccf",

--- a/src/nwbinspector/checks/__init__.py
+++ b/src/nwbinspector/checks/__init__.py
@@ -12,6 +12,7 @@ from ._ecephys import (
     check_electrodes_location_allen_ccf,
     check_negative_spike_times,
     check_spike_times_not_in_unobserved_interval,
+    check_units_resolution_is_set,
     check_units_table_duration,
 )
 from ._general import (
@@ -178,6 +179,7 @@ __all__ = [
     "check_spatial_series_degrees_magnitude",
     "check_ascending_spike_times",
     "check_electrical_series_unscaled_data",
+    "check_units_resolution_is_set",
     "check_rate_is_positive",
     "check_imaging_plane_location_allen_ccf",
     "check_electrodes_location_allen_ccf",

--- a/src/nwbinspector/checks/__init__.py
+++ b/src/nwbinspector/checks/__init__.py
@@ -12,8 +12,8 @@ from ._ecephys import (
     check_electrodes_location_allen_ccf,
     check_negative_spike_times,
     check_spike_times_not_in_unobserved_interval,
-    check_units_resolution_is_valid,
     check_units_resolution_is_set,
+    check_units_resolution_is_valid,
     check_units_table_duration,
 )
 from ._general import (

--- a/src/nwbinspector/checks/_ecephys.py
+++ b/src/nwbinspector/checks/_ecephys.py
@@ -38,7 +38,7 @@ def check_units_resolution_is_set(units_table: Units) -> Optional[InspectorMessa
     """
     Check that the Units table has resolution set to a meaningful positive float.
 
-    Best Practice :ref:`best_practice_units_resolution`
+    Best Practice: :ref:`best_practice_units_resolution`
     """
     if "spike_times" not in units_table:
         return None
@@ -71,7 +71,7 @@ def check_units_resolution_is_valid(units_table: Units) -> Optional[InspectorMes
     A resolution greater than 0.01 seconds (sampling rate below 100 Hz) likely indicates that
     the sampling rate was entered instead of the resolution (1/sampling_rate).
 
-    Best Practice :ref:`best_practice_units_resolution`
+    Best Practice: :ref:`best_practice_units_resolution`
     """
     if "spike_times" not in units_table:
         return None

--- a/src/nwbinspector/checks/_ecephys.py
+++ b/src/nwbinspector/checks/_ecephys.py
@@ -58,6 +58,35 @@ def check_units_resolution_is_set(units_table: Units) -> Optional[InspectorMessa
     )
 
 
+@register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=Units)
+def check_units_resolution_in_range(units_table: Units) -> Optional[InspectorMessage]:
+    """
+    Check that the Units table resolution is not suspiciously large.
+
+    A resolution greater than 0.01 seconds (sampling rate below 100 Hz) likely indicates that
+    the sampling rate was entered instead of the resolution (1/sampling_rate).
+
+    Best Practice :ref:`best_practice_units_resolution`
+    """
+    if "spike_times" not in units_table:
+        return None
+
+    resolution = units_table.resolution
+    if resolution is None or np.isnan(resolution) or resolution <= 0:
+        return None
+
+    if resolution > 0.01:
+        return InspectorMessage(
+            message=(
+                f"Units table resolution is {resolution}, which is unexpectedly large. "
+                "Resolution should be 1/sampling_rate (e.g., 1/30000 for a 30 kHz system), "
+                "not the sampling rate itself."
+            )
+        )
+
+    return None
+
+
 @register_check(importance=Importance.CRITICAL, neurodata_type=ElectricalSeries)
 def check_electrical_series_dims(electrical_series: ElectricalSeries) -> Optional[InspectorMessage]:
     """

--- a/src/nwbinspector/checks/_ecephys.py
+++ b/src/nwbinspector/checks/_ecephys.py
@@ -47,11 +47,16 @@ def check_units_resolution_is_set(units_table: Units) -> Optional[InspectorMessa
     if resolution is not None and not np.isnan(resolution) and resolution > 0:
         return None
 
+    if resolution is None or (isinstance(resolution, float) and np.isnan(resolution)):
+        detail = "Units table has spike_times but resolution is not set."
+    else:
+        detail = f"Units table has spike_times but resolution is set to an invalid value ({resolution})."
+
     return InspectorMessage(
         message=(
-            "Units table has spike_times but resolution is not set. "
+            f"{detail} "
             "Resolution indicates the smallest possible difference between two spike times "
-            "and should be set to 1/sampling_rate of the recording system "
+            "and should be a positive float equal to 1/sampling_rate of the recording system "
             "(e.g., Units(resolution=1/30000) for a 30 kHz system). "
             "This information is needed to assess the precision of spike timing data."
         )

--- a/src/nwbinspector/checks/_ecephys.py
+++ b/src/nwbinspector/checks/_ecephys.py
@@ -33,6 +33,31 @@ def check_negative_spike_times(units_table: Units) -> Optional[InspectorMessage]
     return None
 
 
+@register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=Units)
+def check_units_resolution_is_set(units_table: Units) -> Optional[InspectorMessage]:
+    """
+    Check that the Units table has resolution set to a meaningful positive float.
+
+    Best Practice :ref:`best_practice_units_resolution`
+    """
+    if "spike_times" not in units_table:
+        return None
+
+    resolution = units_table.resolution
+    if resolution is not None and not np.isnan(resolution) and resolution > 0:
+        return None
+
+    return InspectorMessage(
+        message=(
+            "Units table has spike_times but resolution is not set. "
+            "Resolution indicates the smallest possible difference between two spike times "
+            "and should be set to 1/sampling_rate of the recording system "
+            "(e.g., Units(resolution=1/30000) for a 30 kHz system). "
+            "This information is needed to assess the precision of spike timing data."
+        )
+    )
+
+
 @register_check(importance=Importance.CRITICAL, neurodata_type=ElectricalSeries)
 def check_electrical_series_dims(electrical_series: ElectricalSeries) -> Optional[InspectorMessage]:
     """

--- a/src/nwbinspector/checks/_ecephys.py
+++ b/src/nwbinspector/checks/_ecephys.py
@@ -59,7 +59,7 @@ def check_units_resolution_is_set(units_table: Units) -> Optional[InspectorMessa
 
 
 @register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=Units)
-def check_units_resolution_in_range(units_table: Units) -> Optional[InspectorMessage]:
+def check_units_resolution_is_valid(units_table: Units) -> Optional[InspectorMessage]:
     """
     Check that the Units table resolution is not suspiciously large.
 

--- a/tests/unit_tests/test_ecephys.py
+++ b/tests/unit_tests/test_ecephys.py
@@ -144,7 +144,7 @@ def test_check_units_resolution_is_valid_skip_no_spike_times():
 
 
 def test_check_units_resolution_is_valid_skip_not_set():
-    """Units with resolution not set should be skipped (handled by the other check)."""
+    """Units with resolution not set should pass."""
     units_table = Units()
     units_table.add_unit(spike_times=[0.1, 0.2, 0.3])
     assert check_units_resolution_is_valid(units_table) is None

--- a/tests/unit_tests/test_ecephys.py
+++ b/tests/unit_tests/test_ecephys.py
@@ -81,14 +81,6 @@ def test_check_units_resolution_is_set_pass_positive_float():
     assert check_units_resolution_is_set(units_table) is None
 
 
-def test_check_units_resolution_is_set_pass_no_spike_times():
-    """Units without spike_times column should skip the check."""
-    units_table = Units()
-    units_table.add_column(name="custom_col", description="test")
-    units_table.add_row(custom_col=1)
-    assert check_units_resolution_is_set(units_table) is None
-
-
 def test_check_units_resolution_is_set_fail_nan():
     """Units with resolution set to NaN should fail."""
     units_table = Units(resolution=float("nan"))
@@ -132,14 +124,6 @@ def test_check_units_resolution_is_valid_pass_valid():
     """Resolution of 1/30000 should pass."""
     units_table = Units(resolution=1 / 30000)
     units_table.add_unit(spike_times=[0.1, 0.2, 0.3])
-    assert check_units_resolution_is_valid(units_table) is None
-
-
-def test_check_units_resolution_is_valid_skip_no_spike_times():
-    """Units without spike_times should skip the check."""
-    units_table = Units(resolution=30000.0)
-    units_table.add_column(name="custom_col", description="test")
-    units_table.add_row(custom_col=1)
     assert check_units_resolution_is_valid(units_table) is None
 
 

--- a/tests/unit_tests/test_ecephys.py
+++ b/tests/unit_tests/test_ecephys.py
@@ -19,6 +19,7 @@ from nwbinspector.checks import (
     check_electrodes_location_allen_ccf,
     check_negative_spike_times,
     check_spike_times_not_in_unobserved_interval,
+    check_units_resolution_in_range,
     check_units_resolution_is_set,
     check_units_table_duration,
 )
@@ -107,6 +108,60 @@ def test_check_units_resolution_is_set_fail_negative():
     units_table = Units(resolution=-1.0)
     units_table.add_unit(spike_times=[0.1, 0.2, 0.3])
     assert check_units_resolution_is_set(units_table) is not None
+
+
+def test_check_units_resolution_in_range_fail_sampling_rate():
+    """Resolution set to a sampling rate value (e.g., 30000) should fail."""
+    units_table = Units(resolution=30000.0)
+    units_table.add_unit(spike_times=[0.1, 0.2, 0.3])
+    assert check_units_resolution_in_range(units_table) == InspectorMessage(
+        message=(
+            "Units table resolution is 30000.0, which is unexpectedly large. "
+            "Resolution should be 1/sampling_rate (e.g., 1/30000 for a 30 kHz system), "
+            "not the sampling rate itself."
+        ),
+        importance=Importance.BEST_PRACTICE_VIOLATION,
+        check_function_name="check_units_resolution_in_range",
+        object_type="Units",
+        object_name="Units",
+        location="/",
+    )
+
+
+def test_check_units_resolution_in_range_fail_borderline():
+    """Resolution just above 0.01 should fail."""
+    units_table = Units(resolution=0.011)
+    units_table.add_unit(spike_times=[0.1, 0.2, 0.3])
+    assert check_units_resolution_in_range(units_table) is not None
+
+
+def test_check_units_resolution_in_range_pass_valid():
+    """Resolution of 1/30000 should pass."""
+    units_table = Units(resolution=1 / 30000)
+    units_table.add_unit(spike_times=[0.1, 0.2, 0.3])
+    assert check_units_resolution_in_range(units_table) is None
+
+
+def test_check_units_resolution_in_range_pass_at_boundary():
+    """Resolution of exactly 0.01 should pass."""
+    units_table = Units(resolution=0.01)
+    units_table.add_unit(spike_times=[0.1, 0.2, 0.3])
+    assert check_units_resolution_in_range(units_table) is None
+
+
+def test_check_units_resolution_in_range_skip_no_spike_times():
+    """Units without spike_times should skip the check."""
+    units_table = Units(resolution=30000.0)
+    units_table.add_column(name="custom_col", description="test")
+    units_table.add_row(custom_col=1)
+    assert check_units_resolution_in_range(units_table) is None
+
+
+def test_check_units_resolution_in_range_skip_not_set():
+    """Units with resolution not set should be skipped (handled by the other check)."""
+    units_table = Units()
+    units_table.add_unit(spike_times=[0.1, 0.2, 0.3])
+    assert check_units_resolution_in_range(units_table) is None
 
 
 class TestCheckElectricalSeries(TestCase):

--- a/tests/unit_tests/test_ecephys.py
+++ b/tests/unit_tests/test_ecephys.py
@@ -19,6 +19,7 @@ from nwbinspector.checks import (
     check_electrodes_location_allen_ccf,
     check_negative_spike_times,
     check_spike_times_not_in_unobserved_interval,
+    check_units_resolution_is_set,
     check_units_table_duration,
 )
 
@@ -50,6 +51,62 @@ def test_check_negative_spike_times_some_negative():
         object_name="Units",
         location="/",
     )
+
+
+def test_check_units_resolution_is_set_fail_not_set():
+    """Units with spike_times but no resolution set should fail."""
+    units_table = Units()
+    units_table.add_unit(spike_times=[0.1, 0.2, 0.3])
+    assert check_units_resolution_is_set(units_table) == InspectorMessage(
+        message=(
+            "Units table has spike_times but resolution is not set. "
+            "Resolution indicates the smallest possible difference between two spike times "
+            "and should be set to 1/sampling_rate of the recording system "
+            "(e.g., Units(resolution=1/30000) for a 30 kHz system). "
+            "This information is needed to assess the precision of spike timing data."
+        ),
+        importance=Importance.BEST_PRACTICE_VIOLATION,
+        check_function_name="check_units_resolution_is_set",
+        object_type="Units",
+        object_name="Units",
+        location="/",
+    )
+
+
+def test_check_units_resolution_is_set_pass_positive_float():
+    """Units with resolution set to a meaningful positive float should pass."""
+    units_table = Units(resolution=1 / 30000)
+    units_table.add_unit(spike_times=[0.1, 0.2, 0.3])
+    assert check_units_resolution_is_set(units_table) is None
+
+
+def test_check_units_resolution_is_set_pass_no_spike_times():
+    """Units without spike_times column should skip the check."""
+    units_table = Units()
+    units_table.add_column(name="custom_col", description="test")
+    units_table.add_row(custom_col=1)
+    assert check_units_resolution_is_set(units_table) is None
+
+
+def test_check_units_resolution_is_set_fail_nan():
+    """Units with resolution set to NaN should fail."""
+    units_table = Units(resolution=float("nan"))
+    units_table.add_unit(spike_times=[0.1, 0.2, 0.3])
+    assert check_units_resolution_is_set(units_table) is not None
+
+
+def test_check_units_resolution_is_set_fail_zero():
+    """Units with resolution set to 0.0 should fail."""
+    units_table = Units(resolution=0.0)
+    units_table.add_unit(spike_times=[0.1, 0.2, 0.3])
+    assert check_units_resolution_is_set(units_table) is not None
+
+
+def test_check_units_resolution_is_set_fail_negative():
+    """Units with resolution set to a negative value should fail."""
+    units_table = Units(resolution=-1.0)
+    units_table.add_unit(spike_times=[0.1, 0.2, 0.3])
+    assert check_units_resolution_is_set(units_table) is not None
 
 
 class TestCheckElectricalSeries(TestCase):

--- a/tests/unit_tests/test_ecephys.py
+++ b/tests/unit_tests/test_ecephys.py
@@ -62,7 +62,7 @@ def test_check_units_resolution_is_set_fail_not_set():
         message=(
             "Units table has spike_times but resolution is not set. "
             "Resolution indicates the smallest possible difference between two spike times "
-            "and should be set to 1/sampling_rate of the recording system "
+            "and should be a positive float equal to 1/sampling_rate of the recording system "
             "(e.g., Units(resolution=1/30000) for a 30 kHz system). "
             "This information is needed to assess the precision of spike timing data."
         ),

--- a/tests/unit_tests/test_ecephys.py
+++ b/tests/unit_tests/test_ecephys.py
@@ -19,7 +19,7 @@ from nwbinspector.checks import (
     check_electrodes_location_allen_ccf,
     check_negative_spike_times,
     check_spike_times_not_in_unobserved_interval,
-    check_units_resolution_in_range,
+    check_units_resolution_is_valid,
     check_units_resolution_is_set,
     check_units_table_duration,
 )
@@ -110,58 +110,44 @@ def test_check_units_resolution_is_set_fail_negative():
     assert check_units_resolution_is_set(units_table) is not None
 
 
-def test_check_units_resolution_in_range_fail_sampling_rate():
+def test_check_units_resolution_is_valid_fail_sampling_rate():
     """Resolution set to a sampling rate value (e.g., 30000) should fail."""
     units_table = Units(resolution=30000.0)
     units_table.add_unit(spike_times=[0.1, 0.2, 0.3])
-    assert check_units_resolution_in_range(units_table) == InspectorMessage(
+    assert check_units_resolution_is_valid(units_table) == InspectorMessage(
         message=(
             "Units table resolution is 30000.0, which is unexpectedly large. "
             "Resolution should be 1/sampling_rate (e.g., 1/30000 for a 30 kHz system), "
             "not the sampling rate itself."
         ),
         importance=Importance.BEST_PRACTICE_VIOLATION,
-        check_function_name="check_units_resolution_in_range",
+        check_function_name="check_units_resolution_is_valid",
         object_type="Units",
         object_name="Units",
         location="/",
     )
 
 
-def test_check_units_resolution_in_range_fail_borderline():
-    """Resolution just above 0.01 should fail."""
-    units_table = Units(resolution=0.011)
-    units_table.add_unit(spike_times=[0.1, 0.2, 0.3])
-    assert check_units_resolution_in_range(units_table) is not None
-
-
-def test_check_units_resolution_in_range_pass_valid():
+def test_check_units_resolution_is_valid_pass_valid():
     """Resolution of 1/30000 should pass."""
     units_table = Units(resolution=1 / 30000)
     units_table.add_unit(spike_times=[0.1, 0.2, 0.3])
-    assert check_units_resolution_in_range(units_table) is None
+    assert check_units_resolution_is_valid(units_table) is None
 
 
-def test_check_units_resolution_in_range_pass_at_boundary():
-    """Resolution of exactly 0.01 should pass."""
-    units_table = Units(resolution=0.01)
-    units_table.add_unit(spike_times=[0.1, 0.2, 0.3])
-    assert check_units_resolution_in_range(units_table) is None
-
-
-def test_check_units_resolution_in_range_skip_no_spike_times():
+def test_check_units_resolution_is_valid_skip_no_spike_times():
     """Units without spike_times should skip the check."""
     units_table = Units(resolution=30000.0)
     units_table.add_column(name="custom_col", description="test")
     units_table.add_row(custom_col=1)
-    assert check_units_resolution_in_range(units_table) is None
+    assert check_units_resolution_is_valid(units_table) is None
 
 
-def test_check_units_resolution_in_range_skip_not_set():
+def test_check_units_resolution_is_valid_skip_not_set():
     """Units with resolution not set should be skipped (handled by the other check)."""
     units_table = Units()
     units_table.add_unit(spike_times=[0.1, 0.2, 0.3])
-    assert check_units_resolution_in_range(units_table) is None
+    assert check_units_resolution_is_valid(units_table) is None
 
 
 class TestCheckElectricalSeries(TestCase):

--- a/tests/unit_tests/test_ecephys.py
+++ b/tests/unit_tests/test_ecephys.py
@@ -19,8 +19,8 @@ from nwbinspector.checks import (
     check_electrodes_location_allen_ccf,
     check_negative_spike_times,
     check_spike_times_not_in_unobserved_interval,
-    check_units_resolution_is_valid,
     check_units_resolution_is_set,
+    check_units_resolution_is_valid,
     check_units_table_duration,
 )
 


### PR DESCRIPTION
The `resolution` field on the Units table indicates the smallest possible difference between two spike times, in seconds (i.e., `1/sampling_rate`). This field is almost never set in practice but it carries meaningful information about the precision of spike timing data. Downstream users need this to judge whether fine-timescale analyses are appropriate for a given dataset, for example, cross-correlograms for monosynaptic connection detection require sub-millisecond timing precision that not all recording systems provide.

This PR adds `check_units_resolution_is_set`, which flags at `BEST_PRACTICE_VIOLATION` level when a Units table has spike_times but resolution is not a meaningful positive float (None, NaN, or <= 0). The message tells users exactly what to set and why: `Units(resolution=1/30000)` for a 30 kHz system.

Relates to https://github.com/NeurodataWithoutBorders/nwb-schema/pull/666, #676, #683.

c.c @alejoe91 