### PR TITLE
Fix the check_name_slashes docstring and an attribute message typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Bumped GitHub Actions workflow dependencies (`actions/checkout` v4 -> v6, `actions/setup-python` v5 -> v6, `codecov/codecov-action` v4 -> v5) to migrate off Node.js 20, which GitHub is removing from runners on 2026-09-16. [#702](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/702)
 
 ### Fixes
+* Fixed the docstring of `check_name_slashes` and a typo in the message of `check_empty_string_for_optional_attribute` ("Improve by omitting"). [#754](https://github.com/NeurodataWithoutBorders/nwbinspector/issues/754)
 * Fixed unit tests that failed at construction time against recent PyNWB and HDMF. [#707](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/707) [#708](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/708)
 * Skipped Ontobee in the documentation external link check, which frequently timed out and caused spurious CI failures. [#709](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/709)
 * Fixed `run_checks` raising `TypeError` when a `progress_bar_class` was passed without `progress_bar_options`; the keyword arguments are now coalesced to an empty dict before being forwarded to the progress-bar constructor. [#701](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/701)

--- a/src/nwbinspector/checks/_general.py
+++ b/src/nwbinspector/checks/_general.py
@@ -9,7 +9,7 @@ COMMON_DESCRIPTION_PLACEHOLDERS = ["no description", "no desc", "none", "placeho
 
 @register_check(importance=Importance.CRITICAL, neurodata_type=None)
 def check_name_slashes(neurodata_object: object) -> Optional[InspectorMessage]:
-    """Check if there  has been added for the session."""
+    """Check if an object name contains a forward or backward slash."""
     if hasattr(neurodata_object, "name") and any((x in neurodata_object.name for x in ["/", "\\"])):
         return InspectorMessage(message="Object name contains slashes.")
 

--- a/src/nwbinspector/checks/_nwb_containers.py
+++ b/src/nwbinspector/checks/_nwb_containers.py
@@ -114,7 +114,7 @@ def check_empty_string_for_optional_attribute(nwb_container: NWBContainer) -> Op
     fields = [attr for attr in optional_attrs if getattr(nwb_container, attr) == ""]
     for field in fields:
         yield InspectorMessage(
-            message=f'The attribute "{field}" is optional and you have supplied an empty string. Improve my omitting '
+            message=f'The attribute "{field}" is optional and you have supplied an empty string. Improve by omitting '
             "this attribute (in MatNWB or PyNWB) or entering as None (in PyNWB)"
         )
 

--- a/tests/unit_tests/test_nwb_containers.py
+++ b/tests/unit_tests/test_nwb_containers.py
@@ -119,7 +119,7 @@ def test_hit_check_empty_string_for_optional_attribute():
     )
 
     assert check_empty_string_for_optional_attribute(nwb_container=nwbfile)[0] == InspectorMessage(
-        message='The attribute "pharmacology" is optional and you have supplied an empty string. Improve my omitting '
+        message='The attribute "pharmacology" is optional and you have supplied an empty string. Improve by omitting '
         "this attribute (in MatNWB or PyNWB) or entering as None (in PyNWB)",
         importance=Importance.BEST_PRACTICE_SUGGESTION,
         location="/",


### PR DESCRIPTION
Fixes #754.

The docstring of `check_name_slashes` was a leftover from a copied function ("Check if there  has been added for the session") and now describes the check. The message of `check_empty_string_for_optional_attribute` said "Improve my omitting" and now says "Improve by omitting"; the unit test that asserts the full message is updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hfn8dhw9cwP5FiVaCgFmCt
