### PR TITLE
Drop the unreachable pkg_resources fallback in get_package_version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added `check_subject_age_reference` to validate that `Subject.age__reference`, when present, is one of the supported values (`"birth"` or `"gestational"`). This catches invalid references in files written by tools that do not enforce the schema constraint. [#250](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/250)
 
 ### Improvements
+* Simplified `get_package_version` to call `importlib.metadata.version` directly. Its `pkg_resources` fallback was unreachable, since `importlib.metadata` raises `PackageNotFoundError` rather than the `ModuleNotFoundError` it caught, and the project requires Python 3.10. [#752](https://github.com/NeurodataWithoutBorders/nwbinspector/issues/752)
 * Raised the minimum required PyNWB to `>=4.0` to track the latest PyNWB release. [#708](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/708)
 * Bumped GitHub Actions workflow dependencies (`actions/checkout` v4 -> v6, `actions/setup-python` v5 -> v6, `codecov/codecov-action` v4 -> v5) to migrate off Node.js 20, which GitHub is removing from runners on 2026-09-16. [#702](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/702)
 

--- a/src/nwbinspector/utils/_utils.py
+++ b/src/nwbinspector/utils/_utils.py
@@ -5,6 +5,7 @@ import os
 import re
 from functools import lru_cache
 from importlib import import_module
+from importlib.metadata import version as importlib_version
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, TypeVar, Union
 
@@ -158,17 +159,13 @@ def get_package_version(name: str) -> version.Version:
     -------
     version : Version
         The package version as an object from packaging.version.Version, which allows comparison to other versions.
+
+    Raises
+    ------
+    importlib.metadata.PackageNotFoundError
+        If no distribution with that name is installed.
     """
-    try:
-        from importlib.metadata import version as importlib_version
-
-        package_version = importlib_version(name)
-    except ModuleNotFoundError:  # Remove the except clause when minimal supported version becomes 3.8
-        from pkg_resources import get_distribution
-
-        package_version = get_distribution(name).version
-
-    return version.parse(package_version)
+    return version.parse(importlib_version(name))
 
 
 def calculate_number_of_cpu(requested_cpu: int = 1) -> int:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -209,3 +209,17 @@ def test_get_nwbfiles_from_path_nested_zarr_directory(tmp_path):
     result = get_nwbfiles_from_path(tmp_path)
 
     assert nested_zarr in result
+
+
+def test_get_package_version():
+    from packaging.version import Version
+
+    assert isinstance(get_package_version(name="nwbinspector"), Version)
+    assert get_package_version(name="pynwb") >= Version("4.0")
+
+
+def test_get_package_version_missing_package():
+    from importlib.metadata import PackageNotFoundError
+
+    with pytest.raises(PackageNotFoundError):
+        get_package_version(name="a-package-that-is-not-installed")


### PR DESCRIPTION
Fixes #752.

`get_package_version` caught `ModuleNotFoundError` around `importlib.metadata.version` and fell back to `pkg_resources`. That branch could never run: `importlib.metadata` is always importable on Python 3.10 and up, and an unknown package raises `PackageNotFoundError`, which was not caught. The function now calls `importlib.metadata.version` directly and documents that `PackageNotFoundError` propagates.

Tests cover the installed case (returns a `Version`, and PyNWB reports at least 4.0) and the missing-package case. The remaining mypy errors reported for this module are pre-existing and in `is_ascending_series`; this change removes one of the nine reported on `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hfn8dhw9cwP5FiVaCgFmCt
