### PR TITLE
Add GitHub link to ReadTheDocs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,6 +43,14 @@ html_theme_options = {
     "collapse_navigation": False,
 }
 
+html_context = {
+    "display_github": True,
+    "github_user": "NeurodataWithoutBorders",
+    "github_repo": "nwbinspector",
+    "github_version": "dev",
+    "conf_py_path": "/docs/",
+}
+
 # --------------------------------------------------
 # Extension configuration
 # --------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `html_context` to `docs/conf.py` so the sphinx-rtd-theme displays a GitHub icon in the navbar and "Edit on GitHub" links on each page, pointing to `NeurodataWithoutBorders/nwbinspector`.

## Test plan
- [x] Built docs locally and verified GitHub link appears in the RTD theme header

🤖 Generated with [Claude Code](https://claude.com/claude-code)