### PR TITLE
Skip Ontobee in documentation external link check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Bumped GitHub Actions workflow dependencies (`actions/checkout` v4 -> v6, `actions/setup-python` v5 -> v6, `codecov/codecov-action` v4 -> v5) to migrate off Node.js 20, which GitHub is removing from runners on 2026-09-16. [#702](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/702)
 
 ### Fixes
+* Skipped Ontobee in the documentation external link check, which frequently timed out and caused spurious CI failures. [#709](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/709)
 * Fixed unit tests that failed at construction time against recent PyNWB and HDMF. [#707](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/707)
 * Fixed `run_checks` raising `TypeError` when a `progress_bar_class` was passed without `progress_bar_options`; the keyword arguments are now coalesced to an empty dict before being forwarded to the progress-bar constructor. [#701](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/701)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,6 +51,12 @@ html_context = {
     "conf_py_path": "/docs/",
 }
 
+# linkcheck
+# Ontobee is frequently slow or unreachable, so external link checking skips it to avoid spurious failures.
+linkcheck_ignore = [
+    r"https://ontobee\.org/?.*",
+]
+
 # --------------------------------------------------
 # Extension configuration
 # --------------------------------------------------


### PR DESCRIPTION
## Problem

The `run-doc-link-checks` job (`sphinx-build -b linkcheck`) failed because the Ontobee server timed out:

```
(api/checks: line 3) timeout https://ontobee.org/ - HTTPSConnectionPool(host='ontobee.org', port=443):
Max retries exceeded ... Connection to ontobee.org timed out. (connect timeout=30)
```

Ontobee is frequently slow or unreachable, and a timeout is treated as a broken link, which fails the build. This is the only link causing the failure: the two redirecting links in `nwbfile_metadata.rst` are persistent identifiers (a `purl.obolibrary.org` PURL and a `doi.org` DOI) that are designed to redirect, and Sphinx does not treat redirects as failures.

## Fix

Add Ontobee to `linkcheck_ignore` in `docs/conf.py` so the external link check no longer depends on its availability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)