### PR TITLE
Copy the ignore list in configure_checks before adding SKIP entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Bumped GitHub Actions workflow dependencies (`actions/checkout` v4 -> v6, `actions/setup-python` v5 -> v6, `codecov/codecov-action` v4 -> v5) to migrate off Node.js 20, which GitHub is removing from runners on 2026-09-16. [#702](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/702)
 
 ### Fixes
+* Fixed `configure_checks` appending the `SKIP` entries of a config to the caller's `ignore` list in place. [#746](https://github.com/NeurodataWithoutBorders/nwbinspector/issues/746)
 * Fixed unit tests that failed at construction time against recent PyNWB and HDMF. [#707](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/707) [#708](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/708)
 * Skipped Ontobee in the documentation external link check, which frequently timed out and caused spurious CI failures. [#709](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/709)
 * Fixed `run_checks` raising `TypeError` when a `progress_bar_class` was passed without `progress_bar_options`; the keyword arguments are now coalesced to an empty dict before being forwarded to the progress-bar constructor. [#701](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/701)

--- a/src/nwbinspector/_configuration.py
+++ b/src/nwbinspector/_configuration.py
@@ -114,7 +114,7 @@ def configure_checks(
     checks_out: list = []
     if config is not None:
         validate_config(config=config)
-        ignore = ignore or []
+        ignore = list(ignore) if ignore is not None else []  # copy, so SKIP entries never leak into the caller's list
         for check in checks:
             mapped_check = copy_check(check=check)
             for importance_name, func_names in config.items():

--- a/tests/test_check_configuration.py
+++ b/tests/test_check_configuration.py
@@ -86,6 +86,17 @@ class TestCheckConfiguration(TestCase):
         checks_out = configure_checks(checks=self.checks, config=config)
         self.assertListEqual(list1=[x.__name__ for x in checks_out], list2=[x.__name__ for x in self.checks[:3]])
 
+    def test_configure_checks_skip_does_not_mutate_ignore(self):
+        """SKIP entries in the config used to be appended to the caller's ignore list in place."""
+        config = dict(SKIP=["check_timestamps_match_first_dimension"])
+        ignore = ["check_small_dataset_compression"]
+        checks_out = configure_checks(checks=self.checks, config=config, ignore=ignore)
+
+        self.assertListEqual(list1=ignore, list2=["check_small_dataset_compression"])
+        self.assertListEqual(
+            list1=[x.__name__ for x in checks_out], list2=["check_regular_timestamps", "check_data_orientation"]
+        )
+
     def test_bad_schema(self):
         config = dict(WRONG="test")
         with self.assertRaises(expected_exception=ValidationError):


### PR DESCRIPTION
Fixes #746.

`configure_checks` appended the `SKIP` names from a config to the `ignore` list passed in by the caller. Since `inspect_nwbfile_object` calls `configure_checks` for every file, a user's list grew by the SKIP entries once per file. The function now copies the list before adding to it.

The test passes a one-element `ignore` list together with a SKIP config, asserts that the list is unchanged afterwards, and asserts that both the ignored and the skipped check are absent from the result. It fails on `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hfn8dhw9cwP5FiVaCgFmCt
