### PR TITLE
Add `check_image_series_external_file_format`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v0.7.3 (Upcoming)
 
 ### New Checks
+* Added `check_image_series_external_file_format`, which flags `ImageSeries` external files stored in a legacy video container or with a legacy codec. Lossy video should use H.264, VP8, VP9 or AV1 in an MP4 or WebM container, and lossless video should use FFV1 rather than an uncompressed or legacy lossless codec.
 * Added `check_spike_times_without_nans` to detect NaN values in Units spike times, which indicate conversion bugs or unclean array padding. [#689](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/689)
 * Added `check_subject_age_reference` to validate that `Subject.age__reference`, when present, is one of the supported values (`"birth"` or `"gestational"`). This catches invalid references in files written by tools that do not enforce the schema constraint. [#250](https://github.com/NeurodataWithoutBorders/nwbinspector/pull/250)
 

--- a/docs/best_practices/image_series.rst
+++ b/docs/best_practices/image_series.rst
@@ -45,3 +45,39 @@ If there is no external file, there should be no starting frame set. This is a l
 older versions of PyNWB (< 2.2.0).
 
 Check function: :py:meth:`~nwbinspector.checks._image_series.check_image_series_starting_frame_without_external_file`
+
+
+Video Files
+-----------
+
+
+.. _best_practice_external_file_format:
+
+Use a standard video container and codec
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The format of a video has two parts, the codec that the frames are encoded with and the container that holds them,
+and the right choice for each depends on whether the video is lossy or lossless.
+
+For lossy video, use H.264, VP8, VP9 or AV1 in an MP4 or WebM container. All four codecs are efficient and play
+everywhere, and which of them to pick depends on the tooling and hardware available. H.264 is covered by patents
+managed through a patent pool, while VP8, VP9 and AV1 are royalty-free. MP4 and WebM are the two containers that every
+platform supports and the only two a browser can play: Safari supports neither Matroska (``.mkv``) nor the other
+legacy containers, and the
+`MDN container guide <https://developer.mozilla.org/en-US/docs/Web/Media/Guides/Formats/Containers>`_ lists MP4 and
+WebM as the only two with universal support. Most scientific video is in ``.avi`` or ``.mov`` with a legacy codec such
+as MJPEG, MPEG-4 Part 2 (``mp4v``, DIVX, XVID), WMV or DV, because that is what the camera SDK or the operating system
+produced by default, not because either was chosen.
+
+When only the container is wrong, no re-encoding is needed. The stream is copied byte for byte and only the container
+headers are rewritten, which takes seconds even for a large file: ``ffmpeg -i input.mkv -c copy output.mp4``. When the
+codec is wrong the re-encoding settles both at once:
+``ffmpeg -i input.avi -c:v libx264 -crf 18 -pix_fmt yuv420p output.mp4``.
+
+For lossless video, use FFV1. It compresses two to three times smaller than uncompressed video with identical pixel
+values, adds per-frame checksums, and handles grayscale and high bit depth without the chroma subsampling that
+consumer codecs impose, which is why the preservation community standardised on it. FFV1 is normally paired with MKV,
+but the container makes no practical difference here: every tool that reads FFV1 handles MKV and AVI alike, and no
+browser decodes lossless video whatever it is held in. Lossless data should never be re-encoded to a lossy codec.
+
+Check function: :py:meth:`~nwbinspector.checks._image_series.check_image_series_external_file_format`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "click",
     "tqdm",
     "isodate",
+    "av",
 ]
 
 [project.optional-dependencies]

--- a/src/nwbinspector/checks/__init__.py
+++ b/src/nwbinspector/checks/__init__.py
@@ -32,6 +32,7 @@ from ._icephys import (
 )
 from ._image_series import (
     check_image_series_data_size,
+    check_image_series_external_file_format,
     check_image_series_external_file_relative,
     check_image_series_external_file_valid,
     check_image_series_starting_frame_without_external_file,
@@ -121,6 +122,7 @@ __all__ = [
     "check_name_slashes",
     "check_name_colons",
     "check_image_series_data_size",
+    "check_image_series_external_file_format",
     "check_image_series_external_file_relative",
     "check_image_series_external_file_valid",
     "check_image_series_starting_frame_without_external_file",

--- a/src/nwbinspector/checks/_image_series.py
+++ b/src/nwbinspector/checks/_image_series.py
@@ -55,6 +55,69 @@ def check_image_series_external_file_relative(image_series: ImageSeries) -> Opti
     return None
 
 
+RECOMMENDED_LOSSY_CONTAINERS = (".mp4", ".webm")
+RECOMMENDED_LOSSY_CODECS = ("h264", "vp8", "vp9", "av1")
+RECOMMENDED_LOSSLESS_CODECS = ("ffv1",)
+
+
+@register_check(importance=Importance.BEST_PRACTICE_SUGGESTION, neurodata_type=ImageSeries)
+def check_image_series_external_file_format(image_series: ImageSeries) -> Optional[Iterable[InspectorMessage]]:
+    """
+    Check if the external_file of an ImageSeries uses a standard video container and codec.
+
+    Best Practice: :ref:`best_practice_external_file_format`
+    """
+    # False positive case; TwoPhotonSeries are a subclass of ImageSeries, but their external files are imaging
+    # data such as TIFF stacks rather than video
+    if isinstance(image_series, TwoPhotonSeries) or image_series.external_file is None:
+        return None
+    try:
+        import av
+    except ImportError:  # the format cannot be read without PyAV, so nothing can be said about it
+        return None
+
+    nwbfile_path = Path(get_nwbfile_path_from_internal_object(neurodata_object=image_series))
+    for file_path in image_series.external_file:
+        file_path = file_path.decode() if isinstance(file_path, bytes) else file_path
+        resolved_path = Path(file_path) if Path(file_path).is_absolute() else nwbfile_path.parent / file_path
+        if not resolved_path.exists():  # reported by check_image_series_external_file_valid
+            continue
+        try:
+            with av.open(str(resolved_path)) as container:
+                if not container.streams.video:
+                    continue
+                codec = container.streams.video[0].codec_context.codec.canonical_name
+        except av.FFmpegError:  # not a media file, or one that cannot be opened
+            continue
+
+        if codec not in RECOMMENDED_LOSSY_CODECS and codec not in RECOMMENDED_LOSSLESS_CODECS:
+            yield InspectorMessage(
+                message=(
+                    f"The external file '{file_path}' uses the '{codec}' codec, which is not one of the standard "
+                    "video codecs. Please use H.264, VP8, VP9 or AV1 in an MP4 or WebM container, or FFV1 if the "
+                    "video has to stay lossless. Note that H.264 is covered by patents while VP8, VP9 and AV1 are "
+                    "royalty-free."
+                )
+            )
+            continue  # the re-encoding settles the container as well
+
+        if codec in RECOMMENDED_LOSSLESS_CODECS:
+            continue  # every tool that reads FFV1 handles its containers alike, so the container gains nothing
+
+        suffix = PurePosixPath(file_path).suffix.lower()
+        if suffix not in RECOMMENDED_LOSSY_CONTAINERS:
+            yield InspectorMessage(
+                message=(
+                    f"The external file '{file_path}' uses the '{suffix}' container, which is not a standard "
+                    "container for sharing video. Please use MP4 or WebM instead. The codec is already a "
+                    "recommended one, so the container can be changed without re-encoding: "
+                    f"ffmpeg -i {file_path} -c copy output.mp4"
+                )
+            )
+
+    return None
+
+
 @register_check(importance=Importance.BEST_PRACTICE_VIOLATION, neurodata_type=ImageSeries)
 def check_image_series_data_size(image_series: ImageSeries, gb_lower_bound: float = 20.0) -> Optional[InspectorMessage]:
     """

--- a/tests/unit_tests/test_image_series.py
+++ b/tests/unit_tests/test_image_series.py
@@ -4,13 +4,17 @@ from pathlib import Path
 from shutil import rmtree
 from tempfile import mkdtemp
 
+import av
 import numpy as np
 from pynwb import NWBHDF5IO, H5DataIO
+from pynwb.device import Device, DeviceModel
 from pynwb.image import ImageSeries
+from pynwb.ophys import ImagingPlane, OpticalChannel, TwoPhotonSeries
 
 from nwbinspector import Importance, InspectorMessage
 from nwbinspector.checks import (
     check_image_series_data_size,
+    check_image_series_external_file_format,
     check_image_series_external_file_relative,
     check_image_series_external_file_valid,
     check_image_series_starting_frame_without_external_file,
@@ -19,6 +23,19 @@ from nwbinspector.checks import (
 from nwbinspector.testing import make_minimal_nwbfile
 
 TESTING_FILES_FOLDER_PATH = os.environ.get("TESTING_FILES_FOLDER_PATH", None)
+
+
+def _write_video(path, codec, pixel_format):
+    """Write a five frame 64 by 64 video so that a real codec can be read back from it."""
+    with av.open(str(path), "w") as container:
+        stream = container.add_stream(codec, rate=10)
+        stream.width, stream.height, stream.pix_fmt = 64, 64, pixel_format
+        for frame_index in range(5):
+            array = np.full(shape=(64, 64, 3), fill_value=frame_index * 20, dtype=np.uint8)
+            for packet in stream.encode(av.VideoFrame.from_ndarray(array, format="rgb24")):
+                container.mux(packet)
+        for packet in stream.encode():
+            container.mux(packet)
 
 
 @unittest.skipIf(
@@ -263,3 +280,127 @@ class TestCheckImageSeriesStoredInternally(unittest.TestCase):
                 )
                 == expected_message
             )
+
+
+class TestExternalFileFormat(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdir = Path(mkdtemp())
+        for file_name, codec, pixel_format in [
+            ("h264.mp4", "libx264", "yuv420p"),
+            ("vp9.webm", "libvpx-vp9", "yuv420p"),
+            ("h264.mkv", "libx264", "yuv420p"),
+            ("mjpeg.avi", "mjpeg", "yuvj420p"),
+            ("ffv1.mkv", "ffv1", "yuv420p"),
+            ("rawvideo.avi", "rawvideo", "yuv420p"),
+        ]:
+            _write_video(path=cls.tmpdir / file_name, codec=codec, pixel_format=pixel_format)
+
+        cls.nwbfile_path = cls.tmpdir / "test.nwb"
+        nwbfile = make_minimal_nwbfile()
+        for series_name, file_name in [
+            ("StandardMP4", "h264.mp4"),
+            ("StandardWebM", "vp9.webm"),
+            ("LegacyContainer", "h264.mkv"),
+            ("LegacyCodec", "mjpeg.avi"),
+            ("Lossless", "ffv1.mkv"),
+            ("Uncompressed", "rawvideo.avi"),
+            ("Missing", "missing.mp4"),
+        ]:
+            nwbfile.add_acquisition(
+                ImageSeries(
+                    name=series_name,
+                    rate=1.0,
+                    external_file=[f"./{file_name}"],
+                    format="external",
+                    num_samples=1,
+                )
+            )
+        with NWBHDF5IO(path=cls.nwbfile_path, mode="w") as io:
+            io.write(nwbfile)
+
+    @classmethod
+    def tearDownClass(cls):
+        rmtree(cls.tmpdir)
+
+    def setUp(self):
+        self.io = NWBHDF5IO(path=self.nwbfile_path, mode="r")
+        self.nwbfile = self.io.read()
+
+    def tearDown(self):
+        self.io.close()
+
+    def test_standard_container_and_codec_passes(self):
+        assert check_image_series_external_file_format(image_series=self.nwbfile.acquisition["StandardMP4"]) is None
+        assert check_image_series_external_file_format(image_series=self.nwbfile.acquisition["StandardWebM"]) is None
+
+    def test_lossy_codec_in_legacy_container(self):
+        """The codec is H.264, so the container can be changed without re-encoding."""
+        messages = check_image_series_external_file_format(image_series=self.nwbfile.acquisition["LegacyContainer"])
+
+        assert len(messages) == 1
+        assert messages[0] == InspectorMessage(
+            message=(
+                "The external file './h264.mkv' uses the '.mkv' container, which is not a standard "
+                "container for sharing video. Please use MP4 or WebM instead. The codec is already a "
+                "recommended one, so the container can be changed without re-encoding: "
+                "ffmpeg -i ./h264.mkv -c copy output.mp4"
+            ),
+            importance=Importance.BEST_PRACTICE_SUGGESTION,
+            check_function_name="check_image_series_external_file_format",
+            object_type="ImageSeries",
+            object_name="LegacyContainer",
+            location="/acquisition/LegacyContainer",
+        )
+
+    def test_legacy_codec(self):
+        """A re-encoding settles the container as well, so the container is not reported separately."""
+        messages = check_image_series_external_file_format(image_series=self.nwbfile.acquisition["LegacyCodec"])
+
+        assert len(messages) == 1
+        assert messages[0].message == (
+            "The external file './mjpeg.avi' uses the 'mjpeg' codec, which is not one of the standard "
+            "video codecs. Please use H.264, VP8, VP9 or AV1 in an MP4 or WebM container, or FFV1 if the "
+            "video has to stay lossless. Note that H.264 is covered by patents while VP8, VP9 and AV1 are "
+            "royalty-free."
+        )
+
+    def test_lossless_codec_passes(self):
+        """The container of a lossless video is not reported, so FFV1 passes whatever holds it."""
+        assert check_image_series_external_file_format(image_series=self.nwbfile.acquisition["Lossless"]) is None
+
+    def test_uncompressed_codec(self):
+        messages = check_image_series_external_file_format(image_series=self.nwbfile.acquisition["Uncompressed"])
+
+        assert len(messages) == 1
+        assert "'rawvideo' codec" in messages[0].message
+
+    def test_missing_file_is_ignored(self):
+        """A missing external file is already reported by check_image_series_external_file_valid."""
+        assert check_image_series_external_file_format(image_series=self.nwbfile.acquisition["Missing"]) is None
+
+    def test_two_photon_series_is_ignored(self):
+        """The external file of a TwoPhotonSeries is imaging data, such as a TIFF stack, rather than video."""
+        device_model = DeviceModel(name="Model", description="microscope model", manufacturer="Manufacturer")
+        imaging_plane = ImagingPlane(
+            name="ImagingPlane",
+            optical_channel=OpticalChannel(
+                name="OpticalChannel", description="an optical channel", emission_lambda=500.0
+            ),
+            description="an imaging plane",
+            device=Device(name="Microscope", description="a microscope", model=device_model),
+            excitation_lambda=600.0,
+            indicator="GFP",
+            location="V1",
+        )
+        two_photon_series = TwoPhotonSeries(
+            name="TwoPhotonSeries",
+            imaging_plane=imaging_plane,
+            rate=1.0,
+            external_file=["./frames.tif"],
+            format="external",
+            num_samples=1,
+            unit="n.a.",
+        )
+
+        assert check_image_series_external_file_format(image_series=two_photon_series) is None


### PR DESCRIPTION
In #669 we discussed which video formats belong in an NWB file and @bendichter asked to move forward with a best practice for it. This PR adds that entry to the ImageSeries best practices and a `BEST_PRACTICE_SUGGESTION` check that opens each `external_file` with PyAV and asks for H.264, VP8, VP9 or AV1 in an MP4 or WebM container for lossy video, and FFV1 for lossless video with no opinion on its container. The message names the four lossy codecs without picking one and only notes that H.264 is covered by patents while VP8, VP9 and AV1 are royalty-free.

This should close #669.
