### PR TITLE
Update ReadTheDocs build image to Ubuntu 24.04

### DIFF
--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -6,9 +6,9 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
-    python: "3.10"
+    python: "3.13"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/docs/requirements-rtd.txt
+++ b/docs/requirements-rtd.txt
@@ -1,8 +1,8 @@
 numpy
 jsonschema==3.2.0
 Jinja2>=3.1.3
-sphinx==5.1.1
-sphinx_rtd_theme==0.5.1
-readthedocs-sphinx-search==0.3.2
-sphinx-copybutton==0.5.0
-sphinx-tabs==3.4.7
+sphinx>=7.4
+sphinx_rtd_theme>=2.0
+readthedocs-sphinx-search>=0.3.2
+sphinx-copybutton>=0.5.0
+sphinx-tabs>=3.4.7


### PR DESCRIPTION
## Summary
- Update ReadTheDocs build image from `ubuntu-20.04` to `ubuntu-24.04` (ubuntu-20.04 is deprecated after June 1, 2026)
- Update Python from 3.10 to 3.13
- Update Sphinx and related doc dependencies to versions compatible with Python 3.13 (`imghdr` was removed in Python 3.13, breaking Sphinx 5.x)

Fixes #693

See: https://docs.readthedocs.io/en/stable/config-file/v2.html#build-os