### PR TITLE
Fix external-file ImageSeries test and require pynwb>=4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@
 ### New Checks
 
 ### Improvements
+* Raised the minimum required PyNWB to `>=4.0` to track the latest PyNWB release. [#708](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/708)
 * Bumped GitHub Actions workflow dependencies (`actions/checkout` v4 -> v6, `actions/setup-python` v5 -> v6, `codecov/codecov-action` v4 -> v5) to migrate off Node.js 20, which GitHub is removing from runners on 2026-09-16. [#702](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/702)
 
 ### Fixes
-* Fixed unit tests that failed at construction time against recent PyNWB and HDMF. [#707](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/707)
+* Fixed unit tests that failed at construction time against recent PyNWB and HDMF. [#707](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/707) [#708](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/708)
 * Fixed `run_checks` raising `TypeError` when a `progress_bar_class` was passed without `progress_bar_options`; the keyword arguments are now coalesced to an empty dict before being forwarded to the progress-bar constructor. [#701](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/701)
 
 # v0.7.2 (May 19, 2026)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "pynwb>=3.1",   # NWB Inspector should always be used with most recent minor versions of PyNWB
+    "pynwb>=4.0",   # NWB Inspector should always be used with most recent minor versions of PyNWB
     "fsspec",
     "requests",
     "aiohttp",

--- a/tests/unit_tests/test_image_series.py
+++ b/tests/unit_tests/test_image_series.py
@@ -58,6 +58,7 @@ class TestExternalFileValid(unittest.TestCase):
             rate=1.0,
             external_file=[bytes("/".join([".", good_external_path.name]), "utf-8")],
             format="external",
+            num_samples=1,
         )
         assert check_image_series_external_file_relative(image_series=image_series) is None
 


### PR DESCRIPTION
Follow-up to #707.

## Problem

After PyNWB 4.0.0 was released, the daily and dev CI workflows started failing on `tests/unit_tests/test_image_series.py::TestExternalFileValid::test_check_image_series_external_file_valid_bytestring_pass`:

```
ValueError: ImageSeries 'TestImageSeries': num_samples should be set when format='external'
and rate is used for timing, because data is empty and its length cannot be used to determine
the number of frames.
```

PyNWB 4.0.0 added validation that an `ImageSeries` with `format='external'` and `rate` timing must set `num_samples`, since the frame count cannot be inferred from the (empty) data length. The test constructs exactly such an `ImageSeries` without `num_samples`, so it now raises at construction time.

#707 ran against PyNWB 3.1.3 (PyNWB 4.0.0 had not yet been released), so it did not surface this. The scheduled runs picked up 4.0.0 once it was published.

## Changes

- Pass `num_samples=1` when constructing the `ImageSeries` in that test, satisfying the PyNWB 4.0.0 validation.
- Raise the minimum PyNWB to `>=4.0` in `pyproject.toml`. NWB Inspector targets the latest PyNWB only (see #510), and the latest release is now 4.0.0, so the floor is bumped to match.

## Scope

The test is the only place in the suite combining `format="external"` with `rate` timing and empty data. Other external-file constructions use `timestamps`, which derive the frame count and do not trip the new check.

Note: the `test-dandi-dev` / `test-dandi-dev-live` jobs fail with the same `ValueError` raised from DANDI's own test fixtures (`dandi/tests/fixtures.py`), which is an upstream DANDI incompatibility with PyNWB 4.0 and is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)