### PR TITLE
Raise ValueError from calculate_number_of_cpu instead of asserting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Bumped GitHub Actions workflow dependencies (`actions/checkout` v4 -> v6, `actions/setup-python` v5 -> v6, `codecov/codecov-action` v4 -> v5) to migrate off Node.js 20, which GitHub is removing from runners on 2026-09-16. [#702](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/702)
 
 ### Fixes
+* `calculate_number_of_cpu` now raises `ValueError` instead of `AssertionError` for an out-of-range request, so the validation is not stripped under `python -O`. The message for a request that is too negative now explains the limit instead of saying fewer CPUs were requested than available. [#755](https://github.com/NeurodataWithoutBorders/nwbinspector/issues/755)
 * Fixed unit tests that failed at construction time against recent PyNWB and HDMF. [#707](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/707) [#708](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/708)
 * Skipped Ontobee in the documentation external link check, which frequently timed out and caused spurious CI failures. [#709](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/709)
 * Fixed `run_checks` raising `TypeError` when a `progress_bar_class` was passed without `progress_bar_options`; the keyword arguments are now coalesced to an empty dict before being forwarded to the progress-bar constructor. [#701](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/701)

--- a/src/nwbinspector/utils/_utils.py
+++ b/src/nwbinspector/utils/_utils.py
@@ -181,12 +181,20 @@ def calculate_number_of_cpu(requested_cpu: int = 1) -> int:
         The desired number of CPUs to use.
 
         The default is 1.
+
+    Raises
+    ------
+    ValueError
+        If the request exceeds the number of available CPUs or is more negative than -(total_cpu - 1).
     """
     total_cpu = os.cpu_count() or 1  # Annotations say os.cpu_count can return None for some reason
-    assert requested_cpu <= total_cpu, f"Requested more CPUs ({requested_cpu}) than are available ({total_cpu})!"
-    assert requested_cpu >= -(
-        total_cpu - 1
-    ), f"Requested fewer CPUs ({requested_cpu}) than are available ({total_cpu})!"
+    if requested_cpu > total_cpu:
+        raise ValueError(f"Requested more CPUs ({requested_cpu}) than are available ({total_cpu})!")
+    if requested_cpu < -(total_cpu - 1):
+        raise ValueError(
+            f"Requested CPUs ({requested_cpu}) is below the minimum of -{total_cpu - 1} "
+            f"(negative values leave that many of the {total_cpu} available CPUs unused)!"
+        )
     if requested_cpu > 0:
         return requested_cpu
     else:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -121,21 +121,27 @@ def test_get_package_version_value():
 class TestCalulcateNumberOfCPU(TestCase):
     total_cpu = os.cpu_count()
 
-    def test_request_more_than_available_assert(self):
+    def test_request_more_than_available(self):
         requested_cpu = 2500
         with self.assertRaisesWith(
-            exc_type=AssertionError,
+            exc_type=ValueError,
             exc_msg=f"Requested more CPUs ({requested_cpu}) than are available ({self.total_cpu})!",
         ):
             calculate_number_of_cpu(requested_cpu=requested_cpu)
 
-    def test_request_fewer_than_available_assert(self):
+    def test_request_too_negative(self):
         requested_cpu = -2500
         with self.assertRaisesWith(
-            exc_type=AssertionError,
-            exc_msg=f"Requested fewer CPUs ({requested_cpu}) than are available ({self.total_cpu})!",
+            exc_type=ValueError,
+            exc_msg=(
+                f"Requested CPUs ({requested_cpu}) is below the minimum of -{self.total_cpu - 1} "
+                f"(negative values leave that many of the {self.total_cpu} available CPUs unused)!"
+            ),
         ):
             calculate_number_of_cpu(requested_cpu=requested_cpu)
+
+    def test_calculate_number_of_cpu_positive_value(self):
+        assert calculate_number_of_cpu(requested_cpu=1) == 1
 
     def test_calculate_number_of_cpu_negative_value(self):
         requested_cpu = -1  # CI only has 2 jobs available


### PR DESCRIPTION
Fixes #755.

`calculate_number_of_cpu` validated `requested_cpu` with two `assert` statements, which Python removes under `-O`, so in that mode an out-of-range `n_jobs` reached `ProcessPoolExecutor` unchecked. Both checks now raise `ValueError`. The message for a too-negative request used to say "Requested fewer CPUs than are available", which described the wrong condition; it now states the minimum and why it exists.

Callers that caught `AssertionError` for this case will need to catch `ValueError` instead; there are none in the repo. The two existing tests are updated for the exception type and the new message, and a positive-value test is added. The behavior for `0` (use all CPUs) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hfn8dhw9cwP5FiVaCgFmCt
