### PR TITLE
Fix latent run_checks crash and unblock mypy v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 
 ### Fixes
+* Fixed `run_checks` raising `TypeError` when a `progress_bar_class` was passed without `progress_bar_options`; the keyword arguments are now coalesced to an empty dict before being forwarded to the progress-bar constructor. [#701](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/701)
 
 # v0.7.2 (May 19, 2026)
 

--- a/src/nwbinspector/_nwb_inspection.py
+++ b/src/nwbinspector/_nwb_inspection.py
@@ -442,7 +442,7 @@ def run_checks(
         Otherwise, has length zero (if cast as `list`), or raises `StopIteration` (if explicitly calling `next`).
     """
     if progress_bar_class is not None:
-        check_progress = progress_bar_class(iterable=checks, total=len(checks), **progress_bar_options)
+        check_progress = progress_bar_class(iterable=checks, total=len(checks), **(progress_bar_options or {}))
     else:
         check_progress = checks
 

--- a/src/nwbinspector/_registration.py
+++ b/src/nwbinspector/_registration.py
@@ -20,7 +20,7 @@ if _HAS_HDMF_ZARR:
 else:
     _DATASET_TYPES = (h5py.Dataset,)
 
-available_checks = list()
+available_checks: list = []
 
 
 # TODO: neurodata_type could have annotation hdmf.utils.ExtenderMeta, which seems to apply to all currently checked


### PR DESCRIPTION
The mypy bump to v2.1.0 on `dev` (13d0d67) surfaced a real latent bug in `run_checks`: when a caller passed `progress_bar_class` without also passing `progress_bar_options`, the default `None` was being splatted directly into the progress-bar constructor and would raise `TypeError`. This PR coalesces the kwargs to an empty dict before forwarding. The other change is a one-line annotation on `available_checks` in `_registration.py` to satisfy mypy 2.x's stricter `var-annotated` checking and has no behavior impact.
