### PR TITLE
Remove arguments deprecated for removal after 3/1/2025

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added `check_subject_age_reference` to validate that `Subject.age__reference`, when present, is one of the supported values (`"birth"` or `"gestational"`). This catches invalid references in files written by tools that do not enforce the schema constraint. [#250](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/250)
 
 ### Improvements
+* Removed the `stream` and `version_id` arguments of `inspect_all` and the `driver` and `max_retries` arguments of `inspect_nwbfile`, all of which had been deprecated for removal after 3/1/2025. Use `inspect_dandiset`, `inspect_dandi_file_path`, or `inspect_url` to inspect files on the DANDI archive. [#750](https://github.com/NeurodataWithoutBorders/nwbinspector/issues/750)
 * Raised the minimum required PyNWB to `>=4.0` to track the latest PyNWB release. [#708](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/708)
 * Bumped GitHub Actions workflow dependencies (`actions/checkout` v4 -> v6, `actions/setup-python` v5 -> v6, `codecov/codecov-action` v4 -> v5) to migrate off Node.js 20, which GitHub is removing from runners on 2026-09-16. [#702](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/702)
 

--- a/src/nwbinspector/_nwb_inspection.py
+++ b/src/nwbinspector/_nwb_inspection.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from pathlib import Path
 from typing import Iterable, Optional, Type, Union
-from warnings import filterwarnings, warn
+from warnings import filterwarnings
 
 import pynwb
 from natsort import natsorted
@@ -39,18 +39,18 @@ def inspect_all(
     progress_bar: bool = True,
     progress_bar_class: Type[tqdm] = tqdm,
     progress_bar_options: Optional[dict] = None,
-    stream: bool = False,  # TODO: remove after 3/1/2025
-    version_id: Optional[str] = None,  # TODO: remove after 3/1/2025
     modules: OptionalListOfStrings = None,
 ) -> Iterable[Union[InspectorMessage, None]]:
     """
     Inspect a local NWBFile or folder of NWBFiles and return suggestions for improvements according to best practices.
 
+    To inspect a Dandiset or a file on the DANDI archive, use ``inspect_dandiset``, ``inspect_dandi_file_path``,
+    or ``inspect_url`` instead.
+
     Parameters
     ----------
     path : PathType
-        File path to an NWBFile, folder path to iterate over recursively and scan all NWBFiles present, or a
-        six-digit identifier of the DANDISet.
+        File path to an NWBFile, or folder path to iterate over recursively and scan all NWBFiles present.
     config : dict, optional
         If a dictionary, it must be valid against our JSON configuration schema.
         Can specify a mapping of importance levels and list of check functions whose importance you wish to change.
@@ -98,34 +98,6 @@ def inspect_all(
 
     for module in modules:
         importlib.import_module(module)
-
-    # TODO: remove these blocks after 3/1/2025
-    if version_id is not None:
-        deprecation_message = (
-            "The `version_id` argument is deprecated and will be removed after 3/1/2025. "
-            "Please call `nwbinspector.inspect_dandiset` with the argument `dandiset_version` instead."
-        )
-        warn(message=deprecation_message, category=DeprecationWarning, stacklevel=2)
-    if stream:
-        from ._dandi_inspection import inspect_dandiset
-
-        warning_message = (
-            "The `stream` argument is deprecated and will be removed after 3/1/2025. "
-            "Please call `nwbinspector.inspect_dandiset` instead."
-        )
-        warn(message=warning_message, category=DeprecationWarning, stacklevel=2)
-
-        for message in inspect_dandiset(
-            dandiset_id=str(path),
-            dandiset_version=version_id,
-            config=config,
-            ignore=ignore,
-            select=select,
-            skip_validate=skip_validate,
-        ):
-            yield message
-
-        return None
 
     calculated_number_of_jobs = calculate_number_of_cpu(requested_cpu=n_jobs)
     if progress_bar_options is None:
@@ -193,8 +165,6 @@ def inspect_all(
                 async_nwbfiles_iterable = progress_bar_class(async_nwbfiles_iterable, **progress_bar_options)
             for future in async_nwbfiles_iterable:
                 for message in future.result():
-                    if stream:
-                        message.file_path = nwbfiles[message.file_path]
                     yield message
 
 
@@ -211,9 +181,7 @@ def _pickle_inspect_nwb(
 
 def inspect_nwbfile(
     nwbfile_path: Union[str, Path],
-    driver: Optional[str] = None,  # TODO: remove after 3/1/2025
     skip_validate: bool = False,
-    max_retries: Optional[int] = None,  # TODO: remove after 3/1/2025
     checks: Optional[list] = None,
     config: Optional[dict] = None,
     ignore: OptionalListOfStrings = None,
@@ -223,10 +191,12 @@ def inspect_nwbfile(
     """
     Open an NWB file, inspect the contents, and return suggestions for improvements according to best practices.
 
+    To inspect a file on the DANDI archive, use ``inspect_dandi_file_path`` or ``inspect_url`` instead.
+
     Parameters
     ----------
     nwbfile_path : FilePathType
-        Path to the NWB file on disk or on S3.
+        Path to the NWB file on disk.
     skip_validate : bool
         Skip the PyNWB validation step.
         The default is False, which is recommended.
@@ -254,13 +224,6 @@ def inspect_nwbfile(
         The default is the lowest level, BEST_PRACTICE_SUGGESTION.
     """
     checks = checks or available_checks
-    # TODO: remove error after 3/1/2025
-    if driver is not None or max_retries is not None:
-        message = (
-            "The `driver` and `max_retries` arguments are deprecated and will be removed after 3/1/2025. "
-            "Please call `nwbinspector.inspect_dandi_file_path` instead."
-        )
-        raise ValueError(message)
 
     nwbfile_path = str(nwbfile_path)
     filterwarnings(action="ignore", message="No cached namespaces found in .*")

--- a/tests/streaming_tests.py
+++ b/tests/streaming_tests.py
@@ -5,7 +5,6 @@ import pytest
 from nwbinspector import (
     Importance,
     InspectorMessage,
-    inspect_all,
     inspect_dandi_file_path,
     inspect_dandiset,
     inspect_url,
@@ -13,28 +12,6 @@ from nwbinspector import (
 from nwbinspector.testing import check_streaming_tests_enabled
 
 STREAMING_TESTS_ENABLED, DISABLED_STREAMING_TESTS_REASON = check_streaming_tests_enabled()
-
-
-@pytest.mark.skipif(not STREAMING_TESTS_ENABLED, reason=DISABLED_STREAMING_TESTS_REASON or "")
-def test_inspect_all_streaming():
-    dandiset_id = "000126"
-    select = ["check_subject_species_exists"]
-
-    test_messages = list(inspect_all(path=dandiset_id, stream=True, select=select))
-    assert len(test_messages) == 1
-
-    test_message = test_messages[0]
-    expected_message = InspectorMessage(
-        message="Subject species is missing.",
-        importance=Importance.CRITICAL,  # Uses dandi config by default
-        check_function_name="check_subject_species_exists",
-        object_type="Subject",
-        object_name="subject",
-        location="/general/subject",
-        file_path="sub-1/sub-1.nwb",
-    )
-
-    assert test_message == expected_message
 
 
 @pytest.mark.skipif(not STREAMING_TESTS_ENABLED, reason=DISABLED_STREAMING_TESTS_REASON or "")


### PR DESCRIPTION
Fixes #750.

This removes the four arguments whose deprecation notices said they would be removed after 3/1/2025: `stream` and `version_id` on `inspect_all`, and `driver` and `max_retries` on `inspect_nwbfile`. The `stream` redirect into `inspect_dandiset`, the `ValueError` for `driver` and `max_retries`, and the unreachable `if stream:` remap in the parallel branch go with them. The docstrings now point at `inspect_dandiset`, `inspect_dandi_file_path`, and `inspect_url` for DANDI content. The CLI's `--stream` and `--version-id` options are unaffected, since they already route to those functions.

The only in-repo caller was `test_inspect_all_streaming`, which inspected Dandiset 000126 with the same single check as `test_inspect_dandiset` and asserted the same message, so it is removed rather than rewritten. The `backend` argument of `read_nwbfile` and `read_nwbfile_and_io` have later removal dates and are left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hfn8dhw9cwP5FiVaCgFmCt
