### PR TITLE
Flag table region indices equal to the target table length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Bumped GitHub Actions workflow dependencies (`actions/checkout` v4 -> v6, `actions/setup-python` v5 -> v6, `codecov/codecov-action` v4 -> v5) to migrate off Node.js 20, which GitHub is removing from runners on 2026-09-16. [#702](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/702)
 
 ### Fixes
+* Fixed `check_dynamic_table_region_data_validity` not flagging an index equal to the length of the target table, which is already out of range for zero-based indices. The message now says "greater than or equal to". [#738](https://github.com/NeurodataWithoutBorders/nwbinspector/issues/738)
 * Fixed unit tests that failed at construction time against recent PyNWB and HDMF. [#707](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/707) [#708](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/708)
 * Skipped Ontobee in the documentation external link check, which frequently timed out and caused spurious CI failures. [#709](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/709)
 * Fixed `run_checks` raising `TypeError` when a `progress_bar_class` was passed without `progress_bar_options`; the keyword arguments are now coalesced to an empty dict before being forwarded to the progress-bar constructor. [#701](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/701)

--- a/src/nwbinspector/checks/_tables.py
+++ b/src/nwbinspector/checks/_tables.py
@@ -26,11 +26,11 @@ def check_dynamic_table_region_data_validity(
     dynamic_table_region: DynamicTableRegion, nelems: Optional[int] = NELEMS
 ) -> Optional[InspectorMessage]:
     """Check if a DynamicTableRegion is valid."""
-    if np.any(np.asarray(dynamic_table_region.data[:nelems]) > len(dynamic_table_region.table)):
+    if np.any(np.asarray(dynamic_table_region.data[:nelems]) >= len(dynamic_table_region.table)):
         return InspectorMessage(
             message=(
-                f"Some elements of {dynamic_table_region.name} are out of range because they are greater than the "
-                "length of the target table. Note that data should contain indices, not ids."
+                f"Some elements of {dynamic_table_region.name} are out of range because they are greater than or "
+                "equal to the length of the target table. Note that data should contain indices, not ids."
             )
         )
     if np.any(np.asarray(dynamic_table_region.data[:nelems]) < 0):

--- a/tests/unit_tests/test_tables.py
+++ b/tests/unit_tests/test_tables.py
@@ -52,8 +52,8 @@ class TestCheckDynamicTableRegion(TestCase):
 
         assert check_dynamic_table_region_data_validity(dynamic_table_region) == InspectorMessage(
             message=(
-                "Some elements of dyn_tab are out of range because they are greater than the length of the target "
-                "table. Note that data should contain indices, not ids."
+                "Some elements of dyn_tab are out of range because they are greater than or equal to the length of "
+                "the target table. Note that data should contain indices, not ids."
             ),
             importance=Importance.CRITICAL,
             check_function_name="check_dynamic_table_region_data_validity",
@@ -61,6 +61,31 @@ class TestCheckDynamicTableRegion(TestCase):
             object_name="dyn_tab",
             location="/",
         )
+
+    def test_check_dynamic_table_region_data_validity_eq_len(self):
+        """An index equal to the table length is the first out-of-range value and must be flagged."""
+        dynamic_table_region = DynamicTableRegion(name="dyn_tab", description="desc", data=[0, 1], table=self.table)
+        dynamic_table_region.data[:] = [0, len(self.table)]
+
+        assert check_dynamic_table_region_data_validity(dynamic_table_region) == InspectorMessage(
+            message=(
+                "Some elements of dyn_tab are out of range because they are greater than or equal to the length of "
+                "the target table. Note that data should contain indices, not ids."
+            ),
+            importance=Importance.CRITICAL,
+            check_function_name="check_dynamic_table_region_data_validity",
+            object_type="DynamicTableRegion",
+            object_name="dyn_tab",
+            location="/",
+        )
+
+    def test_pass_check_dynamic_table_region_data_last_index(self):
+        """The last valid index is len(table) - 1 and must not be flagged."""
+        dynamic_table_region = DynamicTableRegion(
+            name="dyn_tab", description="desc", data=[0, len(self.table) - 1], table=self.table
+        )
+
+        assert check_dynamic_table_region_data_validity(dynamic_table_region) is None
 
     def test_pass_check_dynamic_table_region_data(self):
         dynamic_table_region = DynamicTableRegion(name="dyn_tab", description="desc", data=[0, 1, 2], table=self.table)


### PR DESCRIPTION
Fixes #738.

`check_dynamic_table_region_data_validity` used `>` against the length of the target table, so an index equal to the length, which is the first out-of-range value for zero-based indices, was not reported. The comparison is now `>=`, and the message reads "greater than or equal to the length of the target table" so that it matches the condition.

Two tests are added: one builds a region whose data contains `len(table)` and expects the message, and one uses `len(table) - 1` and expects no message. The first fails on `dev`. The existing test for a value well past the end is updated for the new wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hfn8dhw9cwP5FiVaCgFmCt
