### PR TITLE
Handle empty columns in dictionary check

### DIFF
--- a/src/nwbinspector/checks/_tables.py
+++ b/src/nwbinspector/checks/_tables.py
@@ -258,7 +258,12 @@ def check_table_values_for_dict(
         return None  # an empty table is reported by check_empty_table
 
     for column in table.columns:
-        if not hasattr(column, "data") or isinstance(column, VectorIndex) or not isinstance(column.data[0], str):
+        if (
+            not hasattr(column, "data")
+            or isinstance(column, VectorIndex)
+            or len(column.data) == 0
+            or not isinstance(column.data[0], str)
+        ):
             continue
         for string in cache_data_selection(data=column.data, selection=slice(nelems)):
             if is_dict_in_string(string=string):

--- a/tests/unit_tests/test_tables.py
+++ b/tests/unit_tests/test_tables.py
@@ -377,6 +377,13 @@ def test_check_table_values_for_dict_non_str():
     assert check_table_values_for_dict(table=table) is None
 
 
+def test_check_table_values_for_dict_empty_table():
+    table = DynamicTable(name="test_table", description="")
+    table.add_column(name="test_column", description="")
+
+    assert check_table_values_for_dict(table=table) is None
+
+
 def test_check_table_values_for_dict_pass():
     table = DynamicTable(name="test_table", description="")
     table.add_column(name="test_column", description="")


### PR DESCRIPTION
## Summary

- Skip empty table columns before inspecting their first value in `check_table_values_for_dict`.
- Add a regression test covering an empty `DynamicTable` column.

## Why

`DynamicTable` and `EventsTable` can define columns before any rows are added. The check previously indexed `column.data[0]` unconditionally, causing an `IndexError` during inspection instead of returning no finding.

Fixes #712.

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1`, `PYTHONPATH=src`: `377 passed, 30 skipped`
- `ruff check src/nwbinspector/checks/_tables.py tests/unit_tests/test_tables.py`: passed
- Black was not available in the local environment.
