### PR TITLE
[New Check] Detect single uncompressed HDF5 chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v0.7.3 (Upcoming)
 
 ### New Checks
+* Added `check_single_chunk_dataset_compression` to flag large HDF5 datasets stored as a single uncompressed chunk, with guidance to use contiguous storage for smaller data or chunking and compression for larger data. [#722](https://github.com/NeurodataWithoutBorders/nwbinspector/issues/722)
 * Added `check_spike_times_without_nans` to detect NaN values in Units spike times, which indicate conversion bugs or unclean array padding. [#689](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/689)
 * Added `check_subject_age_reference` to validate that `Subject.age__reference`, when present, is one of the supported values (`"birth"` or `"gestational"`). This catches invalid references in files written by tools that do not enforce the schema constraint. [#250](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/250)
 

--- a/docs/best_practices/time_series.rst
+++ b/docs/best_practices/time_series.rst
@@ -183,7 +183,8 @@ chunk individually. This is especially important when writing NWBFiles that are 
 `MatNWB instructions <https://matnwb.readthedocs.io/en/latest/pages/tutorials/dataPipe.html>`_
 
 Check functions: :py::meth:`~nwbinspector.checks._nwb_containers.check_large_dataset_compression`,
-:py::meth:`~nwbinspector.checks._nwb_containers.check_small_dataset_compression`
+:py::meth:`~nwbinspector.checks._nwb_containers.check_small_dataset_compression`,
+:py::meth:`~nwbinspector.checks._nwb_containers.check_single_chunk_dataset_compression`
 
 
 

--- a/src/nwbinspector/checks/__init__.py
+++ b/src/nwbinspector/checks/__init__.py
@@ -44,6 +44,7 @@ from ._images import (
 from ._nwb_containers import (
     check_empty_string_for_optional_attribute,
     check_large_dataset_compression,
+    check_single_chunk_dataset_compression,
     check_small_dataset_compression,
 )
 from ._nwbfile_metadata import (
@@ -131,6 +132,7 @@ __all__ = [
     "check_empty_string_for_optional_attribute",
     "check_small_dataset_compression",
     "check_large_dataset_compression",
+    "check_single_chunk_dataset_compression",
     "check_keywords",
     "check_institution",
     "check_subject_age",

--- a/src/nwbinspector/checks/_nwb_containers.py
+++ b/src/nwbinspector/checks/_nwb_containers.py
@@ -95,6 +95,41 @@ def check_small_dataset_compression(
 
 
 @register_check(importance=Importance.BEST_PRACTICE_SUGGESTION, neurodata_type=NWBContainer)
+def check_single_chunk_dataset_compression(
+    nwb_container: NWBContainer, mb_lower_bound: float = 50.0
+) -> Optional[InspectorMessage]:
+    """
+    Check if a large HDF5 dataset is stored as one uncompressed chunk.
+
+    Unchunked datasets are not reported: contiguous storage is appropriate for
+    smaller datasets. A dataset that is chunked as one uncompressed block is
+    less useful for both access and storage once it is larger than
+    ``mb_lower_bound``.
+
+    Best Practice: :ref:`best_practice_compression`
+    """
+    for field in getattr(nwb_container, "fields", dict()).values():
+        if not isinstance(field, h5py.Dataset):
+            continue
+
+        if (
+            field.compression is None
+            and field.chunks is not None
+            and field.size * field.dtype.itemsize > mb_lower_bound * 1e6
+            and all(chunk >= size for chunk, size in zip(field.chunks, field.shape))
+        ):
+            return InspectorMessage(
+                message=(
+                    f"{os.path.split(field.name)[1]} is stored as a single uncompressed chunk. "
+                    "Consider leaving small datasets unchunked or enabling chunking and compression for larger "
+                    "datasets."
+                )
+            )
+
+    return None
+
+
+@register_check(importance=Importance.BEST_PRACTICE_SUGGESTION, neurodata_type=NWBContainer)
 def check_empty_string_for_optional_attribute(nwb_container: NWBContainer) -> Optional[Iterable[InspectorMessage]]:
     """
     Check if any NWBContainer has optional fields that are written as an empty string.

--- a/tests/unit_tests/test_nwb_containers.py
+++ b/tests/unit_tests/test_nwb_containers.py
@@ -13,6 +13,7 @@ from nwbinspector import Importance, InspectorMessage, Severity
 from nwbinspector.checks import (
     check_empty_string_for_optional_attribute,
     check_large_dataset_compression,
+    check_single_chunk_dataset_compression,
     check_small_dataset_compression,
 )
 
@@ -90,6 +91,65 @@ class TestNWBContainers(TestCase):
         with h5py.File(name=self.file_path, mode="w") as file:
             nwb_container = self.add_dataset_to_nwb_container(file=file, gb_size=0.001)
             self.assertIsNone(obj=check_large_dataset_compression(nwb_container=nwb_container))
+
+    def test_check_single_chunk_dataset_compression(self):
+        with h5py.File(name=self.file_path, mode="w") as file:
+            dataset = file.create_dataset(name="test_dataset", shape=(10,), dtype="float64", chunks=(10,))
+            nwb_container = NWBContainer(name="test_container")
+            nwb_container.fields.update(dataset=dataset)
+
+            result = check_single_chunk_dataset_compression(nwb_container=nwb_container, mb_lower_bound=0)
+
+            self.assertEqual(
+                first=result,
+                second=InspectorMessage(
+                    message=(
+                        "test_dataset is stored as a single uncompressed chunk. Consider leaving small datasets "
+                        "unchunked or enabling chunking and compression for larger datasets."
+                    ),
+                    importance=Importance.BEST_PRACTICE_SUGGESTION,
+                    check_function_name="check_single_chunk_dataset_compression",
+                    object_type="NWBContainer",
+                    object_name="test_container",
+                    location="/",
+                ),
+            )
+
+    def test_check_single_chunk_dataset_compression_at_threshold(self):
+        with h5py.File(name=self.file_path, mode="w") as file:
+            dataset = file.create_dataset(name="test_dataset", shape=(10,), dtype="float64", chunks=(10,))
+            nwb_container = NWBContainer(name="test_container")
+            nwb_container.fields.update(dataset=dataset)
+
+            self.assertIsNone(
+                obj=check_single_chunk_dataset_compression(nwb_container=nwb_container, mb_lower_bound=0.00008)
+            )
+
+    def test_check_single_chunk_dataset_compression_ignores_unchunked_dataset(self):
+        with h5py.File(name=self.file_path, mode="w") as file:
+            dataset = file.create_dataset(name="test_dataset", shape=(10,), dtype="float64")
+            nwb_container = NWBContainer(name="test_container")
+            nwb_container.fields.update(dataset=dataset)
+
+            self.assertIsNone(obj=check_single_chunk_dataset_compression(nwb_container=nwb_container, mb_lower_bound=0))
+
+    def test_check_single_chunk_dataset_compression_ignores_compressed_dataset(self):
+        with h5py.File(name=self.file_path, mode="w") as file:
+            dataset = file.create_dataset(
+                name="test_dataset", shape=(10,), dtype="float64", chunks=(10,), compression="gzip"
+            )
+            nwb_container = NWBContainer(name="test_container")
+            nwb_container.fields.update(dataset=dataset)
+
+            self.assertIsNone(obj=check_single_chunk_dataset_compression(nwb_container=nwb_container, mb_lower_bound=0))
+
+    def test_check_single_chunk_dataset_compression_ignores_multiple_chunks(self):
+        with h5py.File(name=self.file_path, mode="w") as file:
+            dataset = file.create_dataset(name="test_dataset", shape=(10,), dtype="float64", chunks=(5,))
+            nwb_container = NWBContainer(name="test_container")
+            nwb_container.fields.update(dataset=dataset)
+
+            self.assertIsNone(obj=check_single_chunk_dataset_compression(nwb_container=nwb_container, mb_lower_bound=0))
 
 
 def test_no_error_raised_when_dataset_is_compressed():


### PR DESCRIPTION
## Motivation

Closes #722.

Some HDF5 datasets are created with chunking enabled but the chunk shape is large enough to cover the entire dataset. When compression is disabled, this creates a single uncompressed chunk: it loses the flexibility of chunked storage without gaining compression. Contiguous storage is usually a better fit for smaller datasets, while larger datasets should use multiple chunks and compression.

## Changes

- Add `check_single_chunk_dataset_compression` for HDF5 datasets larger than the configurable 50 MB threshold.
- Ignore contiguous datasets, compressed datasets, and datasets that span multiple chunks.
- Emit an actionable suggestion that distinguishes the small/contiguous and large/chunked-compressed choices.
- Add boundary and storage-layout tests, export the check, document it with the other compression checks, and update the changelog.

## Validation

- `python -m ruff check src/nwbinspector/checks/_nwb_containers.py src/nwbinspector/checks/__init__.py tests/unit_tests/test_nwb_containers.py`
- `PYTHONPATH=src python -m pytest tests/unit_tests/test_nwb_containers.py tests/test_check_configuration.py -q` (23 passed)
- `python -m compileall -q src/nwbinspector tests/unit_tests/test_nwb_containers.py`

This contribution was developed with Codex assistance and reviewed against the existing check and test conventions.
