### PR TITLE
Fix DynamicTableRegion upper-bound validation

### DIFF
--- a/src/nwbinspector/checks/_tables.py
+++ b/src/nwbinspector/checks/_tables.py
@@ -26,10 +26,11 @@ def check_dynamic_table_region_data_validity(
     dynamic_table_region: DynamicTableRegion, nelems: Optional[int] = NELEMS
 ) -> Optional[InspectorMessage]:
     """Check if a DynamicTableRegion is valid."""
-    if np.any(np.asarray(dynamic_table_region.data[:nelems]) > len(dynamic_table_region.table)):
+    if np.any(np.asarray(dynamic_table_region.data[:nelems]) >= len(dynamic_table_region.table)):
         return InspectorMessage(
             message=(
-                f"Some elements of {dynamic_table_region.name} are out of range because they are greater than the "
+                f"Some elements of {dynamic_table_region.name} are out of range because they are greater than or "
+                "equal to the "
                 "length of the target table. Note that data should contain indices, not ids."
             )
         )

--- a/tests/unit_tests/test_tables.py
+++ b/tests/unit_tests/test_tables.py
@@ -52,7 +52,8 @@ class TestCheckDynamicTableRegion(TestCase):
 
         assert check_dynamic_table_region_data_validity(dynamic_table_region) == InspectorMessage(
             message=(
-                "Some elements of dyn_tab are out of range because they are greater than the length of the target "
+                "Some elements of dyn_tab are out of range because they are greater than or equal to the length of "
+                "the target "
                 "table. Note that data should contain indices, not ids."
             ),
             importance=Importance.CRITICAL,
@@ -61,6 +62,16 @@ class TestCheckDynamicTableRegion(TestCase):
             object_name="dyn_tab",
             location="/",
         )
+
+    def test_check_dynamic_table_region_data_validity_equal_len(self):
+        # The valid table indices are 0 through len(table) - 1.
+        dynamic_table_region = DynamicTableRegion(name="dyn_tab", description="desc", data=[0, 1], table=self.table)
+        dynamic_table_region.data[:] = [0, len(self.table)]
+
+        result = check_dynamic_table_region_data_validity(dynamic_table_region)
+
+        assert result is not None
+        assert "greater than or equal to the length" in result.message
 
     def test_pass_check_dynamic_table_region_data(self):
         dynamic_table_region = DynamicTableRegion(name="dyn_tab", description="desc", data=[0, 1, 2], table=self.table)


### PR DESCRIPTION
## Summary

DynamicTableRegion stores zero-based row indices, so the largest valid value is len(table) - 1. The validator previously allowed an index equal to len(table), which is out of bounds.

This change:

- rejects indices greater than or equal to the target table length;
- updates the diagnostic message to describe the inclusive upper bound; and
- adds a regression test for the exact boundary value.

## Validation

- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/unit_tests/test_tables.py -q — 48 passed
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/unit_tests -q — 294 passed, 7 skipped