### PR TITLE
Name the --overwrite flag in file-exists errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Bumped GitHub Actions workflow dependencies (`actions/checkout` v4 -> v6, `actions/setup-python` v5 -> v6, `codecov/codecov-action` v4 -> v5) to migrate off Node.js 20, which GitHub is removing from runners on 2026-09-16. [#702](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/702)
 
 ### Fixes
+* Fixed the "file already exists" errors from `save_report` and the CLI `--json-file-path` option telling the user to pass a `-o` flag, which does not exist; they now name `--overwrite`. [#748](https://github.com/NeurodataWithoutBorders/nwbinspector/issues/748)
 * Fixed unit tests that failed at construction time against recent PyNWB and HDMF. [#707](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/707) [#708](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/708)
 * Skipped Ontobee in the documentation external link check, which frequently timed out and caused spurious CI failures. [#709](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/709)
 * Fixed `run_checks` raising `TypeError` when a `progress_bar_class` was passed without `progress_bar_options`; the keyword arguments are now coalesced to an empty dict before being forwarded to the progress-bar constructor. [#701](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/701)

--- a/src/nwbinspector/_formatting.py
+++ b/src/nwbinspector/_formatting.py
@@ -258,7 +258,9 @@ def save_report(report_file_path: Union[str, Path], formatted_messages: list[str
     report_file_path = Path(report_file_path)
 
     if report_file_path.exists() and not overwrite:
-        raise FileExistsError(f"The file {report_file_path} already exists! Set 'overwrite=True' or pass '-o' flag.")
+        raise FileExistsError(
+            f"The file {report_file_path} already exists! Set 'overwrite=True' or pass the '--overwrite' flag."
+        )
 
     with open(file=report_file_path, mode="w", newline="\n") as file:
         for line in formatted_messages:

--- a/src/nwbinspector/_nwbinspector_cli.py
+++ b/src/nwbinspector/_nwbinspector_cli.py
@@ -214,7 +214,9 @@ def _nwbinspector_cli(
 
     if json_file_path is not None:
         if Path(json_file_path).exists() and not overwrite:
-            raise FileExistsError(f"The file {json_file_path} already exists! Specify the '-o' flag to overwrite.")
+            raise FileExistsError(
+                f"The file {json_file_path} already exists! Pass the '--overwrite' flag to overwrite."
+            )
         with open(file=json_file_path, mode="w") as fp:
             json_report = dict(header=_get_report_header(), messages=messages)
             json.dump(obj=json_report, fp=fp, cls=InspectorOutputJSONEncoder)

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -67,3 +67,38 @@ class TestMessageFormatterSummary(TestCase):
 
         self.assertIn("Scanned 4 file(s).", formatted_messages)
         self.assertIn("Found 3 issues across 2 file(s):", formatted_messages)
+
+
+def test_save_report_existing_file_message_names_overwrite_flag(tmp_path):
+    """The message used to point at a '-o' flag that the CLI does not have."""
+    import pytest
+
+    from nwbinspector import save_report
+
+    report_file_path = tmp_path / "report.txt"
+    report_file_path.write_text("existing")
+
+    with pytest.raises(FileExistsError, match="--overwrite"):
+        save_report(report_file_path=report_file_path, formatted_messages=[], overwrite=False)
+
+
+def test_cli_existing_json_file_message_names_overwrite_flag(tmp_path):
+    from click.testing import CliRunner
+    from pynwb import NWBHDF5IO
+
+    from nwbinspector._nwbinspector_cli import _nwbinspector_cli
+    from nwbinspector.testing import make_minimal_nwbfile
+
+    nwbfile_path = tmp_path / "test.nwb"
+    with NWBHDF5IO(path=nwbfile_path, mode="w") as io:
+        io.write(make_minimal_nwbfile())
+    json_file_path = tmp_path / "report.json"
+    json_file_path.write_text("{}")
+
+    result = CliRunner().invoke(
+        _nwbinspector_cli, [str(nwbfile_path), "--json-file-path", str(json_file_path), "--skip-validate"]
+    )
+
+    assert isinstance(result.exception, FileExistsError)
+    assert "--overwrite" in str(result.exception)
+    assert "-o'" not in str(result.exception)


### PR DESCRIPTION
Fixes #748.

The "already exists" errors raised by `save_report` and by the CLI for `--json-file-path` told the user to pass `-o`, which is not a flag the CLI defines. Both now say `--overwrite`.

One test calls `save_report` against an existing file and matches on `--overwrite`; the other drives the CLI with click's `CliRunner` against an existing JSON path and checks the exception text. Both fail on `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hfn8dhw9cwP5FiVaCgFmCt
