### PR TITLE
Fix DynamicTableRegion tests for latest HDMF

### DIFF
--- a/tests/unit_tests/test_tables.py
+++ b/tests/unit_tests/test_tables.py
@@ -32,7 +32,9 @@ class TestCheckDynamicTableRegion(TestCase):
             self.table.add_row(test_column=1)
 
     def test_check_dynamic_table_region_data_validity_lt_zero(self):
-        dynamic_table_region = DynamicTableRegion(name="dyn_tab", description="desc", data=[-1, 0], table=self.table)
+        # Create without table to bypass HDMF's validation of data bounds, then set table
+        dynamic_table_region = DynamicTableRegion(name="dyn_tab", description="desc", data=[-1, 0])
+        dynamic_table_region.table = self.table
 
         assert check_dynamic_table_region_data_validity(dynamic_table_region) == InspectorMessage(
             message="Some elements of dyn_tab are out of range because they are less than 0.",
@@ -44,7 +46,9 @@ class TestCheckDynamicTableRegion(TestCase):
         )
 
     def test_check_dynamic_table_region_data_validity_gt_len(self):
-        dynamic_table_region = DynamicTableRegion(name="dyn_tab", description="desc", data=[0, 20], table=self.table)
+        # Create without table to bypass HDMF's validation of data bounds, then set table
+        dynamic_table_region = DynamicTableRegion(name="dyn_tab", description="desc", data=[0, 20])
+        dynamic_table_region.table = self.table
 
         assert check_dynamic_table_region_data_validity(dynamic_table_region) == InspectorMessage(
             message=(


### PR DESCRIPTION
## Summary
- HDMF now validates `DynamicTableRegion` data bounds at construction time, raising `IndexError` for out-of-range values
- Updated two tests to construct `DynamicTableRegion` without the `table` argument first, then assign `table` afterwards to bypass validation while still testing our check function

Fixes #695

## Test plan
- [x] `test_check_dynamic_table_region_data_validity_lt_zero` passes
- [x] `test_check_dynamic_table_region_data_validity_gt_len` passes
- [x] All 47 tests in `test_tables.py` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)