### PR TITLE
Bound the amount of spike-time data read by the Units checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added `check_subject_age_reference` to validate that `Subject.age__reference`, when present, is one of the supported values (`"birth"` or `"gestational"`). This catches invalid references in files written by tools that do not enforce the schema constraint. [#250](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/250)
 
 ### Improvements
+* `check_negative_spike_times` and `check_units_table_duration` now read only the first and last spike of each unit through a shared helper, `check_ascending_spike_times` reads at most `nelems` spike times per unit directly through the index array instead of materializing each unit's full train, and `check_spike_times_without_nans` scans the spike times in fixed-size chunks. None of these checks loads every spike time in the file into memory any more. [#744](https://github.com/NeurodataWithoutBorders/nwbinspector/issues/744)
 * Raised the minimum required PyNWB to `>=4.0` to track the latest PyNWB release. [#708](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/708)
 * Bumped GitHub Actions workflow dependencies (`actions/checkout` v4 -> v6, `actions/setup-python` v5 -> v6, `codecov/codecov-action` v4 -> v5) to migrate off Node.js 20, which GitHub is removing from runners on 2026-09-16. [#702](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/702)
 

--- a/src/nwbinspector/checks/_ecephys.py
+++ b/src/nwbinspector/checks/_ecephys.py
@@ -1,7 +1,8 @@
 """Check functions specific to extracellular electrophysiology neurodata types."""
 
-from typing import Iterable, Optional
+from typing import Iterable, Iterator, Optional, Union
 
+import h5py
 import numpy as np
 from pynwb import NWBFile
 from pynwb.ecephys import ElectricalSeries, SpikeEventSeries
@@ -15,6 +16,53 @@ from ..utils import get_data_shape
 NELEMS = 200
 # Default duration threshold: 1 year in seconds
 DURATION_THRESHOLD = 31557600.0
+
+
+def _get_spike_times_index(units_table: Units) -> np.ndarray:
+    """Return the cumulative end index of each unit's spike train, which is a small array (one integer per unit)."""
+    return np.asarray(units_table["spike_times"].data[:])
+
+
+def _get_boundary_spike_indices(spike_times_index: np.ndarray) -> np.ndarray:
+    """
+    Return the sorted, unique flat indices of the first and last spike of every non-empty unit.
+
+    Reading only these values answers questions about sorted spike trains (a negative first spike, NaN padding at
+    the end of a train, the total duration) without loading every spike time in the file.
+    """
+    if len(spike_times_index) == 0:
+        return np.array([], dtype=spike_times_index.dtype)
+
+    # The leading zero must share the dtype of the index array: mixing uint64 with a signed integer array
+    # promotes the result to float64, which cannot be used as a fancy index
+    first_spike_indices = np.concatenate(
+        [
+            np.zeros(shape=1, dtype=spike_times_index.dtype),
+            spike_times_index[spike_times_index != spike_times_index[-1]],
+        ]
+    )
+    last_spike_indices = spike_times_index[spike_times_index != 0] - 1
+
+    return np.unique(np.concatenate([first_spike_indices, last_spike_indices]))
+
+
+def _iterate_chunks(data: Union[h5py.Dataset, np.ndarray, list], chunk_size: int = 500_000) -> Iterator[np.ndarray]:
+    """Yield contiguous slices of a one-dimensional array-like without loading all of it at once."""
+    for start in range(0, len(data), chunk_size):
+        yield np.asarray(data[start : start + chunk_size])
+
+
+def _read_boundary_spike_times(units_table: Units) -> np.ndarray:
+    """Read the first and last spike time of every non-empty unit in a single selection."""
+    boundary_indices = _get_boundary_spike_indices(spike_times_index=_get_spike_times_index(units_table=units_table))
+    if len(boundary_indices) == 0:
+        return np.array([], dtype=float)
+
+    spike_times_data = units_table["spike_times"].target.data
+    if isinstance(spike_times_data, list):
+        spike_times_data = np.array(spike_times_data)
+
+    return np.asarray(spike_times_data[boundary_indices])
 
 
 @register_check(importance=Importance.CRITICAL, neurodata_type=Units)
@@ -36,10 +84,15 @@ def check_units_table_has_spikes(units_table: Units) -> Optional[InspectorMessag
 
 @register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=Units)
 def check_negative_spike_times(units_table: Units) -> Optional[InspectorMessage]:
-    """Check if the Units table contains negative spike times."""
+    """
+    Check if the Units table contains negative spike times.
+
+    Spike trains are sorted within each unit, so only the first spike of each unit is read.
+    Unsorted trains are reported by ``check_ascending_spike_times``.
+    """
     if "spike_times" not in units_table:
         return None
-    if np.any(np.asarray(units_table["spike_times"].target.data[:]) < 0):
+    if np.any(_read_boundary_spike_times(units_table=units_table) < 0):
         return InspectorMessage(
             message=(
                 "This Units table contains negative spike times. Time should generally be aligned to the earliest "
@@ -249,12 +302,16 @@ def check_spike_times_without_nans(units_table: Units) -> Optional[InspectorMess
     """
     Check if the Units table contains NaN values in spike times.
 
+    A NaN can appear anywhere in a train, so every spike time is scanned, but in chunks so that the memory
+    used does not grow with the size of the dataset.
+
     Best Practice: :ref:`best_practice_spike_times_without_nans`
     """
     if "spike_times" not in units_table:
         return None
 
-    if np.any(np.isnan(np.asarray(units_table["spike_times"].target.data[:]))):
+    spike_times_data = units_table["spike_times"].target.data
+    if any(np.isnan(chunk).any() for chunk in _iterate_chunks(data=spike_times_data)):
         return InspectorMessage(
             message="Units table contains NaN spike times. Spike times should be valid timestamps in seconds."
         )
@@ -278,10 +335,17 @@ def check_ascending_spike_times(units_table: Units, nelems: Optional[int] = NELE
 
     resolution_is_set = units_table.resolution is not None
 
-    for unit_id in range(len(units_table)):
-        spike_times = units_table["spike_times"][unit_id]
-        if nelems is not None:
-            spike_times = spike_times[:nelems]
+    spike_times_index = _get_spike_times_index(units_table=units_table)
+    spike_times_data = units_table["spike_times"].target.data
+    if isinstance(spike_times_data, list):
+        spike_times_data = np.array(spike_times_data)
+
+    start = 0
+    for unit_id, stop in enumerate(spike_times_index):
+        # Slice the flat dataset directly so that at most nelems values per unit are read from disk or over the network
+        read_stop = stop if nelems is None else min(stop, start + nelems)
+        spike_times = np.asarray(spike_times_data[start:read_stop])
+        start = stop
 
         diffs = np.diff(spike_times)
 
@@ -394,31 +458,8 @@ def check_units_table_duration(
     if "spike_times" not in units_table:
         return None
 
-    # Read the index array (cumulative indices marking end of each unit's spikes)
-    # This is small - just one integer per unit
-    idxs = np.asarray(units_table["spike_times"].data[:])
-
-    if len(idxs) == 0:
-        return None
-
-    # Build indices for first and last spike of each unit
-    # First spike indices: 0 for first unit, then idxs[:-1] for subsequent units
-    # Last spike indices: idxs - 1 for each unit
-    first_spike_idxs = np.concatenate([[np.uint64(0)], idxs[idxs != idxs[-1]]])
-    last_spike_idxs = idxs[idxs != 0] - 1
-
-    # Combine into single array of indices to read, then read all at once
-    all_indices = np.concatenate([first_spike_idxs, last_spike_idxs])
-    all_indices = np.unique(all_indices)  # Remove duplicates for efficiency
-
-    # Read only the needed spike times in one operation
-    spike_times_data = units_table["spike_times"].target.data
-
-    # needed to get tests to work on example data that is a list, not an h5py dataset
-    if isinstance(spike_times_data, list):
-        spike_times_data = np.array(spike_times_data)
-
-    boundary_spike_times = spike_times_data[all_indices]
+    # The first and last spike of every unit bound the duration, and are read in one selection
+    boundary_spike_times = _read_boundary_spike_times(units_table=units_table)
 
     if len(boundary_spike_times) == 0:
         return None

--- a/tests/unit_tests/test_ecephys.py
+++ b/tests/unit_tests/test_ecephys.py
@@ -4,7 +4,7 @@ from uuid import uuid4
 
 import numpy as np
 from hdmf.common.table import DynamicTable, DynamicTableRegion
-from pynwb import NWBFile
+from pynwb import NWBHDF5IO, NWBFile
 from pynwb.ecephys import ElectricalSeries, SpikeEventSeries
 from pynwb.file import Subject
 from pynwb.misc import Units
@@ -512,6 +512,91 @@ class TestCheckAscendingSpikeTimes(TestCase):
     def test_ascending_spike_times_nelems(self):
         self.units_table.add_unit(spike_times=[0.0, 0.1, 0.05])
         assert check_ascending_spike_times(units_table=self.units_table, nelems=2) is None
+
+
+class TestUnitsChecksBoundedReads(TestCase):
+    """The Units checks must not read every spike time in the file; see the boundary-index helper in _ecephys.py."""
+
+    number_of_units = 10
+    spikes_per_unit = 500_000  # 5M float64 spike times, a 40 MB dataset
+
+    @classmethod
+    def setUpClass(cls):
+        from tempfile import mkdtemp
+
+        cls.tempdir = mkdtemp()
+        cls.nwbfile_path = f"{cls.tempdir}/units.nwb"
+        nwbfile = NWBFile(
+            session_description="", identifier=str(uuid4()), session_start_time=datetime.now().astimezone()
+        )
+        for _ in range(cls.number_of_units):
+            nwbfile.add_unit(spike_times=np.arange(cls.spikes_per_unit) / 30000.0)
+        with NWBHDF5IO(path=cls.nwbfile_path, mode="w") as io:
+            io.write(nwbfile)
+
+    @classmethod
+    def tearDownClass(cls):
+        from shutil import rmtree
+
+        rmtree(cls.tempdir, ignore_errors=True)
+
+    def _peak_memory(self, check_function) -> float:
+        import tracemalloc
+
+        with NWBHDF5IO(path=self.nwbfile_path, mode="r") as io:
+            units_table = io.read().units
+            tracemalloc.start()
+            result = check_function(units_table)
+            _, peak = tracemalloc.get_traced_memory()
+            tracemalloc.stop()
+        assert result is None
+        return peak / 1e6
+
+    def test_check_negative_spike_times_reads_boundary_spikes_only(self):
+        assert self._peak_memory(check_negative_spike_times) < 1.0
+
+    def test_check_units_table_duration_reads_boundary_spikes_only(self):
+        assert self._peak_memory(check_units_table_duration) < 1.0
+
+    def test_check_ascending_spike_times_reads_nelems_per_unit(self):
+        assert self._peak_memory(check_ascending_spike_times) < 1.0
+
+    def test_check_spike_times_without_nans_reads_in_chunks(self):
+        # One 1M-element chunk plus its boolean mask is about 9 MB; the full 40 MB dataset must never be resident
+        assert self._peak_memory(check_spike_times_without_nans) < 15.0
+
+
+def test_check_negative_spike_times_in_later_unit():
+    """The negative time is the first spike of the third unit, well past the first 200 flat values."""
+    units_table = Units()
+    units_table.add_unit(spike_times=np.arange(300) / 100.0)
+    units_table.add_unit(spike_times=np.arange(300) / 100.0)
+    units_table.add_unit(spike_times=[-1.0, 0.5])
+    assert check_negative_spike_times(units_table=units_table) is not None
+
+
+def test_check_spike_times_without_nans_padding_in_later_unit():
+    """NaN padding at the end of the third unit's train, well past the first 200 flat values."""
+    units_table = Units()
+    units_table.add_unit(spike_times=np.arange(300) / 100.0)
+    units_table.add_unit(spike_times=np.arange(300) / 100.0)
+    units_table.add_unit(spike_times=[0.5, 0.6, np.nan, np.nan])
+    assert check_spike_times_without_nans(units_table=units_table) is not None
+
+
+def test_check_ascending_spike_times_on_disk_slices_through_index(tmp_path):
+    """Descending times in the second unit must be found when reading a written file through the index array."""
+    nwbfile = NWBFile(session_description="", identifier=str(uuid4()), session_start_time=datetime.now().astimezone())
+    nwbfile.add_unit(spike_times=[0.0, 0.1, 0.2])
+    nwbfile.add_unit(spike_times=[1.0, 0.9, 1.2])
+    nwbfile_path = tmp_path / "units.nwb"
+    with NWBHDF5IO(path=nwbfile_path, mode="w") as io:
+        io.write(nwbfile)
+
+    with NWBHDF5IO(path=nwbfile_path, mode="r") as io:
+        result = check_ascending_spike_times(units_table=io.read().units)
+        assert result is not None
+        assert result.message.startswith("Unit 1 contains descending spike times")
 
 
 def test_check_units_table_duration_pass():

--- a/tests/unit_tests/test_ecephys.py
+++ b/tests/unit_tests/test_ecephys.py
@@ -519,6 +519,8 @@ class TestUnitsChecksBoundedReads(TestCase):
 
     number_of_units = 10
     spikes_per_unit = 500_000  # 5M float64 spike times, a 40 MB dataset
+    tempdir: str
+    nwbfile_path: str
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
Fixes #744.

`check_negative_spike_times` and `check_spike_times_without_nans` loaded every spike time in the file with `target.data[:]`, and `check_ascending_spike_times` evaluated `units_table["spike_times"][unit_id]` for every unit, which reads the unit's whole train before the `nelems` slice is applied.

The boundary-index construction that `check_units_table_duration` already had (first and last spike of every non-empty unit, built from the small `spike_times_index` array and read in one selection) is now a helper shared with `check_negative_spike_times`. Spike trains are sorted within a unit, so a negative time is the first spike of some unit; unsorted trains are the job of the ascending check. `check_ascending_spike_times` now walks the index array and slices the flat dataset directly, so at most `nelems` values per unit are transferred.

I had planned to use the boundary spikes for the NaN check as well, on the grounds that padding sits at the end of a train, but the existing test has a NaN in the middle of a train and I think that expectation is right for a CRITICAL check. That check therefore still scans every spike time, but in 500k-element chunks, so its memory no longer grows with the dataset. Its I/O is unchanged.

The new test class writes a 40 MB Units table (10 units, 500k spikes each) and measures each check with `tracemalloc`. On `dev` the peaks were 45 MB, 45 MB, and 8 MB for the negative, NaN, and ascending checks; here the negative, duration, and ascending checks stay under 1 MB and the NaN check under 15 MB. Three smaller tests place the negative time, the NaN padding, and the descending train in a later unit so that they are past the first 200 flat values, and the on-disk ascending test confirms the slice-through-index path finds a problem in the second unit.

This overlaps with #741 on the lines that build the boundary indices in `check_units_table_duration` (the helper here carries the same dtype fix). Whichever merges second will need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hfn8dhw9cwP5FiVaCgFmCt
