### PR TITLE
Check Units waveform electrode dimensions

### DIFF
--- a/docs/best_practices/ecephys.rst
+++ b/docs/best_practices/ecephys.rst
@@ -111,6 +111,19 @@ Check functions: :py:meth:`~nwbinspector.checks._ecephys.check_units_resolution_
 :py:meth:`~nwbinspector.checks._ecephys.check_units_resolution_is_valid`
 
 
+.. _best_practice_units_waveforms_electrodes:
+
+Waveform Electrode Dimension
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When a ``Units`` table stores individual ``waveforms``, each spike's waveform must contain one waveform row for
+every electrode listed in that unit's ``electrodes`` entry. A mismatch usually means the electrode and sample axes
+were transposed when the data was written. Keep the electrode order consistent with the referenced electrode table
+and verify the dimensions before sharing the NWB file.
+
+Check function: :py:meth:`~nwbinspector.checks._ecephys.check_units_waveforms_electrodes`
+
+
 .. _best_practice_spike_times_not_in_samples:
 
 Spike Times in Seconds

--- a/src/nwbinspector/checks/__init__.py
+++ b/src/nwbinspector/checks/__init__.py
@@ -19,6 +19,7 @@ from ._ecephys import (
     check_units_resolution_is_valid,
     check_units_table_duration,
     check_units_table_has_spikes,
+    check_units_waveforms_electrodes,
 )
 from ._general import (
     check_description,
@@ -200,4 +201,5 @@ __all__ = [
     "check_electrodes_location_allen_ccf",
     "check_intracellular_electrode_location_allen_ccf",
     "check_units_table_has_spikes",
+    "check_units_waveforms_electrodes",
 ]

--- a/src/nwbinspector/checks/_ecephys.py
+++ b/src/nwbinspector/checks/_ecephys.py
@@ -107,12 +107,18 @@ def check_units_waveforms_electrodes(units_table: Units) -> Optional[Iterable[In
         )
         return None
 
+    assert waveform_unit_ends is not None
+    assert electrode_unit_ends is not None
+    assert waveform_spike_index is not None
     n_spike_index_rows = len(waveform_spike_index)
     waveform_payload = getattr(getattr(waveforms_column, "target", None), "target", None)
-    try:
-        n_waveform_rows = len(waveform_payload)
-    except TypeError:
+    if waveform_payload is None:
         n_waveform_rows = None
+    else:
+        try:
+            n_waveform_rows = len(waveform_payload)
+        except TypeError:
+            n_waveform_rows = None
 
     if (len(waveform_unit_ends) and waveform_unit_ends[-1] > n_spike_index_rows) or (
         n_waveform_rows is not None and len(waveform_spike_index) and waveform_spike_index[-1] > n_waveform_rows

--- a/src/nwbinspector/checks/_ecephys.py
+++ b/src/nwbinspector/checks/_ecephys.py
@@ -72,6 +72,8 @@ def check_units_waveforms_electrodes(units_table: Units) -> Optional[Iterable[In
     Only the small index arrays are read; the waveform samples themselves are not
     accessed.  A malformed index is reported as a critical finding because the
     waveform/electrode relationship cannot be validated safely.
+
+    Best Practice: :ref:`best_practice_units_waveforms_electrodes`
     """
     if "waveforms" not in units_table or "electrodes" not in units_table:
         return None

--- a/src/nwbinspector/checks/_ecephys.py
+++ b/src/nwbinspector/checks/_ecephys.py
@@ -17,6 +17,31 @@ NELEMS = 200
 DURATION_THRESHOLD = 31557600.0
 
 
+def _read_index_data(index: object) -> Optional[np.ndarray]:
+    """Read a ragged-array index without touching the indexed payload."""
+    if not hasattr(index, "target"):
+        return None
+    try:
+        data = getattr(index, "data")
+        values = np.asarray(data[:])
+    except (AttributeError, IndexError, TypeError, ValueError):
+        return None
+
+    if values.ndim != 1 or not np.issubdtype(values.dtype, np.integer):
+        return None
+    return values.astype(np.int64, copy=False)
+
+
+def _ragged_row_lengths(index_data: np.ndarray, nrows: int) -> Optional[np.ndarray]:
+    """Return row lengths from cumulative ragged-array indices."""
+    if len(index_data) != nrows:
+        return None
+    if len(index_data) and (np.any(index_data < 0) or np.any(np.diff(index_data) < 0)):
+        return None
+    starts = np.concatenate((np.array([0], dtype=np.int64), index_data[:-1]))
+    return index_data - starts
+
+
 @register_check(importance=Importance.CRITICAL, neurodata_type=Units)
 def check_units_table_has_spikes(units_table: Units) -> Optional[InspectorMessage]:
     """
@@ -31,6 +56,115 @@ def check_units_table_has_spikes(units_table: Units) -> Optional[InspectorMessag
                 "A Units table without spike times is likely an error or misuse of the neurodata type."
             )
         )
+    return None
+
+
+@register_check(importance=Importance.CRITICAL, neurodata_type=Units)
+def check_units_waveforms_electrodes(units_table: Units) -> Optional[Iterable[InspectorMessage]]:
+    """Check that each unit's waveform channel count matches its electrode references.
+
+    ``Units.waveforms`` is a doubly-ragged column.  Its outer index groups spikes by
+    unit and its nested index groups waveform rows (one row per electrode) by spike.
+    Comparing the nested index increments with the ``electrodes`` index catches the
+    common mistake of swapping the electrode and sample dimensions when calling
+    :meth:`~pynwb.misc.Units.add_unit`.
+
+    Only the small index arrays are read; the waveform samples themselves are not
+    accessed.  A malformed index is reported as a critical finding because the
+    waveform/electrode relationship cannot be validated safely.
+    """
+    if "waveforms" not in units_table or "electrodes" not in units_table:
+        return None
+
+    n_units = len(units_table)
+    waveforms_column = units_table["waveforms"]
+    electrodes_column = units_table["electrodes"]
+
+    waveform_unit_ends = _read_index_data(waveforms_column)
+    waveform_spike_index = _read_index_data(getattr(waveforms_column, "target", None))
+    electrode_unit_ends = _read_index_data(electrodes_column)
+
+    waveform_unit_lengths = (
+        _ragged_row_lengths(waveform_unit_ends, n_units) if waveform_unit_ends is not None else None
+    )
+    electrode_unit_lengths = (
+        _ragged_row_lengths(electrode_unit_ends, n_units) if electrode_unit_ends is not None else None
+    )
+
+    if waveform_unit_lengths is None or electrode_unit_lengths is None or waveform_spike_index is None:
+        yield InspectorMessage(
+            message=(
+                "This Units table has malformed waveforms or electrodes ragged indices. "
+                "The waveform electrode dimension could not be checked against the electrode references."
+            )
+        )
+        return None
+
+    if len(waveform_spike_index) and (
+        waveform_spike_index[0] < 0 or np.any(np.diff(waveform_spike_index) < 0)
+    ):
+        yield InspectorMessage(
+            message=(
+                "This Units table has malformed waveforms ragged indices. "
+                "The per-spike waveform electrode dimension could not be checked."
+            )
+        )
+        return None
+
+    n_spike_index_rows = len(waveform_spike_index)
+    waveform_payload = getattr(getattr(waveforms_column, "target", None), "target", None)
+    try:
+        n_waveform_rows = len(waveform_payload)
+    except TypeError:
+        n_waveform_rows = None
+
+    if (
+        (len(waveform_unit_ends) and waveform_unit_ends[-1] > n_spike_index_rows)
+        or (n_waveform_rows is not None and len(waveform_spike_index) and waveform_spike_index[-1] > n_waveform_rows)
+    ):
+        yield InspectorMessage(
+            message=(
+                "This Units table has incomplete waveforms ragged indices. "
+                "The per-spike waveform electrode dimension could not be checked."
+            )
+        )
+        return None
+
+    for unit_index in range(n_units):
+        spike_start = 0 if unit_index == 0 else int(waveform_unit_ends[unit_index - 1])
+        spike_stop = int(waveform_unit_ends[unit_index])
+        if spike_stop == spike_start:
+            continue
+
+        spike_boundaries = waveform_spike_index[spike_start:spike_stop]
+        previous_boundary = 0 if spike_start == 0 else int(waveform_spike_index[spike_start - 1])
+        waveform_electrode_counts = np.diff(
+            np.concatenate((np.array([previous_boundary], dtype=np.int64), spike_boundaries))
+        )
+        expected_electrode_count = int(electrode_unit_lengths[unit_index])
+
+        if len(waveform_electrode_counts) == 0:
+            continue
+
+        if not np.all(waveform_electrode_counts == waveform_electrode_counts[0]):
+            counts = ", ".join(str(int(count)) for count in waveform_electrode_counts)
+            yield InspectorMessage(
+                message=(
+                    f"Units row {unit_index} has inconsistent waveform electrode dimensions "
+                    f"across spikes ({counts}) but references {expected_electrode_count} electrodes. "
+                    "The waveforms may be malformed or transposed."
+                )
+            )
+        elif int(waveform_electrode_counts[0]) != expected_electrode_count:
+            observed_electrode_count = int(waveform_electrode_counts[0])
+            yield InspectorMessage(
+                message=(
+                    f"Units row {unit_index} stores {observed_electrode_count} waveform channels per spike "
+                    f"but references {expected_electrode_count} electrodes. "
+                    "The waveform electrode dimension may be transposed."
+                )
+            )
+
     return None
 
 

--- a/src/nwbinspector/checks/_ecephys.py
+++ b/src/nwbinspector/checks/_ecephys.py
@@ -84,9 +84,7 @@ def check_units_waveforms_electrodes(units_table: Units) -> Optional[Iterable[In
     waveform_spike_index = _read_index_data(getattr(waveforms_column, "target", None))
     electrode_unit_ends = _read_index_data(electrodes_column)
 
-    waveform_unit_lengths = (
-        _ragged_row_lengths(waveform_unit_ends, n_units) if waveform_unit_ends is not None else None
-    )
+    waveform_unit_lengths = _ragged_row_lengths(waveform_unit_ends, n_units) if waveform_unit_ends is not None else None
     electrode_unit_lengths = (
         _ragged_row_lengths(electrode_unit_ends, n_units) if electrode_unit_ends is not None else None
     )
@@ -100,9 +98,7 @@ def check_units_waveforms_electrodes(units_table: Units) -> Optional[Iterable[In
         )
         return None
 
-    if len(waveform_spike_index) and (
-        waveform_spike_index[0] < 0 or np.any(np.diff(waveform_spike_index) < 0)
-    ):
+    if len(waveform_spike_index) and (waveform_spike_index[0] < 0 or np.any(np.diff(waveform_spike_index) < 0)):
         yield InspectorMessage(
             message=(
                 "This Units table has malformed waveforms ragged indices. "
@@ -118,9 +114,8 @@ def check_units_waveforms_electrodes(units_table: Units) -> Optional[Iterable[In
     except TypeError:
         n_waveform_rows = None
 
-    if (
-        (len(waveform_unit_ends) and waveform_unit_ends[-1] > n_spike_index_rows)
-        or (n_waveform_rows is not None and len(waveform_spike_index) and waveform_spike_index[-1] > n_waveform_rows)
+    if (len(waveform_unit_ends) and waveform_unit_ends[-1] > n_spike_index_rows) or (
+        n_waveform_rows is not None and len(waveform_spike_index) and waveform_spike_index[-1] > n_waveform_rows
     ):
         yield InspectorMessage(
             message=(

--- a/tests/unit_tests/test_ecephys.py
+++ b/tests/unit_tests/test_ecephys.py
@@ -25,7 +25,103 @@ from nwbinspector.checks import (
     check_units_resolution_is_valid,
     check_units_table_duration,
     check_units_table_has_spikes,
+    check_units_waveforms_electrodes,
 )
+
+
+def _make_units_with_waveforms(waveform_electrode_counts, electrode_counts):
+    nwbfile = NWBFile(
+        session_description="", identifier=str(uuid4()), session_start_time=datetime.now().astimezone()
+    )
+    device = nwbfile.create_device(name="dev")
+    group = nwbfile.create_electrode_group(name="electrode_group", description="desc", location="loc", device=device)
+    n_electrodes = max(1, max(electrode_counts, default=0))
+    for _ in range(n_electrodes):
+        nwbfile.add_electrode(location="unknown", group=group)
+
+    units = Units(name="units")
+    nwbfile.units = units
+    for unit_index, (waveform_electrode_count, electrode_count) in enumerate(
+        zip(waveform_electrode_counts, electrode_counts)
+    ):
+        units.add_unit(
+            spike_times=[float(unit_index), float(unit_index) + 0.1],
+            electrodes=list(range(electrode_count)),
+            waveforms=np.zeros((2, waveform_electrode_count, 4)),
+        )
+    return units
+
+
+def test_check_units_waveforms_electrodes_pass():
+    units_table = _make_units_with_waveforms([2], [2])
+    assert check_units_waveforms_electrodes(units_table) is None
+
+
+def test_check_units_waveforms_electrodes_reports_transposed_dimension():
+    units_table = _make_units_with_waveforms([10], [2])
+    results = check_units_waveforms_electrodes(units_table)
+
+    assert results is not None
+    assert len(results) == 1
+    assert results[0].message == (
+        "Units row 0 stores 10 waveform channels per spike but references 2 electrodes. "
+        "The waveform electrode dimension may be transposed."
+    )
+    assert results[0].importance == Importance.CRITICAL
+
+
+def test_check_units_waveforms_electrodes_reports_only_affected_units():
+    units_table = _make_units_with_waveforms([2, 3], [2, 2])
+    results = check_units_waveforms_electrodes(units_table)
+
+    assert results is not None
+    assert len(results) == 1
+    assert "Units row 1" in results[0].message
+
+
+def test_check_units_waveforms_electrodes_reports_inconsistent_spike_dimensions():
+    units_table = _make_units_with_waveforms([2], [2])
+    units_table["waveforms"].target.data[1] = 3
+
+    results = check_units_waveforms_electrodes(units_table)
+
+    assert results is not None
+    assert len(results) == 1
+    assert "inconsistent waveform electrode dimensions" in results[0].message
+    assert "2, 1" in results[0].message
+
+
+def test_check_units_waveforms_electrodes_skips_missing_columns():
+    units_table = Units(name="units")
+    units_table.add_unit(spike_times=[0.0])
+    assert check_units_waveforms_electrodes(units_table) is None
+
+
+def test_check_units_waveforms_electrodes_skips_empty_table():
+    units_table = Units(name="units")
+    assert check_units_waveforms_electrodes(units_table) is None
+
+
+def test_check_units_waveforms_electrodes_reports_malformed_indices():
+    units_table = _make_units_with_waveforms([2], [2])
+    units_table["waveforms"].data[0] = 99
+
+    results = check_units_waveforms_electrodes(units_table)
+
+    assert results is not None
+    assert len(results) == 1
+    assert "incomplete" in results[0].message
+
+
+def test_check_units_waveforms_electrodes_reports_incomplete_nested_indices():
+    units_table = _make_units_with_waveforms([2], [2])
+    units_table["waveforms"].target.data[1] = 99
+
+    results = check_units_waveforms_electrodes(units_table)
+
+    assert results is not None
+    assert len(results) == 1
+    assert "incomplete" in results[0].message
 
 
 def test_check_units_table_has_spikes_fail():

--- a/tests/unit_tests/test_ecephys.py
+++ b/tests/unit_tests/test_ecephys.py
@@ -30,9 +30,7 @@ from nwbinspector.checks import (
 
 
 def _make_units_with_waveforms(waveform_electrode_counts, electrode_counts):
-    nwbfile = NWBFile(
-        session_description="", identifier=str(uuid4()), session_start_time=datetime.now().astimezone()
-    )
+    nwbfile = NWBFile(session_description="", identifier=str(uuid4()), session_start_time=datetime.now().astimezone())
     device = nwbfile.create_device(name="dev")
     group = nwbfile.create_electrode_group(name="electrode_group", description="desc", location="loc", device=device)
     n_electrodes = max(1, max(electrode_counts, default=0))


### PR DESCRIPTION
Fixes #714. Adds a critical Units check that compares the per-spike waveform row count from the doubly-ragged waveforms indices with each unit's electrodes references. It reports affected unit rows, catches transposed or inconsistent dimensions, and reports malformed or incomplete index metadata. The implementation reads only the small index arrays and never loads waveform samples. Added regression coverage for valid and transposed layouts, multiple units, inconsistent spike dimensions, missing columns, empty tables, and malformed indices. Validation: 63 focused ecephys tests passed; ruff passed; inspector end-to-end tests passed (24 passed, 22 skipped); HDF5-backed NWB smoke test passed.