### PR TITLE
Fix IndexError in check_table_values_for_dict on empty tables (fixes #712)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Fixed unit tests that failed at construction time against recent PyNWB and HDMF. [#707](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/707) [#708](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/708)
 * Skipped Ontobee in the documentation external link check, which frequently timed out and caused spurious CI failures. [#709](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/709)
 * Fixed `run_checks` raising `TypeError` when a `progress_bar_class` was passed without `progress_bar_options`; the keyword arguments are now coalesced to an empty dict before being forwarded to the progress-bar constructor. [#701](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/701)
+* Fixed `check_table_values_for_dict` raising `IndexError` on empty tables. Columns with zero-length data (as found in an empty `DynamicTable` or `EventsTable`) are now skipped before `column.data[0]` is accessed. [#712](https://github.com/NeurodataWithoutBorders/nwbinspector/issues/712)
 
 # v0.7.2 (May 19, 2026)
 

--- a/src/nwbinspector/checks/_tables.py
+++ b/src/nwbinspector/checks/_tables.py
@@ -252,7 +252,12 @@ def check_table_values_for_dict(
 ) -> Optional[Iterable[InspectorMessage]]:
     """Check if any values in a row or column of a table contain a string casting of a Python dictionary."""
     for column in table.columns:
-        if not hasattr(column, "data") or isinstance(column, VectorIndex) or not isinstance(column.data[0], str):
+        if (
+            not hasattr(column, "data")
+            or isinstance(column, VectorIndex)
+            or len(column.data) == 0
+            or not isinstance(column.data[0], str)
+        ):
             continue
         for string in cache_data_selection(data=column.data, selection=slice(nelems)):
             if is_dict_in_string(string=string):

--- a/tests/unit_tests/test_tables.py
+++ b/tests/unit_tests/test_tables.py
@@ -424,6 +424,18 @@ def test_check_table_values_for_dict_json_case_fail():
     ]
 
 
+def test_check_table_values_for_dict_empty_column():
+    """Regression test for https://github.com/NeurodataWithoutBorders/nwbinspector/issues/712.
+
+    An empty table has columns with zero-length data; the check must skip them instead of
+    raising IndexError on ``column.data[0]``.
+    """
+    table = DynamicTable(name="test_table", description="")
+    table.add_column(name="test_column", description="")
+
+    assert check_table_values_for_dict(table=table) is None
+
+
 def test_check_col_not_nan_pass():
     table = DynamicTable(name="test_table", description="")
     for name in ["test_column_not_nan", "test_column_string"]:


### PR DESCRIPTION
## Motivation

`check_table_values_for_dict` crashes with `IndexError: list index out of range`
whenever it is run on a table that has a column with zero rows. Empty `DynamicTable` /
`EventsTable` objects are legitimate NWB constructs, so nwbinspector currently crashes
on any file that contains one.

Root cause (diagnosed by @oruebel in #712), in `src/nwbinspector/checks/_tables.py`,
the per-column skip condition:

```python
for column in table.columns:
    if not hasattr(column, "data") or isinstance(column, VectorIndex) or not isinstance(column.data[0], str):
        continue
```

`column.data[0]` is evaluated with no empty-length guard, so a zero-length column
raises `IndexError`.

## What

Add a `len(column.data) == 0` guard to the skip condition, placed **before** the
`column.data[0]` access so Python's `or` short-circuits on empty columns:

```python
for column in table.columns:
    if (
        not hasattr(column, "data")
        or isinstance(column, VectorIndex)
        or len(column.data) == 0
        or not isinstance(column.data[0], str)
    ):
        continue
```

The multi-line form matches the sibling check `check_col_not_nan` directly below in the
same file. `black --line-length 120` and `ruff` both pass.

### Why this does not over-skip non-empty columns

`or` evaluates left-to-right and stops at the first truthy operand:

- **Empty column** (`len(column.data) == 0` is `True`): short-circuits and `continue`s,
  so `column.data[0]` is never evaluated — the crash is avoided.
- **Non-empty column** (`len(column.data) == 0` is `False`): evaluation falls through to
  `not isinstance(column.data[0], str)`, exactly as before. The new term is `False` for
  every non-empty column, so it changes nothing about which non-empty columns get
  scanned, and the dict-detection logic is untouched.

Only genuinely empty columns are skipped.

## Tests

Added `test_check_table_values_for_dict_empty_column` to `tests/unit_tests/test_tables.py`:

```python
def test_check_table_values_for_dict_empty_column():
    table = DynamicTable(name="test_table", description="")
    table.add_column(name="test_column", description="")
    assert check_table_values_for_dict(table=table) is None
```

- **Before the fix:** fails with `IndexError` at the diagnosed line.
- **After the fix:** passes.

The existing `test_check_table_values_for_dict_*_fail` tests continue to pass, confirming
a non-empty column containing a dict-string still triggers the check (no over-skip).
`pytest tests/unit_tests/test_tables.py` → 48 passed; broad slice → 340 passed, 7 skipped.

## Follow-up (out of scope for #712)

Scoped to `check_table_values_for_dict` per @oruebel's diagnosis. Three sibling checks in
the same file carry the *same* latent empty-table `IndexError` and would still crash on a
full run over an empty table — worth a separate follow-up PR if desired:

- `check_column_binary_capability` — `column.data[0]`
- `check_col_not_nan` — `column[0]`
- `check_table_time_columns_are_not_negative` — `table[column_name][0]`

Happy to open that follow-up.

## CHANGELOG

Added an entry under `# v0.7.3 (Upcoming)` → `### Fixes`.
