### PR TITLE
Add check_image_series_external_file_forward_slashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v0.7.3 (Upcoming)
 
 ### New Checks
+* Added `check_image_series_external_file_forward_slashes` to detect backslashes in `ImageSeries.external_file` paths. Such paths are produced by platform-dependent path joining on Windows and silently fail to resolve on POSIX systems and against archive asset keys such as those used by DANDI. [#697](https://github.com/NeurodataWithoutBorders/nwbinspector/issues/697)
 * Added `check_spike_times_without_nans` to detect NaN values in Units spike times, which indicate conversion bugs or unclean array padding. [#689](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/689)
 * Added `check_subject_age_reference` to validate that `Subject.age__reference`, when present, is one of the supported values (`"birth"` or `"gestational"`). This catches invalid references in files written by tools that do not enforce the schema constraint. [#250](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/250)
 

--- a/docs/best_practices/image_series.rst
+++ b/docs/best_practices/image_series.rst
@@ -35,6 +35,19 @@ When using ``external_file`` the paths passed in the ``external_file`` option sh
 Check function: :py:meth:`~nwbinspector.checks._image_series.check_image_series_external_file_relative`
 
 
+.. _best_practice_image_series_external_file_forward_slashes:
+
+Use forward slashes in external file paths
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The paths passed in the ``external_file`` option should use forward slashes (``/``) as path separators, even when the
+file is written on Windows. Backslashes are introduced by platform-dependent path joining, but they are not treated as
+separators on POSIX systems, and archive asset keys (such as those used by the DANDI Archive) always use forward
+slashes. A path such as ``ses-1_image\abc123_external_file_0.mp4`` will therefore silently fail to resolve.
+
+Check function: :py:meth:`~nwbinspector.checks._image_series.check_image_series_external_file_forward_slashes`
+
+
 .. _best_practice_starting_frame_only_with_external_file:
 
 Starting frame only with external file

--- a/src/nwbinspector/checks/__init__.py
+++ b/src/nwbinspector/checks/__init__.py
@@ -32,6 +32,7 @@ from ._icephys import (
 )
 from ._image_series import (
     check_image_series_data_size,
+    check_image_series_external_file_forward_slashes,
     check_image_series_external_file_relative,
     check_image_series_external_file_valid,
     check_image_series_starting_frame_without_external_file,
@@ -121,6 +122,7 @@ __all__ = [
     "check_name_slashes",
     "check_name_colons",
     "check_image_series_data_size",
+    "check_image_series_external_file_forward_slashes",
     "check_image_series_external_file_relative",
     "check_image_series_external_file_valid",
     "check_image_series_starting_frame_without_external_file",

--- a/src/nwbinspector/checks/_image_series.py
+++ b/src/nwbinspector/checks/_image_series.py
@@ -56,6 +56,33 @@ def check_image_series_external_file_relative(image_series: ImageSeries) -> Opti
 
 
 @register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=ImageSeries)
+def check_image_series_external_file_forward_slashes(
+    image_series: ImageSeries,
+) -> Optional[Iterable[InspectorMessage]]:
+    """
+    Check that the external_file paths specified by an ImageSeries use forward slashes as separators.
+
+    Backslashes are produced by platform-dependent path joining on Windows, but they do not resolve as separators
+    on POSIX systems or against archive asset keys such as those used by DANDI.
+
+    Best Practice: :ref:`best_practice_image_series_external_file_forward_slashes`
+    """
+    if image_series.external_file is None:
+        return None
+    for file_path in image_series.external_file:
+        file_path = file_path.decode() if isinstance(file_path, bytes) else file_path
+        if "\\" in file_path:
+            yield InspectorMessage(
+                message=(
+                    f"The external file '{file_path}' contains a backslash ('\\'). "
+                    "Please use forward slashes ('/') as path separators so the path resolves on all platforms."
+                )
+            )
+
+    return None
+
+
+@register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=ImageSeries)
 def check_image_series_data_size(image_series: ImageSeries, gb_lower_bound: float = 20.0) -> Optional[InspectorMessage]:
     """
     Check if an ImageSeries stored is larger than gb_lower_bound and suggests external file.

--- a/tests/unit_tests/test_image_series.py
+++ b/tests/unit_tests/test_image_series.py
@@ -11,6 +11,7 @@ from pynwb.image import ImageSeries
 from nwbinspector import Importance, InspectorMessage
 from nwbinspector.checks import (
     check_image_series_data_size,
+    check_image_series_external_file_forward_slashes,
     check_image_series_external_file_relative,
     check_image_series_external_file_valid,
     check_image_series_starting_frame_without_external_file,
@@ -112,6 +113,64 @@ def test_check_image_series_external_file_valid_pass_non_external():
     image_series = ImageSeries(name="TestImageSeries", rate=1.0, data=np.zeros(shape=(3, 3, 3, 3)), unit="TestUnit")
 
     assert check_image_series_external_file_valid(image_series=image_series) is None
+
+
+def _make_external_image_series(external_file: list, name: str = "TestImageSeries") -> ImageSeries:
+    return ImageSeries(
+        name=name,
+        rate=1.0,
+        external_file=external_file,
+        starting_frame=list(range(len(external_file))),  # PyNWB requires one starting frame per external file
+        format="external",
+        num_samples=len(external_file),
+    )
+
+
+def test_check_image_series_external_file_forward_slashes_pass():
+    image_series = _make_external_image_series(external_file=["sub-1/ses-1_image/video_external_file_0.mp4"])
+
+    assert check_image_series_external_file_forward_slashes(image_series=image_series) is None
+
+
+def test_check_image_series_external_file_forward_slashes_pass_non_external():
+    image_series = ImageSeries(name="TestImageSeries", rate=1.0, data=np.zeros(shape=(3, 3, 3, 3)), unit="TestUnit")
+
+    assert check_image_series_external_file_forward_slashes(image_series=image_series) is None
+
+
+def test_check_image_series_external_file_forward_slashes_trigger():
+    image_series = _make_external_image_series(external_file=["ses-1_image\\abc123_external_file_0.mp4"])
+
+    assert check_image_series_external_file_forward_slashes(image_series=image_series)[0] == InspectorMessage(
+        message=(
+            "The external file 'ses-1_image\\abc123_external_file_0.mp4' contains a backslash ('\\'). "
+            "Please use forward slashes ('/') as path separators so the path resolves on all platforms."
+        ),
+        importance=Importance.BEST_PRACTICE_VIOLATION,
+        check_function_name="check_image_series_external_file_forward_slashes",
+        object_type="ImageSeries",
+        object_name="TestImageSeries",
+        location="/",
+    )
+
+
+def test_check_image_series_external_file_forward_slashes_bytestring_trigger():
+    """The paths may be read back as bytes depending on the h5py version."""
+    image_series = _make_external_image_series(external_file=[b"ses-1_image\\abc123_external_file_0.mp4"])
+
+    assert len(check_image_series_external_file_forward_slashes(image_series=image_series)) == 1
+
+
+def test_check_image_series_external_file_forward_slashes_trigger_multiple_files():
+    image_series = _make_external_image_series(
+        external_file=["good/video_0.mp4", "bad\\video_1.mp4", "bad\\video_2.mp4"]
+    )
+
+    messages = check_image_series_external_file_forward_slashes(image_series=image_series)
+
+    assert len(messages) == 2
+    assert "bad\\video_1.mp4" in messages[0].message
+    assert "bad\\video_2.mp4" in messages[1].message
 
 
 def test_check_small_image_series_stored_internally():


### PR DESCRIPTION
Closes #697

## Summary

Adds a check that flags backslashes in `ImageSeries.external_file` paths. These are produced by platform-dependent path joining on Windows (e.g. `ses-1_image\abc123_external_file_0.mp4`) and silently fail to resolve on POSIX systems and against archive asset keys, which always use forward slashes. This is what caused `get_dandi_video_info()` to return empty results for Dandiset 001771.

The check decodes bytes paths like the neighboring checks do, and yields one message per offending entry so a series with several external files reports each bad one.

## Severity

Registered at `BEST_PRACTICE_VIOLATION`, paralleling the sibling `check_image_series_external_file_relative`. A path that is genuinely broken locally is already reported as `CRITICAL` by `check_image_series_external_file_valid`. Happy to raise this to `CRITICAL` if reviewers feel the silent failure on the archive warrants it.

## Changes

- New `check_image_series_external_file_forward_slashes` in `src/nwbinspector/checks/_image_series.py`, exported from `checks/__init__.py`
- New best-practice section in `docs/best_practices/image_series.rst` under the `best_practice_image_series_external_file_forward_slashes` anchor referenced by the docstring
- CHANGELOG entry under "New Checks"

## Testing

Five new unit tests cover the passing forward-slash path, a non-external series, the backslash trigger, a bytestring path, and multiple external files. All tests in `test_image_series.py` pass; `ruff` and `black` are clean. Also ran end-to-end through `inspect_nwbfile` on a written NWB file containing one backslash and one forward-slash `ImageSeries` — the check fires on the backslash one only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)