### PR TITLE
Read only the identifier during the inspect_all pre-scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Bumped GitHub Actions workflow dependencies (`actions/checkout` v4 -> v6, `actions/setup-python` v5 -> v6, `codecov/codecov-action` v4 -> v5) to migrate off Node.js 20, which GitHub is removing from runners on 2026-09-16. [#702](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/702)
 
 ### Fixes
+* Fixed the identifier pre-scan in `inspect_all` leaking one open file handle per file and reading every file through PyNWB before the inspection read it again. HDF5 files now have only their `/identifier` dataset read with h5py, and the fallback reader used for Zarr stores closes its IO object. [#730](https://github.com/NeurodataWithoutBorders/nwbinspector/issues/730)
 * Fixed unit tests that failed at construction time against recent PyNWB and HDMF. [#707](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/707) [#708](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/708)
 * Skipped Ontobee in the documentation external link check, which frequently timed out and caused spurious CI failures. [#709](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/709)
 * Fixed `run_checks` raising `TypeError` when a `progress_bar_class` was passed without `progress_bar_options`; the keyword arguments are now coalesced to an empty dict before being forwarded to the progress-bar constructor. [#701](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/701)

--- a/src/nwbinspector/_nwb_inspection.py
+++ b/src/nwbinspector/_nwb_inspection.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Iterable, Optional, Type, Union
 from warnings import filterwarnings, warn
 
+import h5py
 import pynwb
 from natsort import natsorted
 from packaging import version
@@ -140,11 +141,10 @@ def inspect_all(
     identifiers = defaultdict(list)
     for nwbfile_path in nwbfiles:
         try:
-            nwbfile = read_nwbfile(nwbfile_path=nwbfile_path)
-            identifiers[nwbfile.identifier].append(nwbfile_path)
+            identifiers[_read_nwbfile_identifier(nwbfile_path=nwbfile_path)].append(nwbfile_path)
         except _MissingHdmfZarrError:
             raise  # missing-hdmf-zarr propagates directly to the caller
-        except Exception as exception:
+        except Exception:
             continue  # other read failure errors will be returned as part of inspect_nwbfile
 
     if len(identifiers) != len(nwbfiles):
@@ -196,6 +196,27 @@ def inspect_all(
                     if stream:
                         message.file_path = nwbfiles[message.file_path]
                     yield message
+
+
+def _read_nwbfile_identifier(nwbfile_path: Union[str, Path]) -> str:
+    """
+    Read only the identifier of an NWB file, without building the full in-memory NWBFile.
+
+    HDF5 files are opened directly with h5py and closed before returning. Other backends (Zarr) fall back to the
+    full reader, and the IO object is closed afterwards so that no file handles are left open.
+    """
+    nwbfile_path = str(nwbfile_path)
+
+    if h5py.is_hdf5(nwbfile_path):
+        with h5py.File(name=nwbfile_path, mode="r") as file:
+            identifier = file["identifier"][()]
+        return identifier.decode() if isinstance(identifier, bytes) else str(identifier)
+
+    nwbfile = read_nwbfile(nwbfile_path=nwbfile_path)
+    try:
+        return nwbfile.identifier
+    finally:
+        nwbfile.get_read_io().close()
 
 
 def _pickle_inspect_nwb(

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -7,6 +7,7 @@ from tempfile import mkdtemp
 from typing import Type, Union
 from unittest import TestCase, skipUnless
 
+import h5py
 import numpy as np
 from hdmf.backends.io import HDMFIO
 from hdmf.common import DynamicTable
@@ -43,6 +44,12 @@ else:
     NWBZarrIO = None  # sentinel; classes referencing it are skipped via skipUnless
 
 EXPECTED_REPORTS_FOLDER_PATH = Path(__file__).parent / "expected_reports"
+
+
+def get_open_hdf5_file_paths() -> set[Path]:
+    """Return the paths of every HDF5 file currently held open by the HDF5 library in this process."""
+    file_ids = h5py.h5f.get_obj_ids(h5py.h5f.OBJ_ALL, h5py.h5f.OBJ_FILE)
+    return {Path(h5py.h5f.get_name(file_id).decode()).resolve() for file_id in file_ids}
 
 
 @register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=DynamicTable)
@@ -871,6 +878,14 @@ class TestCheckUniqueIdentifiersPassHDF5(TestInspectorOnBackend):
         expected_message = []
 
         assert test_message == expected_message
+
+    def test_inspect_all_leaves_no_open_files(self):
+        """The identifier pre-scan used to read every file through PyNWB without closing the IO object."""
+        list(inspect_all(path=self.tempdir, select=["check_data_orientation"], skip_validate=self.skip_validate))
+
+        open_file_paths = get_open_hdf5_file_paths()
+        leaked_file_paths = {path for path in open_file_paths if path.is_relative_to(self.tempdir.resolve())}
+        assert leaked_file_paths == set()
 
 
 class TestCheckUniqueIdentifiersFailHDF5(TestInspectorOnBackend):


### PR DESCRIPTION
Fixes #730.

The duplicate-identifier pre-scan in `inspect_all` built the full NWBFile for every file in the folder through `read_nwbfile` and never closed the IO object it got back. Each file left one handle open, and the whole folder was read twice.

The pre-scan now calls a small helper that reads only the `/identifier` dataset. For HDF5 files (detected with `h5py.is_hdf5`) it opens the file with h5py in a context manager, so nothing is built and nothing is left open. Anything h5py cannot open, which in practice means Zarr stores, falls back to `read_nwbfile` and closes the IO in a `finally` block. Because the fallback still goes through `read_nwbfile`, the `_MissingHdmfZarrError` raised for a `.nwb.zarr` store without `hdmf-zarr` installed propagates exactly as before, and `tests/test_missing_hdmf_zarr.py` is unaffected.

The regression test runs `inspect_all` over the unique-identifier fixture folder and then asks the HDF5 library which files it still has open (`h5f.get_obj_ids` with `OBJ_ALL`), asserting that none of them live in the fixture folder. It fails on `dev` and passes here. The existing pass and fail tests for `check_unique_identifiers` cover the identifier values themselves on both backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hfn8dhw9cwP5FiVaCgFmCt
