### PR TITLE
Submit all assets before collecting in get_s3_urls_and_dandi_paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Bumped GitHub Actions workflow dependencies (`actions/checkout` v4 -> v6, `actions/setup-python` v5 -> v6, `codecov/codecov-action` v4 -> v5) to migrate off Node.js 20, which GitHub is removing from runners on 2026-09-16. [#702](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/702)
 
 ### Fixes
+* Fixed the parallel branch of `get_s3_urls_and_dandi_paths` collecting results inside the submit loop, which serialized every request. The helper it calls now also forwards its `follow_redirects` and `strip_query` arguments, and the function accepts an optional `client` like `get_nwb_assets_from_dandiset`. [#736](https://github.com/NeurodataWithoutBorders/nwbinspector/issues/736)
 * Fixed unit tests that failed at construction time against recent PyNWB and HDMF. [#707](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/707) [#708](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/708)
 * Skipped Ontobee in the documentation external link check, which frequently timed out and caused spurious CI failures. [#709](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/709)
 * Fixed `run_checks` raising `TypeError` when a `progress_bar_class` was passed without `progress_bar_options`; the keyword arguments are now coalesced to an empty dict before being forwarded to the progress-bar constructor. [#701](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/701)

--- a/src/nwbinspector/tools/_dandi.py
+++ b/src/nwbinspector/tools/_dandi.py
@@ -8,42 +8,74 @@ from typing import Literal, Optional, Union
 from ..utils import calculate_number_of_cpu, is_module_installed
 
 
-def get_s3_urls_and_dandi_paths(dandiset_id: str, version_id: Optional[str] = None, n_jobs: int = 1) -> dict[str, str]:
+def get_s3_urls_and_dandi_paths(
+    dandiset_id: str,
+    version_id: Optional[str] = None,
+    n_jobs: int = 1,
+    client: Union["dandi.dandiapi.DandiAPIClient", None] = None,  # type: ignore
+) -> dict[str, str]:
     """
     Collect S3 URLS from a DANDISet ID.
 
     Returns dictionary that maps each S3 url to the displayed file path on the DANDI archive content page.
-    """
-    assert is_module_installed(module_name="dandi"), "You must install DANDI to get S3 paths (pip install dandi)."
-    from dandi.dandiapi import DandiAPIClient
 
+    Parameters
+    ----------
+    dandiset_id : str
+        The six-digit identifier of the Dandiset.
+    version_id : str, optional
+        The version of the Dandiset. Defaults to the latest published version, or "draft" if none exist.
+    n_jobs : int, optional
+        Number of processes used to resolve the content URLs. Defaults to 1 (no parallelism).
+    client : dandi.dandiapi.DandiAPIClient, optional
+        The client object can be passed to avoid re-instantiation over an iteration.
+    """
     assert re.fullmatch(
         pattern="^[0-9]{6}$", string=dandiset_id
     ), "The specified 'path' is not a proper DANDISet ID. It should be a six-digit numeric identifier."
 
-    s3_urls_to_dandi_paths = dict()
+    if client is not None:
+        return _collect_s3_urls_and_dandi_paths(
+            client=client, dandiset_id=dandiset_id, version_id=version_id, n_jobs=n_jobs
+        )
+
+    assert is_module_installed(module_name="dandi"), "You must install DANDI to get S3 paths (pip install dandi)."
+    from dandi.dandiapi import DandiAPIClient
+
+    with DandiAPIClient() as client:
+        return _collect_s3_urls_and_dandi_paths(
+            client=client, dandiset_id=dandiset_id, version_id=version_id, n_jobs=n_jobs
+        )
+
+
+def _collect_s3_urls_and_dandi_paths(
+    client: "dandi.dandiapi.DandiAPIClient",  # type: ignore
+    dandiset_id: str,
+    version_id: Optional[str],
+    n_jobs: int,
+) -> dict[str, str]:
+    """Resolve the content URL of every NWB asset in the Dandiset, in parallel if requested."""
     n_jobs = calculate_number_of_cpu(requested_cpu=n_jobs)
-    if n_jobs != 1:
-        with DandiAPIClient() as client:
-            dandiset = client.get_dandiset(dandiset_id=dandiset_id, version_id=version_id)
-            max_workers = n_jobs if n_jobs > 0 else None
-            with ProcessPoolExecutor(max_workers=max_workers) as executor:
-                futures = []
-                for asset in dandiset.get_assets():
-                    if asset.path.split(".")[-1] == "nwb":
-                        futures.append(
-                            executor.submit(
-                                _get_content_url_and_path, asset=asset, follow_redirects=1, strip_query=True
-                            )
-                        )
-                    for future in as_completed(futures):
-                        s3_urls_to_dandi_paths.update(future.result())
-    else:
-        with DandiAPIClient() as client:
-            dandiset = client.get_dandiset(dandiset_id=dandiset_id, version_id=version_id)
-            for asset in dandiset.get_assets():
-                if asset.path.split(".")[-1] == "nwb":
-                    s3_urls_to_dandi_paths.update(_get_content_url_and_path(asset=asset))
+
+    dandiset = client.get_dandiset(dandiset_id=dandiset_id, version_id=version_id)
+    nwb_assets = [asset for asset in dandiset.get_assets() if asset.path.split(".")[-1] == "nwb"]
+
+    s3_urls_to_dandi_paths: dict[str, str] = dict()
+    if n_jobs == 1:
+        for asset in nwb_assets:
+            s3_urls_to_dandi_paths.update(_get_content_url_and_path(asset=asset))
+        return s3_urls_to_dandi_paths
+
+    max_workers = n_jobs if n_jobs > 0 else None
+    with ProcessPoolExecutor(max_workers=max_workers) as executor:
+        # Submit every asset before collecting any result, so that requests actually overlap
+        futures = [
+            executor.submit(_get_content_url_and_path, asset=asset, follow_redirects=1, strip_query=True)
+            for asset in nwb_assets
+        ]
+        for future in as_completed(futures):
+            s3_urls_to_dandi_paths.update(future.result())
+
     return s3_urls_to_dandi_paths
 
 
@@ -57,7 +89,7 @@ def _get_content_url_and_path(
 
     Must be globally defined (not as a part of get_s3_urls..) in order to be pickled.
     """
-    return {asset.get_content_url(follow_redirects=1, strip_query=True): asset.path}
+    return {asset.get_content_url(follow_redirects=follow_redirects, strip_query=strip_query): asset.path}
 
 
 def get_nwb_assets_from_dandiset(

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,3 +1,4 @@
+import time
 from datetime import datetime
 from uuid import uuid4
 
@@ -6,7 +7,7 @@ import pynwb
 from hdmf.testing import TestCase
 
 from nwbinspector import Importance, InspectorMessage, Severity, organize_messages
-from nwbinspector.tools import all_of_type
+from nwbinspector.tools import all_of_type, get_s3_urls_and_dandi_paths
 
 
 def test_all_of_type():
@@ -203,3 +204,73 @@ class TestOrganization(TestCase):
             },
         }
         self.assertDictEqual(d1=test_result, d2=true_result)
+
+
+class _FakeRemoteAsset:
+    """Stand-in for dandi.dandiapi.BaseRemoteAsset that records when its content URL was resolved."""
+
+    def __init__(self, path: str, delay: float = 0.0):
+        self.path = path
+        self.delay = delay
+
+    def get_content_url(self, follow_redirects: int = 1, strip_query: bool = True) -> str:
+        start = time.time()
+        time.sleep(self.delay)
+        end = time.time()
+        return (
+            f"https://fake.s3/{self.path}#start={start}&end={end}"
+            f"&follow_redirects={follow_redirects}&strip_query={strip_query}"
+        )
+
+
+class _FakeRemoteDandiset:
+    def __init__(self, assets: list):
+        self._assets = assets
+
+    def get_assets(self):
+        return iter(self._assets)
+
+
+class _FakeDandiAPIClient:
+    def __init__(self, assets: list):
+        self._assets = assets
+
+    def get_dandiset(self, dandiset_id: str, version_id=None):
+        return _FakeRemoteDandiset(assets=self._assets)
+
+
+def _parse_fake_url(url: str) -> dict:
+    fragment = url.split("#", 1)[1]
+    return dict(pair.split("=") for pair in fragment.split("&"))
+
+
+def test_get_s3_urls_and_dandi_paths_serial():
+    assets = [_FakeRemoteAsset(path=f"sub-{j}/sub-{j}.nwb") for j in range(3)]
+    assets.append(_FakeRemoteAsset(path="dandiset.yaml"))
+    client = _FakeDandiAPIClient(assets=assets)
+
+    result = get_s3_urls_and_dandi_paths(dandiset_id="000000", n_jobs=1, client=client)
+
+    assert sorted(result.values()) == [f"sub-{j}/sub-{j}.nwb" for j in range(3)]
+    for url, path in result.items():
+        assert url.startswith(f"https://fake.s3/{path}#")
+        parsed = _parse_fake_url(url)
+        assert parsed["follow_redirects"] == "1"
+        assert parsed["strip_query"] == "True"
+
+
+def test_get_s3_urls_and_dandi_paths_parallel():
+    """Regression test: the parallel branch used to wait on every future after each submit, serializing the work."""
+    delay = 0.5
+    assets = [_FakeRemoteAsset(path=f"sub-{j}/sub-{j}.nwb", delay=delay) for j in range(4)]
+    client = _FakeDandiAPIClient(assets=assets)
+
+    result = get_s3_urls_and_dandi_paths(dandiset_id="000000", n_jobs=2, client=client)
+
+    assert sorted(result.values()) == [f"sub-{j}/sub-{j}.nwb" for j in range(4)]
+
+    intervals = [(float(p["start"]), float(p["end"])) for p in map(_parse_fake_url, result)]
+    overlapping_pairs = [
+        (a, b) for i, a in enumerate(intervals) for b in intervals[i + 1 :] if a[0] < b[1] and b[0] < a[1]
+    ]
+    assert overlapping_pairs, "No two content URL requests ran concurrently; the parallel branch is serialized."


### PR DESCRIPTION
Fixes #736.

In the `n_jobs != 1` branch of `get_s3_urls_and_dandi_paths`, the loop over `as_completed(futures)` was indented inside the loop that submitted the futures, so after each submit the function drained every outstanding request before submitting the next one. The pool never had more than one request in flight. The branch now submits all NWB assets first and collects afterwards.

Two smaller things came along with it. `_get_content_url_and_path` accepted `follow_redirects` and `strip_query` but hardcoded both in the call, and now forwards them. The function also takes an optional `client`, matching `get_nwb_assets_from_dandiset`, which is what makes it testable without the DANDI API: when a client is passed the `dandi` import and the context manager are skipped.

The tests use a fake client whose assets record wall-clock start and end times in the URL they return. The serial test checks the mapping and that the arguments reach the asset. The parallel test uses four assets with a half-second delay each and two workers, and asserts that at least one pair of requests overlapped in time. I confirmed it fails when the original indentation is put back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hfn8dhw9cwP5FiVaCgFmCt
